### PR TITLE
fix(android): disable baseline profiles for reproducible F-Droid builds

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -79,6 +79,14 @@ android.applicationVariants.configureEach {
     }
 }
 
+// Disable AGP baseline profile compilation so assets/dexopt/baseline.prof(m)
+// are not produced. The merged .profm is non-deterministic across build hosts,
+// which breaks F-Droid reproducible builds. Remove once AGP fixes
+// https://issuetracker.google.com/issues/231837768.
+tasks.withType<com.android.build.gradle.internal.tasks.CompileArtProfileTask>().configureEach {
+    enabled = false
+}
+
 flutter {
     source = "../.."
 }


### PR DESCRIPTION
## Summary

v0.16.0 failed F-Droid's reproducibility verification — the only diff between the GitHub-released APK and the F-Droid-built APK was `assets/dexopt/baseline.prof` and `assets/dexopt/baseline.profm`. See [job log](https://gitlab.com/fdroid/checkupdates-bot-fdroiddata/-/jobs/14850763073).

**Root cause:** v0.16.0 added `home_widget: ^0.9.3`, which transitively pulls in `androidx.glance:glance-appwidget:1.1.1` and `androidx.work:work-runtime-ktx:2.11.2`. Both AARs ship baseline profiles, which AGP merges into the final APK. The merged `.profm` is non-deterministic across build hosts (known AGP bug: https://issuetracker.google.com/issues/231837768), which breaks F-Droid's byte-for-byte comparison. v0.15.0 had no dependency shipping a baseline profile, so the issue didn't surface.

**Fix:** Disable AGP's `CompileArtProfileTask` so the files are never produced. This is the F-Droid-recommended workaround and is cleaner than packaging-excludes because it skips the work instead of generating-then-discarding.

## Trade-off

Removing the baseline profile gives back ~10–30% on cold start for the first launch or two after install — ART rebuilds its own profile from observed usage within a few runs. For a network-bound Nextcloud client this is largely invisible to users. The workaround can be removed once https://issuetracker.google.com/issues/231837768 is fixed in AGP.

## Test plan

- [x] `flutter clean && flutter build apk --release --split-per-abi` succeeds
- [x] `unzip -l` on all three release APKs (armeabi-v7a, arm64-v8a, x86_64) shows no `assets/dexopt/baseline.prof*` entries
- [ ] Cut v0.16.1 once merged; checkupdates-bot will re-verify against the new GitHub release APK on its next run