### PR TITLE
feat: add store details with location, hours, contact and notes

### DIFF
--- a/lib/messages.i18n.dart
+++ b/lib/messages.i18n.dart
@@ -1417,6 +1417,81 @@ class StoresMessages {
   /// ```
   String get deleteConfirmBody =>
       """This store will be removed from all items. This cannot be undone.""";
+
+  /// ```dart
+  /// "Location"
+  /// ```
+  String get location => """Location""";
+
+  /// ```dart
+  /// "e.g. 12 Main Street"
+  /// ```
+  String get locationHint => """e.g. 12 Main Street""";
+
+  /// ```dart
+  /// "Opening hours"
+  /// ```
+  String get openingHours => """Opening hours""";
+
+  /// ```dart
+  /// "Add opening hours"
+  /// ```
+  String get addOpeningHours => """Add opening hours""";
+
+  /// ```dart
+  /// "Start"
+  /// ```
+  String get openingHoursStart => """Start""";
+
+  /// ```dart
+  /// "End"
+  /// ```
+  String get openingHoursEnd => """End""";
+
+  /// ```dart
+  /// "Add"
+  /// ```
+  String get openingHoursAdd => """Add""";
+
+  /// ```dart
+  /// "Contact"
+  /// ```
+  String get contact => """Contact""";
+
+  /// ```dart
+  /// "e.g. phone, website, social media"
+  /// ```
+  String get contactHint => """e.g. phone, website, social media""";
+
+  /// ```dart
+  /// "Responsible"
+  /// ```
+  String get responsible => """Responsible""";
+
+  /// ```dart
+  /// "e.g. store manager"
+  /// ```
+  String get responsibleHint => """e.g. store manager""";
+
+  /// ```dart
+  /// "Notes"
+  /// ```
+  String get notes => """Notes""";
+
+  /// ```dart
+  /// "Anything else worth remembering"
+  /// ```
+  String get notesHint => """Anything else worth remembering""";
+
+  /// ```dart
+  /// "No details added yet."
+  /// ```
+  String get noDetails => """No details added yet.""";
+
+  /// ```dart
+  /// "Edit"
+  /// ```
+  String get editAction => """Edit""";
 }
 
 class ChecklistsMessages {
@@ -3826,6 +3901,21 @@ Password: pantry-rocks""",
   """stores.deleteConfirm""": """Delete this store?""",
   """stores.deleteConfirmBody""":
       """This store will be removed from all items. This cannot be undone.""",
+  """stores.location""": """Location""",
+  """stores.locationHint""": """e.g. 12 Main Street""",
+  """stores.openingHours""": """Opening hours""",
+  """stores.addOpeningHours""": """Add opening hours""",
+  """stores.openingHoursStart""": """Start""",
+  """stores.openingHoursEnd""": """End""",
+  """stores.openingHoursAdd""": """Add""",
+  """stores.contact""": """Contact""",
+  """stores.contactHint""": """e.g. phone, website, social media""",
+  """stores.responsible""": """Responsible""",
+  """stores.responsibleHint""": """e.g. store manager""",
+  """stores.notes""": """Notes""",
+  """stores.notesHint""": """Anything else worth remembering""",
+  """stores.noDetails""": """No details added yet.""",
+  """stores.editAction""": """Edit""",
   """checklists.categories""": """Categories""",
   """checklists.noChecklists""": """No checklists yet.""",
   """checklists.noItems""": """No items in this list.""",

--- a/lib/messages.i18n.yaml
+++ b/lib/messages.i18n.yaml
@@ -262,6 +262,21 @@ stores:
   deleteFailed: Failed to delete store.
   deleteConfirm: Delete this store?
   deleteConfirmBody: "This store will be removed from all items. This cannot be undone."
+  location: Location
+  locationHint: "e.g. 12 Main Street"
+  openingHours: Opening hours
+  addOpeningHours: Add opening hours
+  openingHoursStart: Start
+  openingHoursEnd: End
+  openingHoursAdd: Add
+  contact: Contact
+  contactHint: "e.g. phone, website, social media"
+  responsible: Responsible
+  responsibleHint: "e.g. store manager"
+  notes: Notes
+  notesHint: Anything else worth remembering
+  noDetails: No details added yet.
+  editAction: Edit
 
 checklists:
   categories: Categories

--- a/lib/messages_de.i18n.dart
+++ b/lib/messages_de.i18n.dart
@@ -1430,6 +1430,81 @@ class StoresMessagesDe extends StoresMessages {
   /// ```
   String get deleteConfirmBody =>
       """Dieses Geschäft wird von allen Artikeln entfernt. Dies kann nicht rückgängig gemacht werden.""";
+
+  /// ```dart
+  /// "Standort"
+  /// ```
+  String get location => """Standort""";
+
+  /// ```dart
+  /// "z. B. Hauptstraße 12"
+  /// ```
+  String get locationHint => """z. B. Hauptstraße 12""";
+
+  /// ```dart
+  /// "Öffnungszeiten"
+  /// ```
+  String get openingHours => """Öffnungszeiten""";
+
+  /// ```dart
+  /// "Öffnungszeiten hinzufügen"
+  /// ```
+  String get addOpeningHours => """Öffnungszeiten hinzufügen""";
+
+  /// ```dart
+  /// "Von"
+  /// ```
+  String get openingHoursStart => """Von""";
+
+  /// ```dart
+  /// "Bis"
+  /// ```
+  String get openingHoursEnd => """Bis""";
+
+  /// ```dart
+  /// "Hinzufügen"
+  /// ```
+  String get openingHoursAdd => """Hinzufügen""";
+
+  /// ```dart
+  /// "Kontakt"
+  /// ```
+  String get contact => """Kontakt""";
+
+  /// ```dart
+  /// "z. B. Telefon, Website, soziale Medien"
+  /// ```
+  String get contactHint => """z. B. Telefon, Website, soziale Medien""";
+
+  /// ```dart
+  /// "Verantwortlich"
+  /// ```
+  String get responsible => """Verantwortlich""";
+
+  /// ```dart
+  /// "z. B. Filialleitung"
+  /// ```
+  String get responsibleHint => """z. B. Filialleitung""";
+
+  /// ```dart
+  /// "Notizen"
+  /// ```
+  String get notes => """Notizen""";
+
+  /// ```dart
+  /// "Alles Weitere, was man sich merken sollte"
+  /// ```
+  String get notesHint => """Alles Weitere, was man sich merken sollte""";
+
+  /// ```dart
+  /// "Noch keine Angaben hinzugefügt."
+  /// ```
+  String get noDetails => """Noch keine Angaben hinzugefügt.""";
+
+  /// ```dart
+  /// "Bearbeiten"
+  /// ```
+  String get editAction => """Bearbeiten""";
 }
 
 class ChecklistsMessagesDe extends ChecklistsMessages {
@@ -3870,6 +3945,21 @@ Passwort: pantry-rocks""",
   """stores.deleteConfirm""": """Dieses Geschäft löschen?""",
   """stores.deleteConfirmBody""":
       """Dieses Geschäft wird von allen Artikeln entfernt. Dies kann nicht rückgängig gemacht werden.""",
+  """stores.location""": """Standort""",
+  """stores.locationHint""": """z. B. Hauptstraße 12""",
+  """stores.openingHours""": """Öffnungszeiten""",
+  """stores.addOpeningHours""": """Öffnungszeiten hinzufügen""",
+  """stores.openingHoursStart""": """Von""",
+  """stores.openingHoursEnd""": """Bis""",
+  """stores.openingHoursAdd""": """Hinzufügen""",
+  """stores.contact""": """Kontakt""",
+  """stores.contactHint""": """z. B. Telefon, Website, soziale Medien""",
+  """stores.responsible""": """Verantwortlich""",
+  """stores.responsibleHint""": """z. B. Filialleitung""",
+  """stores.notes""": """Notizen""",
+  """stores.notesHint""": """Alles Weitere, was man sich merken sollte""",
+  """stores.noDetails""": """Noch keine Angaben hinzugefügt.""",
+  """stores.editAction""": """Bearbeiten""",
   """checklists.categories""": """Kategorien""",
   """checklists.noChecklists""": """Noch keine Checklisten.""",
   """checklists.noItems""": """Keine Einträge in dieser Liste.""",

--- a/lib/messages_de.i18n.yaml
+++ b/lib/messages_de.i18n.yaml
@@ -262,6 +262,21 @@ stores:
   deleteFailed: Geschäft konnte nicht gelöscht werden.
   deleteConfirm: Dieses Geschäft löschen?
   deleteConfirmBody: "Dieses Geschäft wird von allen Artikeln entfernt. Dies kann nicht rückgängig gemacht werden."
+  location: Standort
+  locationHint: "z. B. Hauptstraße 12"
+  openingHours: Öffnungszeiten
+  addOpeningHours: Öffnungszeiten hinzufügen
+  openingHoursStart: Von
+  openingHoursEnd: Bis
+  openingHoursAdd: Hinzufügen
+  contact: Kontakt
+  contactHint: "z. B. Telefon, Website, soziale Medien"
+  responsible: Verantwortlich
+  responsibleHint: "z. B. Filialleitung"
+  notes: Notizen
+  notesHint: Alles Weitere, was man sich merken sollte
+  noDetails: Noch keine Angaben hinzugefügt.
+  editAction: Bearbeiten
 
 checklists:
   categories: Kategorien

--- a/lib/messages_es.i18n.dart
+++ b/lib/messages_es.i18n.dart
@@ -1430,6 +1430,81 @@ class StoresMessagesEs extends StoresMessages {
   /// ```
   String get deleteConfirmBody =>
       """Esta tienda se eliminará de todos los artículos. Esto no se puede deshacer.""";
+
+  /// ```dart
+  /// "Ubicación"
+  /// ```
+  String get location => """Ubicación""";
+
+  /// ```dart
+  /// "p. ej. Calle Mayor 12"
+  /// ```
+  String get locationHint => """p. ej. Calle Mayor 12""";
+
+  /// ```dart
+  /// "Horario de apertura"
+  /// ```
+  String get openingHours => """Horario de apertura""";
+
+  /// ```dart
+  /// "Añadir horario"
+  /// ```
+  String get addOpeningHours => """Añadir horario""";
+
+  /// ```dart
+  /// "Desde"
+  /// ```
+  String get openingHoursStart => """Desde""";
+
+  /// ```dart
+  /// "Hasta"
+  /// ```
+  String get openingHoursEnd => """Hasta""";
+
+  /// ```dart
+  /// "Añadir"
+  /// ```
+  String get openingHoursAdd => """Añadir""";
+
+  /// ```dart
+  /// "Contacto"
+  /// ```
+  String get contact => """Contacto""";
+
+  /// ```dart
+  /// "p. ej. teléfono, sitio web, redes sociales"
+  /// ```
+  String get contactHint => """p. ej. teléfono, sitio web, redes sociales""";
+
+  /// ```dart
+  /// "Responsable"
+  /// ```
+  String get responsible => """Responsable""";
+
+  /// ```dart
+  /// "p. ej. encargado de la tienda"
+  /// ```
+  String get responsibleHint => """p. ej. encargado de la tienda""";
+
+  /// ```dart
+  /// "Notas"
+  /// ```
+  String get notes => """Notas""";
+
+  /// ```dart
+  /// "Cualquier otra cosa que convenga recordar"
+  /// ```
+  String get notesHint => """Cualquier otra cosa que convenga recordar""";
+
+  /// ```dart
+  /// "Aún no se han añadido detalles."
+  /// ```
+  String get noDetails => """Aún no se han añadido detalles.""";
+
+  /// ```dart
+  /// "Editar"
+  /// ```
+  String get editAction => """Editar""";
 }
 
 class ChecklistsMessagesEs extends ChecklistsMessages {
@@ -3865,6 +3940,21 @@ Contraseña: pantry-rocks""",
   """stores.deleteConfirm""": """¿Eliminar esta tienda?""",
   """stores.deleteConfirmBody""":
       """Esta tienda se eliminará de todos los artículos. Esto no se puede deshacer.""",
+  """stores.location""": """Ubicación""",
+  """stores.locationHint""": """p. ej. Calle Mayor 12""",
+  """stores.openingHours""": """Horario de apertura""",
+  """stores.addOpeningHours""": """Añadir horario""",
+  """stores.openingHoursStart""": """Desde""",
+  """stores.openingHoursEnd""": """Hasta""",
+  """stores.openingHoursAdd""": """Añadir""",
+  """stores.contact""": """Contacto""",
+  """stores.contactHint""": """p. ej. teléfono, sitio web, redes sociales""",
+  """stores.responsible""": """Responsable""",
+  """stores.responsibleHint""": """p. ej. encargado de la tienda""",
+  """stores.notes""": """Notas""",
+  """stores.notesHint""": """Cualquier otra cosa que convenga recordar""",
+  """stores.noDetails""": """Aún no se han añadido detalles.""",
+  """stores.editAction""": """Editar""",
   """checklists.categories""": """Categorías""",
   """checklists.noChecklists""": """Aún no hay listas.""",
   """checklists.noItems""": """No hay artículos en esta lista.""",

--- a/lib/messages_es.i18n.yaml
+++ b/lib/messages_es.i18n.yaml
@@ -262,6 +262,21 @@ stores:
   deleteFailed: "No se pudo eliminar la tienda."
   deleteConfirm: "¿Eliminar esta tienda?"
   deleteConfirmBody: "Esta tienda se eliminará de todos los artículos. Esto no se puede deshacer."
+  location: Ubicación
+  locationHint: "p. ej. Calle Mayor 12"
+  openingHours: Horario de apertura
+  addOpeningHours: Añadir horario
+  openingHoursStart: Desde
+  openingHoursEnd: Hasta
+  openingHoursAdd: Añadir
+  contact: Contacto
+  contactHint: "p. ej. teléfono, sitio web, redes sociales"
+  responsible: Responsable
+  responsibleHint: "p. ej. encargado de la tienda"
+  notes: Notas
+  notesHint: Cualquier otra cosa que convenga recordar
+  noDetails: Aún no se han añadido detalles.
+  editAction: Editar
 
 checklists:
   categories: "Categorías"

--- a/lib/messages_fr.i18n.dart
+++ b/lib/messages_fr.i18n.dart
@@ -1432,6 +1432,81 @@ class StoresMessagesFr extends StoresMessages {
   /// ```
   String get deleteConfirmBody =>
       """Ce magasin sera retiré de tous les articles. Cette action est irréversible.""";
+
+  /// ```dart
+  /// "Emplacement"
+  /// ```
+  String get location => """Emplacement""";
+
+  /// ```dart
+  /// "p. ex. 12 rue Principale"
+  /// ```
+  String get locationHint => """p. ex. 12 rue Principale""";
+
+  /// ```dart
+  /// "Horaires d'ouverture"
+  /// ```
+  String get openingHours => """Horaires d'ouverture""";
+
+  /// ```dart
+  /// "Ajouter des horaires"
+  /// ```
+  String get addOpeningHours => """Ajouter des horaires""";
+
+  /// ```dart
+  /// "Début"
+  /// ```
+  String get openingHoursStart => """Début""";
+
+  /// ```dart
+  /// "Fin"
+  /// ```
+  String get openingHoursEnd => """Fin""";
+
+  /// ```dart
+  /// "Ajouter"
+  /// ```
+  String get openingHoursAdd => """Ajouter""";
+
+  /// ```dart
+  /// "Contact"
+  /// ```
+  String get contact => """Contact""";
+
+  /// ```dart
+  /// "p. ex. téléphone, site web, réseaux sociaux"
+  /// ```
+  String get contactHint => """p. ex. téléphone, site web, réseaux sociaux""";
+
+  /// ```dart
+  /// "Responsable"
+  /// ```
+  String get responsible => """Responsable""";
+
+  /// ```dart
+  /// "p. ex. gérant du magasin"
+  /// ```
+  String get responsibleHint => """p. ex. gérant du magasin""";
+
+  /// ```dart
+  /// "Notes"
+  /// ```
+  String get notes => """Notes""";
+
+  /// ```dart
+  /// "Toute autre chose à retenir"
+  /// ```
+  String get notesHint => """Toute autre chose à retenir""";
+
+  /// ```dart
+  /// "Aucun détail ajouté pour le moment."
+  /// ```
+  String get noDetails => """Aucun détail ajouté pour le moment.""";
+
+  /// ```dart
+  /// "Modifier"
+  /// ```
+  String get editAction => """Modifier""";
 }
 
 class ChecklistsMessagesFr extends ChecklistsMessages {
@@ -3875,6 +3950,21 @@ Mot de passe : pantry-rocks""",
   """stores.deleteConfirm""": """Supprimer ce magasin ?""",
   """stores.deleteConfirmBody""":
       """Ce magasin sera retiré de tous les articles. Cette action est irréversible.""",
+  """stores.location""": """Emplacement""",
+  """stores.locationHint""": """p. ex. 12 rue Principale""",
+  """stores.openingHours""": """Horaires d'ouverture""",
+  """stores.addOpeningHours""": """Ajouter des horaires""",
+  """stores.openingHoursStart""": """Début""",
+  """stores.openingHoursEnd""": """Fin""",
+  """stores.openingHoursAdd""": """Ajouter""",
+  """stores.contact""": """Contact""",
+  """stores.contactHint""": """p. ex. téléphone, site web, réseaux sociaux""",
+  """stores.responsible""": """Responsable""",
+  """stores.responsibleHint""": """p. ex. gérant du magasin""",
+  """stores.notes""": """Notes""",
+  """stores.notesHint""": """Toute autre chose à retenir""",
+  """stores.noDetails""": """Aucun détail ajouté pour le moment.""",
+  """stores.editAction""": """Modifier""",
   """checklists.categories""": """Catégories""",
   """checklists.noChecklists""": """Aucune liste pour le moment.""",
   """checklists.noItems""": """Aucun article dans cette liste.""",

--- a/lib/messages_fr.i18n.yaml
+++ b/lib/messages_fr.i18n.yaml
@@ -262,6 +262,21 @@ stores:
   deleteFailed: "Impossible de supprimer le magasin."
   deleteConfirm: Supprimer ce magasin ?
   deleteConfirmBody: "Ce magasin sera retiré de tous les articles. Cette action est irréversible."
+  location: Emplacement
+  locationHint: "p. ex. 12 rue Principale"
+  openingHours: Horaires d'ouverture
+  addOpeningHours: Ajouter des horaires
+  openingHoursStart: Début
+  openingHoursEnd: Fin
+  openingHoursAdd: Ajouter
+  contact: Contact
+  contactHint: "p. ex. téléphone, site web, réseaux sociaux"
+  responsible: Responsable
+  responsibleHint: "p. ex. gérant du magasin"
+  notes: Notes
+  notesHint: Toute autre chose à retenir
+  noDetails: Aucun détail ajouté pour le moment.
+  editAction: Modifier
 
 checklists:
   categories: "Catégories"

--- a/lib/messages_he.i18n.dart
+++ b/lib/messages_he.i18n.dart
@@ -1422,6 +1422,81 @@ class StoresMessagesHe extends StoresMessages {
   /// ```
   String get deleteConfirmBody =>
       """החנות תוסר מכל הפריטים. לא ניתן לבטל פעולה זו.""";
+
+  /// ```dart
+  /// "מיקום"
+  /// ```
+  String get location => """מיקום""";
+
+  /// ```dart
+  /// "לדוגמה: רחוב הרצל 12"
+  /// ```
+  String get locationHint => """לדוגמה: רחוב הרצל 12""";
+
+  /// ```dart
+  /// "שעות פתיחה"
+  /// ```
+  String get openingHours => """שעות פתיחה""";
+
+  /// ```dart
+  /// "הוספת שעות פתיחה"
+  /// ```
+  String get addOpeningHours => """הוספת שעות פתיחה""";
+
+  /// ```dart
+  /// "התחלה"
+  /// ```
+  String get openingHoursStart => """התחלה""";
+
+  /// ```dart
+  /// "סיום"
+  /// ```
+  String get openingHoursEnd => """סיום""";
+
+  /// ```dart
+  /// "הוספה"
+  /// ```
+  String get openingHoursAdd => """הוספה""";
+
+  /// ```dart
+  /// "איש קשר"
+  /// ```
+  String get contact => """איש קשר""";
+
+  /// ```dart
+  /// "לדוגמה: טלפון, אתר, רשתות חברתיות"
+  /// ```
+  String get contactHint => """לדוגמה: טלפון, אתר, רשתות חברתיות""";
+
+  /// ```dart
+  /// "אחראי"
+  /// ```
+  String get responsible => """אחראי""";
+
+  /// ```dart
+  /// "לדוגמה: מנהל החנות"
+  /// ```
+  String get responsibleHint => """לדוגמה: מנהל החנות""";
+
+  /// ```dart
+  /// "הערות"
+  /// ```
+  String get notes => """הערות""";
+
+  /// ```dart
+  /// "כל דבר נוסף שכדאי לזכור"
+  /// ```
+  String get notesHint => """כל דבר נוסף שכדאי לזכור""";
+
+  /// ```dart
+  /// "עדיין לא נוספו פרטים."
+  /// ```
+  String get noDetails => """עדיין לא נוספו פרטים.""";
+
+  /// ```dart
+  /// "עריכה"
+  /// ```
+  String get editAction => """עריכה""";
 }
 
 class ChecklistsMessagesHe extends ChecklistsMessages {
@@ -3830,6 +3905,21 @@ Map<String, String> get messagesHeMap => {
   """stores.deleteConfirm""": """למחוק את החנות הזו?""",
   """stores.deleteConfirmBody""":
       """החנות תוסר מכל הפריטים. לא ניתן לבטל פעולה זו.""",
+  """stores.location""": """מיקום""",
+  """stores.locationHint""": """לדוגמה: רחוב הרצל 12""",
+  """stores.openingHours""": """שעות פתיחה""",
+  """stores.addOpeningHours""": """הוספת שעות פתיחה""",
+  """stores.openingHoursStart""": """התחלה""",
+  """stores.openingHoursEnd""": """סיום""",
+  """stores.openingHoursAdd""": """הוספה""",
+  """stores.contact""": """איש קשר""",
+  """stores.contactHint""": """לדוגמה: טלפון, אתר, רשתות חברתיות""",
+  """stores.responsible""": """אחראי""",
+  """stores.responsibleHint""": """לדוגמה: מנהל החנות""",
+  """stores.notes""": """הערות""",
+  """stores.notesHint""": """כל דבר נוסף שכדאי לזכור""",
+  """stores.noDetails""": """עדיין לא נוספו פרטים.""",
+  """stores.editAction""": """עריכה""",
   """checklists.categories""": """קטגוריות""",
   """checklists.noChecklists""": """אין רשימות עדיין.""",
   """checklists.noItems""": """אין פריטים ברשימה.""",

--- a/lib/messages_he.i18n.yaml
+++ b/lib/messages_he.i18n.yaml
@@ -262,6 +262,21 @@ stores:
   deleteFailed: מחיקת החנות נכשלה.
   deleteConfirm: למחוק את החנות הזו?
   deleteConfirmBody: "החנות תוסר מכל הפריטים. לא ניתן לבטל פעולה זו."
+  location: מיקום
+  locationHint: "לדוגמה: רחוב הרצל 12"
+  openingHours: שעות פתיחה
+  addOpeningHours: הוספת שעות פתיחה
+  openingHoursStart: התחלה
+  openingHoursEnd: סיום
+  openingHoursAdd: הוספה
+  contact: איש קשר
+  contactHint: "לדוגמה: טלפון, אתר, רשתות חברתיות"
+  responsible: אחראי
+  responsibleHint: "לדוגמה: מנהל החנות"
+  notes: הערות
+  notesHint: כל דבר נוסף שכדאי לזכור
+  noDetails: עדיין לא נוספו פרטים.
+  editAction: עריכה
 
 checklists:
   categories: קטגוריות

--- a/lib/models/store.dart
+++ b/lib/models/store.dart
@@ -1,9 +1,42 @@
+/// A single opening-hours interval for a store.
+///
+/// [day] is ISO-8601: 1 = Monday … 7 = Sunday, identical to Dart's
+/// [DateTime.weekday] — store and read the integer as-is, no conversion.
+/// [start] and [end] are 24-hour `HH:MM` strings, with `start` < `end`
+/// (no overnight/wrap intervals).
+class OpeningHoursInterval {
+  final int
+  day; // 1..7, ISO-8601 (1 = Monday .. 7 = Sunday) == DateTime.weekday
+  final String start; // "HH:MM"
+  final String end; // "HH:MM"
+
+  const OpeningHoursInterval({
+    required this.day,
+    required this.start,
+    required this.end,
+  });
+
+  factory OpeningHoursInterval.fromJson(Map<String, dynamic> json) =>
+      OpeningHoursInterval(
+        day: json['day'] as int,
+        start: json['start'] as String,
+        end: json['end'] as String,
+      );
+
+  Map<String, dynamic> toJson() => {'day': day, 'start': start, 'end': end};
+}
+
 class Store {
   final int id;
   final int houseId;
   final String name;
   final String icon;
   final String color;
+  final String? location;
+  final List<OpeningHoursInterval>? openingHours;
+  final String? contact;
+  final String? responsible;
+  final String? notes;
   final int createdAt;
   final int updatedAt;
 
@@ -13,6 +46,11 @@ class Store {
     required this.name,
     required this.icon,
     required this.color,
+    this.location,
+    this.openingHours,
+    this.contact,
+    this.responsible,
+    this.notes,
     required this.createdAt,
     required this.updatedAt,
   });
@@ -23,6 +61,13 @@ class Store {
     name: json['name'] as String,
     icon: json['icon'] as String,
     color: json['color'] as String,
+    location: json['location'] as String?,
+    openingHours: (json['openingHours'] as List?)
+        ?.map((e) => OpeningHoursInterval.fromJson(e as Map<String, dynamic>))
+        .toList(),
+    contact: json['contact'] as String?,
+    responsible: json['responsible'] as String?,
+    notes: json['notes'] as String?,
     createdAt: json['createdAt'] as int,
     updatedAt: json['updatedAt'] as int,
   );
@@ -33,6 +78,11 @@ class Store {
     'name': name,
     'icon': icon,
     'color': color,
+    'location': location,
+    'openingHours': openingHours?.map((e) => e.toJson()).toList(),
+    'contact': contact,
+    'responsible': responsible,
+    'notes': notes,
     'createdAt': createdAt,
     'updatedAt': updatedAt,
   };
@@ -49,7 +99,21 @@ class Store {
     name: name ?? this.name,
     icon: icon ?? this.icon,
     color: color ?? this.color,
+    location: location,
+    openingHours: openingHours,
+    contact: contact,
+    responsible: responsible,
+    notes: notes,
     createdAt: createdAt,
     updatedAt: updatedAt ?? this.updatedAt,
   );
+
+  /// True when none of the optional info fields carry any content — used by the
+  /// details view to show a placeholder instead of empty rows.
+  bool get hasNoDetails =>
+      (location == null || location!.trim().isEmpty) &&
+      (openingHours == null || openingHours!.isEmpty) &&
+      (contact == null || contact!.trim().isEmpty) &&
+      (responsible == null || responsible!.trim().isEmpty) &&
+      (notes == null || notes!.trim().isEmpty);
 }

--- a/lib/services/store_service.dart
+++ b/lib/services/store_service.dart
@@ -37,10 +37,24 @@ class StoreService {
     required String name,
     required String icon,
     required String color,
+    String? location,
+    List<OpeningHoursInterval>? openingHours,
+    String? contact,
+    String? responsible,
+    String? notes,
   }) async {
     return ApiClient.instance.post<Map<String, dynamic>, Store>(
       '/houses/$houseId/stores',
-      body: {'name': name, 'icon': icon, 'color': color},
+      body: {
+        'name': name,
+        'icon': icon,
+        'color': color,
+        'location': ?location,
+        'openingHours': ?openingHours?.map((e) => e.toJson()).toList(),
+        'contact': ?contact,
+        'responsible': ?responsible,
+        'notes': ?notes,
+      },
       fromJson: (data) => Store.fromJson(data),
     );
   }
@@ -51,10 +65,24 @@ class StoreService {
     String? name,
     String? icon,
     String? color,
+    String? location,
+    List<OpeningHoursInterval>? openingHours,
+    String? contact,
+    String? responsible,
+    String? notes,
   }) async {
     return ApiClient.instance.patch<Map<String, dynamic>, Store>(
       '/houses/$houseId/stores/$storeId',
-      body: {'name': ?name, 'icon': ?icon, 'color': ?color},
+      body: {
+        'name': ?name,
+        'icon': ?icon,
+        'color': ?color,
+        'location': ?location,
+        'openingHours': ?openingHours?.map((e) => e.toJson()).toList(),
+        'contact': ?contact,
+        'responsible': ?responsible,
+        'notes': ?notes,
+      },
       fromJson: (data) => Store.fromJson(data),
     );
   }

--- a/lib/sync/sync_executor.dart
+++ b/lib/sync/sync_executor.dart
@@ -297,6 +297,15 @@ class SyncExecutor {
           name: op.body['name'] as String,
           icon: op.body['icon'] as String,
           color: op.body['color'] as String,
+          location: op.body['location'] as String?,
+          openingHours: (op.body['openingHours'] as List?)
+              ?.map(
+                (e) => OpeningHoursInterval.fromJson(e as Map<String, dynamic>),
+              )
+              .toList(),
+          contact: op.body['contact'] as String?,
+          responsible: op.body['responsible'] as String?,
+          notes: op.body['notes'] as String?,
         );
         return SyncResult(store);
       case SyncOpKind.update:
@@ -307,6 +316,15 @@ class SyncExecutor {
           name: op.body['name'] as String?,
           icon: op.body['icon'] as String?,
           color: op.body['color'] as String?,
+          location: op.body['location'] as String?,
+          openingHours: (op.body['openingHours'] as List?)
+              ?.map(
+                (e) => OpeningHoursInterval.fromJson(e as Map<String, dynamic>),
+              )
+              .toList(),
+          contact: op.body['contact'] as String?,
+          responsible: op.body['responsible'] as String?,
+          notes: op.body['notes'] as String?,
         );
         return SyncResult(store);
       case SyncOpKind.delete:

--- a/lib/utils/opening_hours.dart
+++ b/lib/utils/opening_hours.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart';
+import 'package:pantry/i18n.dart';
+import 'package:pantry/models/store.dart';
+
+/// Helpers for displaying opening hours in the locale's weekday order.
+///
+/// Stored [OpeningHoursInterval.day] is ISO-8601 (1 = Monday … 7 = Sunday),
+/// identical to [DateTime.weekday]. Only the display *order* depends on the
+/// locale's first day of week.
+class OpeningHoursDisplay {
+  const OpeningHoursDisplay._();
+
+  /// ISO weekdays (1..7) ordered by the locale's first day of week.
+  static List<int> weekdayOrder(BuildContext context) {
+    // firstDayOfWeekIndex: 0 = Sunday … 6 = Saturday (note: 0-indexed Sunday,
+    // not the ISO day we store). Convert to ISO (1 = Monday … 7 = Sunday).
+    final firstIndex = MaterialLocalizations.of(context).firstDayOfWeekIndex;
+    final startIso = firstIndex == 0 ? 7 : firstIndex;
+    return List.generate(7, (i) => ((startIso - 1 + i) % 7) + 1);
+  }
+
+  /// A localized weekday name for an ISO [day] (1 = Monday … 7 = Sunday), from
+  /// the app's own translations (intl date symbols aren't initialized, so
+  /// `DateFormat` with a non-en locale would throw). [short] uses the
+  /// abbreviated form.
+  static String weekdayName(
+    BuildContext context,
+    int day, {
+    bool short = false,
+  }) {
+    final names = m.recurrence.dayNames;
+    final abbr = m.recurrence.dayAbbr;
+    return switch (day) {
+      1 => short ? abbr.mo : names.monday,
+      2 => short ? abbr.tu : names.tuesday,
+      3 => short ? abbr.we : names.wednesday,
+      4 => short ? abbr.th : names.thursday,
+      5 => short ? abbr.fr : names.friday,
+      6 => short ? abbr.sa : names.saturday,
+      _ => short ? abbr.su : names.sunday,
+    };
+  }
+
+  /// Formats a canonical 24h `"HH:MM"` string for display in the user's
+  /// locale (e.g. `19:00` or `7:00 PM`). Uses [MaterialLocalizations]
+  /// (already loaded via GlobalMaterialLocalizations) rather than intl's
+  /// `DateFormat`, whose date symbols aren't initialized in this app.
+  /// The stored/sent value stays 24h `"HH:MM"` — this is display-only.
+  static String formatTime(BuildContext context, String hhmm) {
+    final parts = hhmm.split(':');
+    final time = TimeOfDay(
+      hour: int.parse(parts[0]),
+      minute: int.parse(parts[1]),
+    );
+    return MaterialLocalizations.of(context).formatTimeOfDay(time);
+  }
+
+  /// Intervals grouped by ISO day, in the locale's weekday order. Only days
+  /// with at least one interval are returned. Within a day, intervals are
+  /// sorted by start time.
+  static List<MapEntry<int, List<OpeningHoursInterval>>> groupByDay(
+    BuildContext context,
+    List<OpeningHoursInterval> intervals,
+  ) {
+    final byDay = <int, List<OpeningHoursInterval>>{};
+    for (final interval in intervals) {
+      byDay.putIfAbsent(interval.day, () => []).add(interval);
+    }
+    for (final list in byDay.values) {
+      list.sort((a, b) => a.start.compareTo(b.start));
+    }
+    return [
+      for (final day in weekdayOrder(context))
+        if (byDay.containsKey(day)) MapEntry(day, byDay[day]!),
+    ];
+  }
+}

--- a/lib/views/checklists/checklist_item_tile.dart
+++ b/lib/views/checklists/checklist_item_tile.dart
@@ -15,6 +15,7 @@ import 'package:pantry/utils/store_icons.dart';
 import 'package:pantry/views/checklists/checklist_switcher_sheet.dart'
     show parseHexColor;
 import 'package:pantry/widgets/member_avatar.dart';
+import 'package:pantry/widgets/store_detail_dialog.dart';
 import 'swipe_reveal_row.dart';
 
 /// Lightweight pointer to the list an item belongs to, used by the All-lists
@@ -831,6 +832,7 @@ class _MetaRow extends StatelessWidget {
             background: (parseHexColor(s.color) ?? cs.primary).withValues(
               alpha: 0.13,
             ),
+            onTap: () => showStoreDetails(context, s),
           ),
         if (item.quantity != null && item.quantity!.trim().isNotEmpty)
           _Chip(
@@ -876,22 +878,25 @@ class _Chip extends StatelessWidget {
   final Color textColor;
   final Color background;
 
+  /// When set, the chip becomes tappable (used by the store chip to open the
+  /// store details view). Other chips stay inert.
+  final VoidCallback? onTap;
+
   const _Chip({
     this.leading,
     this.label,
     required this.textColor,
     required this.background,
+    this.onTap,
   });
 
   @override
   Widget build(BuildContext context) {
     final hasLabel = label != null;
-    return Container(
+    final radius = BorderRadius.circular(7);
+    final content = Container(
       padding: EdgeInsets.symmetric(horizontal: hasLabel ? 9 : 6, vertical: 3),
-      decoration: BoxDecoration(
-        color: background,
-        borderRadius: BorderRadius.circular(7),
-      ),
+      decoration: BoxDecoration(color: background, borderRadius: radius),
       child: Row(
         mainAxisSize: MainAxisSize.min,
         children: [
@@ -910,6 +915,13 @@ class _Chip extends StatelessWidget {
             ),
         ],
       ),
+    );
+
+    if (onTap == null) return content;
+    return Material(
+      color: Colors.transparent,
+      borderRadius: radius,
+      child: InkWell(onTap: onTap, borderRadius: radius, child: content),
     );
   }
 }

--- a/lib/views/stores/stores_view.dart
+++ b/lib/views/stores/stores_view.dart
@@ -9,6 +9,7 @@ import 'package:pantry/utils/platform_info.dart';
 import 'package:pantry/utils/store_icons.dart';
 import 'package:pantry/widgets/app_bar_back_leading.dart';
 import 'package:pantry/widgets/create_store_dialog.dart';
+import 'package:pantry/widgets/store_detail_dialog.dart';
 
 class StoresView extends StatefulWidget {
   final int houseId;
@@ -69,15 +70,23 @@ class _StoresViewState extends State<StoresView> {
       builder: (_) =>
           CreateStoreDialog(houseId: widget.houseId, existing: store),
     );
-    if (updated != null) {
-      setState(() {
-        final index = _stores.indexWhere((s) => s.id == updated.id);
-        if (index != -1) {
-          _stores[index] = updated;
-          _stores = StoreService.sortStores(_stores);
-        }
-      });
-    }
+    _applyUpdated(updated);
+  }
+
+  Future<void> _view(Store store) async {
+    final updated = await showStoreDetails(context, store);
+    _applyUpdated(updated);
+  }
+
+  void _applyUpdated(Store? updated) {
+    if (updated == null) return;
+    setState(() {
+      final index = _stores.indexWhere((s) => s.id == updated.id);
+      if (index != -1) {
+        _stores[index] = updated;
+        _stores = StoreService.sortStores(_stores);
+      }
+    });
   }
 
   Future<void> _delete(Store store) async {
@@ -200,7 +209,7 @@ class _StoresViewState extends State<StoresView> {
           ),
         ],
       ),
-      onTap: () => _edit(store),
+      onTap: () => _view(store),
     );
   }
 }

--- a/lib/widgets/create_store_dialog.dart
+++ b/lib/widgets/create_store_dialog.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:pantry/i18n.dart';
 import 'package:pantry/models/store.dart';
+import 'package:pantry/utils/opening_hours.dart';
 import 'package:pantry/utils/store_icons.dart';
+import 'package:pantry/utils/text_direction.dart';
 import 'package:pantry/sync/sync_ids.dart';
 import 'package:pantry/sync/sync_manager.dart';
 import 'package:pantry/sync/sync_op.dart';
@@ -33,8 +35,22 @@ class CreateStoreDialog extends StatefulWidget {
 
 class _CreateStoreDialogState extends State<CreateStoreDialog> {
   late final TextEditingController _nameController;
+  late final TextEditingController _locationController;
+  late final TextEditingController _contactController;
+  late final TextEditingController _responsibleController;
+  late final TextEditingController _notesController;
   late String _selectedIcon;
   late String _selectedColor;
+
+  /// Working copy of the store's opening hours.
+  late List<OpeningHoursInterval> _hours;
+
+  // Add-interval row state.
+  bool _showAddRow = false;
+  final Set<int> _selectedDays = {};
+  TimeOfDay? _addStart;
+  TimeOfDay? _addEnd;
+
   bool _saving = false;
 
   bool get _isEditing => widget.existing != null;
@@ -44,30 +60,127 @@ class _CreateStoreDialogState extends State<CreateStoreDialog> {
     super.initState();
     final e = widget.existing;
     _nameController = TextEditingController(text: e?.name ?? '');
+    _locationController = TextEditingController(text: e?.location ?? '');
+    _contactController = TextEditingController(text: e?.contact ?? '');
+    _responsibleController = TextEditingController(text: e?.responsible ?? '');
+    _notesController = TextEditingController(text: e?.notes ?? '');
     _selectedIcon = e?.icon ?? 'store';
     _selectedColor = e?.color ?? storeColors.first;
+    _hours = [...?e?.openingHours];
   }
 
   @override
   void dispose() {
     _nameController.dispose();
+    _locationController.dispose();
+    _contactController.dispose();
+    _responsibleController.dispose();
+    _notesController.dispose();
     super.dispose();
+  }
+
+  String _fmtTime(TimeOfDay t) =>
+      '${t.hour.toString().padLeft(2, '0')}:${t.minute.toString().padLeft(2, '0')}';
+
+  int _minutes(TimeOfDay t) => t.hour * 60 + t.minute;
+
+  bool get _canAddInterval =>
+      _selectedDays.isNotEmpty &&
+      _addStart != null &&
+      _addEnd != null &&
+      _minutes(_addStart!) < _minutes(_addEnd!);
+
+  void _addIntervals() {
+    if (!_canAddInterval) return;
+    final start = _fmtTime(_addStart!);
+    final end = _fmtTime(_addEnd!);
+    setState(() {
+      for (final day in _selectedDays) {
+        _hours.add(OpeningHoursInterval(day: day, start: start, end: end));
+      }
+      _selectedDays.clear();
+      _addStart = null;
+      _addEnd = null;
+    });
+  }
+
+  void _removeInterval(OpeningHoursInterval interval) {
+    setState(() => _hours.remove(interval));
+  }
+
+  Future<void> _pickTime(bool isStart) async {
+    // Drop focus from any text field first: otherwise the picker route restores
+    // focus to it on close, re-opening the keyboard and shifting the layout.
+    FocusManager.instance.primaryFocus?.unfocus();
+    final picked = await showTimePicker(
+      context: context,
+      initialTime:
+          (isStart ? _addStart : _addEnd) ??
+          const TimeOfDay(hour: 9, minute: 0),
+    );
+    if (picked == null) return;
+    setState(() {
+      if (isStart) {
+        _addStart = picked;
+      } else {
+        _addEnd = picked;
+      }
+    });
   }
 
   Future<void> _save() async {
     final name = _nameController.text.trim();
     if (name.isEmpty) return;
 
+    // Sort by [day, start] to mirror the server's canonical ordering.
+    final hours = [..._hours]
+      ..sort((a, b) {
+        final byDay = a.day.compareTo(b.day);
+        return byDay != 0 ? byDay : a.start.compareTo(b.start);
+      });
+
+    final location = _locationController.text.trim();
+    final contact = _contactController.text.trim();
+    final responsible = _responsibleController.text.trim();
+    final notes = _notesController.text.trim();
+
+    // Always send every field so a cleared value reaches the server as an
+    // empty string / empty list, which it maps to null.
+    final body = <String, dynamic>{
+      'name': name,
+      'icon': _selectedIcon,
+      'color': _selectedColor,
+      'location': location,
+      'openingHours': hours.map((e) => e.toJson()).toList(),
+      'contact': contact,
+      'responsible': responsible,
+      'notes': notes,
+    };
+
     setState(() => _saving = true);
     final sync = SyncManager.instance;
     final now = DateTime.now().millisecondsSinceEpoch;
+
+    // Empty text/list become null on the local optimistic copy so the details
+    // view treats them as absent.
+    String? orNull(String v) => v.isEmpty ? null : v;
+    final localHours = hours.isEmpty ? null : hours;
+
     final Store result;
     if (_isEditing) {
       final existing = widget.existing!;
-      result = existing.copyWith(
+      result = Store(
+        id: existing.id,
+        houseId: existing.houseId,
         name: name,
         icon: _selectedIcon,
         color: _selectedColor,
+        location: orNull(location),
+        openingHours: localHours,
+        contact: orNull(contact),
+        responsible: orNull(responsible),
+        notes: orNull(notes),
+        createdAt: existing.createdAt,
         updatedAt: now,
       );
       sync.enqueue(
@@ -78,7 +191,7 @@ class _CreateStoreDialogState extends State<CreateStoreDialog> {
           houseId: widget.houseId,
           entityId: existing.id < 0 ? null : existing.id,
           tempEntityId: existing.id < 0 ? existing.id : null,
-          body: {'name': name, 'icon': _selectedIcon, 'color': _selectedColor},
+          body: body,
           createdAt: now,
         ),
       );
@@ -90,6 +203,11 @@ class _CreateStoreDialogState extends State<CreateStoreDialog> {
         name: name,
         icon: _selectedIcon,
         color: _selectedColor,
+        location: orNull(location),
+        openingHours: localHours,
+        contact: orNull(contact),
+        responsible: orNull(responsible),
+        notes: orNull(notes),
         createdAt: now,
         updatedAt: now,
       );
@@ -100,7 +218,7 @@ class _CreateStoreDialogState extends State<CreateStoreDialog> {
           op: SyncOpKind.create,
           houseId: widget.houseId,
           tempEntityId: tempId,
-          body: {'name': name, 'icon': _selectedIcon, 'color': _selectedColor},
+          body: body,
           createdAt: now,
         ),
       );
@@ -201,6 +319,36 @@ class _CreateStoreDialogState extends State<CreateStoreDialog> {
                 );
               }).toList(),
             ),
+            const SizedBox(height: 16),
+            _infoField(
+              controller: _locationController,
+              label: m.stores.location,
+              hint: m.stores.locationHint,
+            ),
+            const SizedBox(height: 16),
+            Text(m.stores.openingHours, style: theme.textTheme.bodyMedium),
+            const SizedBox(height: 8),
+            _buildHoursEditor(theme),
+            const SizedBox(height: 16),
+            _infoField(
+              controller: _contactController,
+              label: m.stores.contact,
+              hint: m.stores.contactHint,
+              maxLines: 2,
+            ),
+            const SizedBox(height: 16),
+            _infoField(
+              controller: _responsibleController,
+              label: m.stores.responsible,
+              hint: m.stores.responsibleHint,
+            ),
+            const SizedBox(height: 16),
+            _infoField(
+              controller: _notesController,
+              label: m.stores.notes,
+              hint: m.stores.notesHint,
+              maxLines: 3,
+            ),
           ],
         ),
       ),
@@ -220,6 +368,170 @@ class _CreateStoreDialogState extends State<CreateStoreDialog> {
               : Text(m.common.save),
         ),
       ],
+    );
+  }
+
+  Widget _infoField({
+    required TextEditingController controller,
+    required String label,
+    required String hint,
+    int maxLines = 1,
+  }) {
+    return ValueListenableBuilder(
+      valueListenable: controller,
+      builder: (context, value, _) => TextField(
+        controller: controller,
+        maxLines: maxLines,
+        textCapitalization: TextCapitalization.sentences,
+        textDirection: detectTextDirection(value.text),
+        decoration: InputDecoration(
+          labelText: label,
+          hintText: hint,
+          border: const OutlineInputBorder(),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHoursEditor(ThemeData theme) {
+    final grouped = OpeningHoursDisplay.groupByDay(context, _hours);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (grouped.isNotEmpty) ...[
+          for (final entry in grouped)
+            Padding(
+              padding: const EdgeInsetsDirectional.only(bottom: 6),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  SizedBox(
+                    width: 96,
+                    child: Padding(
+                      padding: const EdgeInsetsDirectional.only(top: 6),
+                      child: Text(
+                        OpeningHoursDisplay.weekdayName(context, entry.key),
+                        style: theme.textTheme.bodyMedium?.copyWith(
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                    ),
+                  ),
+                  Expanded(
+                    child: Wrap(
+                      spacing: 6,
+                      runSpacing: 6,
+                      children: [
+                        for (final interval in entry.value)
+                          InputChip(
+                            label: Text(
+                              '${OpeningHoursDisplay.formatTime(context, interval.start)}–'
+                              '${OpeningHoursDisplay.formatTime(context, interval.end)}',
+                            ),
+                            onDeleted: () => _removeInterval(interval),
+                          ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          const SizedBox(height: 8),
+        ],
+        if (_showAddRow)
+          _buildAddRow(theme)
+        else
+          OutlinedButton.icon(
+            onPressed: () => setState(() => _showAddRow = true),
+            icon: const Icon(Icons.add, size: 18),
+            label: Text(m.stores.addOpeningHours),
+          ),
+      ],
+    );
+  }
+
+  Widget _buildAddRow(ThemeData theme) {
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        border: Border.all(color: theme.colorScheme.outlineVariant),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Wrap(
+            spacing: 6,
+            runSpacing: 6,
+            children: [
+              for (final day in OpeningHoursDisplay.weekdayOrder(context))
+                FilterChip(
+                  label: Text(
+                    OpeningHoursDisplay.weekdayName(context, day, short: true),
+                  ),
+                  selected: _selectedDays.contains(day),
+                  onSelected: (sel) => setState(() {
+                    if (sel) {
+                      _selectedDays.add(day);
+                    } else {
+                      _selectedDays.remove(day);
+                    }
+                  }),
+                ),
+            ],
+          ),
+          const SizedBox(height: 12),
+          Row(
+            children: [
+              Expanded(
+                child: OutlinedButton(
+                  onPressed: () => _pickTime(true),
+                  child: Text(
+                    _addStart != null
+                        ? MaterialLocalizations.of(
+                            context,
+                          ).formatTimeOfDay(_addStart!)
+                        : m.stores.openingHoursStart,
+                  ),
+                ),
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: OutlinedButton(
+                  onPressed: () => _pickTime(false),
+                  child: Text(
+                    _addEnd != null
+                        ? MaterialLocalizations.of(
+                            context,
+                          ).formatTimeOfDay(_addEnd!)
+                        : m.stores.openingHoursEnd,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.end,
+            children: [
+              TextButton(
+                onPressed: () => setState(() {
+                  _showAddRow = false;
+                  _selectedDays.clear();
+                  _addStart = null;
+                  _addEnd = null;
+                }),
+                child: Text(m.common.cancel),
+              ),
+              const SizedBox(width: 8),
+              FilledButton(
+                onPressed: _canAddInterval ? _addIntervals : null,
+                child: Text(m.stores.openingHoursAdd),
+              ),
+            ],
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/widgets/store_detail_dialog.dart
+++ b/lib/widgets/store_detail_dialog.dart
@@ -1,0 +1,167 @@
+import 'package:flutter/material.dart';
+import 'package:pantry/i18n.dart';
+import 'package:pantry/models/store.dart';
+import 'package:pantry/utils/opening_hours.dart';
+import 'package:pantry/utils/store_icons.dart';
+import 'package:pantry/utils/text_direction.dart';
+import 'package:pantry/widgets/create_store_dialog.dart';
+
+/// Opens the read-only store details dialog. If the user taps Edit and saves,
+/// the updated [Store] is returned; otherwise the returned value is null.
+Future<Store?> showStoreDetails(BuildContext context, Store store) {
+  return showDialog<Store>(
+    context: context,
+    builder: (_) => StoreDetailDialog(store: store),
+  );
+}
+
+class StoreDetailDialog extends StatelessWidget {
+  final Store store;
+
+  const StoreDetailDialog({super.key, required this.store});
+
+  Color? _parseColor(String hex) {
+    if (hex.isEmpty) return null;
+    hex = hex.replaceFirst('#', '');
+    if (hex.length == 6) hex = 'FF$hex';
+    final value = int.tryParse(hex, radix: 16);
+    return value != null ? Color(value) : null;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final color = _parseColor(store.color) ?? theme.colorScheme.primary;
+
+    return AlertDialog(
+      title: Row(
+        children: [
+          CircleAvatar(
+            backgroundColor: color.withAlpha(40),
+            child: Icon(storeIcon(store.icon), color: color),
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Text(
+              store.name,
+              textDirection: detectTextDirection(store.name),
+            ),
+          ),
+        ],
+      ),
+      content: SingleChildScrollView(
+        child: store.hasNoDetails
+            ? Text(
+                m.stores.noDetails,
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              )
+            : Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  _textRow(context, m.stores.location, store.location),
+                  _hoursRow(context),
+                  _textRow(context, m.stores.contact, store.contact),
+                  _textRow(context, m.stores.responsible, store.responsible),
+                  _textRow(context, m.stores.notes, store.notes),
+                ],
+              ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: Text(m.common.closeDialog),
+        ),
+        FilledButton(
+          onPressed: () async {
+            final updated = await showDialog<Store>(
+              context: context,
+              builder: (_) =>
+                  CreateStoreDialog(houseId: store.houseId, existing: store),
+            );
+            if (updated != null && context.mounted) {
+              Navigator.pop(context, updated);
+            }
+          },
+          child: Text(m.stores.editAction),
+        ),
+      ],
+    );
+  }
+
+  Widget _textRow(BuildContext context, String label, String? value) {
+    if (value == null || value.trim().isEmpty) return const SizedBox.shrink();
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsetsDirectional.only(bottom: 14),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            label,
+            style: theme.textTheme.labelMedium?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+          const SizedBox(height: 2),
+          Text(value.trim(), textDirection: detectTextDirection(value)),
+        ],
+      ),
+    );
+  }
+
+  Widget _hoursRow(BuildContext context) {
+    final hours = store.openingHours;
+    if (hours == null || hours.isEmpty) return const SizedBox.shrink();
+    final theme = Theme.of(context);
+    final grouped = OpeningHoursDisplay.groupByDay(context, hours);
+
+    return Padding(
+      padding: const EdgeInsetsDirectional.only(bottom: 14),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            m.stores.openingHours,
+            style: theme.textTheme.labelMedium?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+          const SizedBox(height: 4),
+          for (final entry in grouped)
+            Padding(
+              padding: const EdgeInsetsDirectional.only(bottom: 2),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  SizedBox(
+                    width: 96,
+                    child: Text(
+                      OpeningHoursDisplay.weekdayName(context, entry.key),
+                      style: theme.textTheme.bodyMedium?.copyWith(
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ),
+                  Expanded(
+                    child: Text(
+                      entry.value
+                          .map(
+                            (i) =>
+                                '${OpeningHoursDisplay.formatTime(context, i.start)}–'
+                                '${OpeningHoursDisplay.formatTime(context, i.end)}',
+                          )
+                          .join(', '),
+                      style: theme.textTheme.bodyMedium,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Brings the Flutter client to parity with server PR #191 (`feat/store-info-fields`, closes #187): five optional info fields on a store and a read-only store details view opened from the store chip on a checklist item.

## What's included

- **Model** — new `OpeningHoursInterval` (ISO `day` 1–7, `HH:MM` `start`/`end`) plus `location`, `openingHours`, `contact`, `responsible`, `notes` on `Store`, threaded through `fromJson`/`toJson`/`copyWith`.
- **Service** — `createStore`/`updateStore` carry the new fields; null-aware body keeps "absent = unchanged" while explicit `''`/`[]` clear a field (server maps to null).
- **Sync** — `_executeStore` reads the new keys on both create and update, so offline store edits replay with info fields intact; the dialog seeds every key into the `SyncOp` body.
- **Edit form** — location, contact (multi-line), responsible, notes (multi-line), and an opening-hours editor supporting multiple intervals and multiple per day: multi-select weekday chips + start/end time pickers add one interval per selected day; existing intervals shown grouped per day with per-interval delete. "Add" gated on ≥1 day and `start` < `end`.
- **Details view** — read-only dialog (`showStoreDetails`) rendering only non-empty fields, hours grouped per day as `HH:MM–HH:MM`, with a "No details added yet." placeholder and an Edit action. Wired to the store chip on checklist items and to the stores list row.
- **i18n** — new `stores` keys across base + de/es/fr/he, regenerated via `make i18n`.

## Notes

- Weekday **ordering** respects `MaterialLocalizations.firstDayOfWeekIndex`; the stored `day` stays ISO (1 = Monday) regardless of display order.
- Weekday **names** come from the app's existing `recurrence.dayNames`/`dayAbbr` translations rather than `intl`'s `DateFormat` — the app never calls `initializeDateFormatting`, so a non-en `DateFormat` locale would throw.

## Testing

- `make analyze` — clean
- `flutter test` — all 270 pass