### PR TITLE
feat(shopping): add Shopping Mode

### DIFF
--- a/lib/i18n/messages.i18n.dart
+++ b/lib/i18n/messages.i18n.dart
@@ -761,6 +761,27 @@ Password: pantry-rocks""";
   String get priceMockName => """Olive oil""";
 
   /// ```dart
+  /// "Shop store by store"
+  /// ```
+  String get shoppingIntroTitle => """Shop store by store""";
+
+  /// ```dart
+  /// "Start a shopping trip over your lists, walk each store in order, and check items off as you go — with a running price total."
+  /// ```
+  String get shoppingIntroBody =>
+      """Start a shopping trip over your lists, walk each store in order, and check items off as you go — with a running price total.""";
+
+  /// ```dart
+  /// "Supermarket"
+  /// ```
+  String get shoppingMockStoreActive => """Supermarket""";
+
+  /// ```dart
+  /// "Pharmacy"
+  /// ```
+  String get shoppingMockStoreNext => """Pharmacy""";
+
+  /// ```dart
   /// "* Requires Pantry for Nextcloud v${version}+"
   /// ```
   String serverRequirementNote(String version) =>
@@ -4357,6 +4378,11 @@ Password: pantry-rocks""",
   """onboarding.priceBody""":
       """Give any item a price — a single amount or a range — in your currency of choice. It shows as a chip on the item, and you can filter your list by price to keep a shop on budget.""",
   """onboarding.priceMockName""": """Olive oil""",
+  """onboarding.shoppingIntroTitle""": """Shop store by store""",
+  """onboarding.shoppingIntroBody""":
+      """Start a shopping trip over your lists, walk each store in order, and check items off as you go — with a running price total.""",
+  """onboarding.shoppingMockStoreActive""": """Supermarket""",
+  """onboarding.shoppingMockStoreNext""": """Pharmacy""",
   """onboarding.dev.showOnboarding""": """Show onboarding""",
   """onboarding.dev.pickLastSeenTitle""": """Preview what's new""",
   """onboarding.dev.pickLastSeenBody""":

--- a/lib/i18n/messages.i18n.dart
+++ b/lib/i18n/messages.i18n.dart
@@ -77,6 +77,7 @@ class Messages {
   ChecklistsMessages get checklists => ChecklistsMessages(this);
   NotesWallMessages get notesWall => NotesWallMessages(this);
   PhotoBoardMessages get photoBoard => PhotoBoardMessages(this);
+  ShoppingMessages get shopping => ShoppingMessages(this);
   ShareMessages get share => ShareMessages(this);
   RecurrenceMessages get recurrence => RecurrenceMessages(this);
   SyncMessages get sync => SyncMessages(this);
@@ -3523,6 +3524,368 @@ class SortPhotoBoardMessages {
   String get custom => """Custom""";
 }
 
+class ShoppingMessages {
+  final Messages _parent;
+  const ShoppingMessages(this._parent);
+
+  /// ```dart
+  /// "Start shopping"
+  /// ```
+  String get startShopping => """Start shopping""";
+
+  /// ```dart
+  /// "Resume shopping"
+  /// ```
+  String get resumeShopping => """Resume shopping""";
+
+  /// ```dart
+  /// "Shopping history"
+  /// ```
+  String get shoppingHistory => """Shopping history""";
+
+  /// ```dart
+  /// "Resume"
+  /// ```
+  String get resume => """Resume""";
+
+  /// ```dart
+  /// "Shopping at ${store}"
+  /// ```
+  String bannerShoppingAt(String store) => """Shopping at ${store}""";
+
+  /// ```dart
+  /// "Store $index/$total"
+  /// ```
+  String bannerStoreProgress(int index, int total) => """Store $index/$total""";
+
+  /// ```dart
+  /// "Shopping now"
+  /// ```
+  String get bannerShoppingNow => """Shopping now""";
+
+  /// ```dart
+  /// "Start shopping"
+  /// ```
+  String get startTitle => """Start shopping""";
+
+  /// ```dart
+  /// "Lists to shop"
+  /// ```
+  String get listsToShop => """Lists to shop""";
+
+  /// ```dart
+  /// "Select all"
+  /// ```
+  String get selectAll => """Select all""";
+
+  /// ```dart
+  /// "Select none"
+  /// ```
+  String get selectNone => """Select none""";
+
+  /// ```dart
+  /// "No lists to shop yet."
+  /// ```
+  String get noListsToShop => """No lists to shop yet.""";
+
+  /// ```dart
+  /// "Stores"
+  /// ```
+  String get storesTitle => """Stores""";
+
+  /// ```dart
+  /// "Turn the stores you'll visit on or off, and drag to set the order."
+  /// ```
+  String get storesHint =>
+      """Turn the stores you'll visit on or off, and drag to set the order.""";
+
+  /// ```dart
+  /// "None of the selected lists have items assigned to a store."
+  /// ```
+  String get noStoresWithItems =>
+      """None of the selected lists have items assigned to a store.""";
+
+  /// ```dart
+  /// "Include items not assigned to any store"
+  /// ```
+  String get includeUnassigned => """Include items not assigned to any store""";
+
+  /// ```dart
+  /// "Start"
+  /// ```
+  String get start => """Start""";
+
+  /// ```dart
+  /// "Failed to start shopping."
+  /// ```
+  String get startFailed => """Failed to start shopping.""";
+
+  /// ```dart
+  /// "You already have a shopping trip in progress."
+  /// ```
+  String get tripInProgress =>
+      """You already have a shopping trip in progress.""";
+
+  /// ```dart
+  /// "You have a shopping trip in progress in ${house}."
+  /// ```
+  String tripInProgressElsewhere(String house) =>
+      """You have a shopping trip in progress in ${house}.""";
+
+  /// ```dart
+  /// "End previous trip"
+  /// ```
+  String get endPreviousTrip => """End previous trip""";
+
+  /// ```dart
+  /// "Failed to end the previous trip."
+  /// ```
+  String get endPreviousFailed => """Failed to end the previous trip.""";
+
+  /// ```dart
+  /// "$count in cart"
+  /// ```
+  String inCart(int count) => """$count in cart""";
+
+  /// ```dart
+  /// "Hide trip from housemates"
+  /// ```
+  String get makePrivate => """Hide trip from housemates""";
+
+  /// ```dart
+  /// "Show trip to housemates"
+  /// ```
+  String get makePublic => """Show trip to housemates""";
+
+  /// ```dart
+  /// "Private"
+  /// ```
+  String get privateBadge => """Private""";
+
+  /// ```dart
+  /// "Next store"
+  /// ```
+  String get nextStore => """Next store""";
+
+  /// ```dart
+  /// "Finish"
+  /// ```
+  String get finish => """Finish""";
+
+  /// ```dart
+  /// "Finish trip"
+  /// ```
+  String get finishTrip => """Finish trip""";
+
+  /// ```dart
+  /// "All checked off here"
+  /// ```
+  String get allCheckedHere => """All checked off here""";
+
+  /// ```dart
+  /// "Move on to the next store."
+  /// ```
+  String get moveOnToNext => """Move on to the next store.""";
+
+  /// ```dart
+  /// "All done"
+  /// ```
+  String get allDone => """All done""";
+
+  /// ```dart
+  /// "Everything's in the cart."
+  /// ```
+  String get everythingInCart => """Everything's in the cart.""";
+
+  /// ```dart
+  /// "Done ($count)"
+  /// ```
+  String doneToday(int count) => """Done ($count)""";
+
+  /// ```dart
+  /// "Nothing to buy here."
+  /// ```
+  String get nothingToBuyHere => """Nothing to buy here.""";
+
+  /// ```dart
+  /// "Couldn't update the item."
+  /// ```
+  String get checkFailed => """Couldn't update the item.""";
+
+  /// ```dart
+  /// "Failed to load items."
+  /// ```
+  String get loadItemsFailed => """Failed to load items.""";
+
+  /// ```dart
+  /// "Review"
+  /// ```
+  String get reviewTitle => """Review""";
+
+  /// ```dart
+  /// "Next store"
+  /// ```
+  String get advanceTitle => """Next store""";
+
+  /// ```dart
+  /// "Actual paid"
+  /// ```
+  String get actualPaid => """Actual paid""";
+
+  /// ```dart
+  /// "Grand total"
+  /// ```
+  String get grandTotal => """Grand total""";
+
+  /// ```dart
+  /// "${_plural(count, one: '1 item without a price', many: '$count items without a price')}"
+  /// ```
+  String itemsWithoutPrice(int count) =>
+      """${_plural(count, one: '1 item without a price', many: '$count items without a price')}""";
+
+  /// ```dart
+  /// "${_plural(count, one: '1 item still unchecked', many: '$count items still unchecked')}"
+  /// ```
+  String itemsStillUnchecked(int count) =>
+      """${_plural(count, one: '1 item still unchecked', many: '$count items still unchecked')}""";
+
+  /// ```dart
+  /// "Any store"
+  /// ```
+  String get anyStore => """Any store""";
+
+  /// ```dart
+  /// "Failed to save the total."
+  /// ```
+  String get saveTotalFailed => """Failed to save the total.""";
+
+  /// ```dart
+  /// "Reminders"
+  /// ```
+  String get remindersTitle => """Reminders""";
+
+  /// ```dart
+  /// "Manage reminders"
+  /// ```
+  String get manageReminders => """Manage reminders""";
+
+  /// ```dart
+  /// "At start"
+  /// ```
+  String get reminderGroupStart => """At start""";
+
+  /// ```dart
+  /// "Between shops"
+  /// ```
+  String get reminderGroupAdvance => """Between shops""";
+
+  /// ```dart
+  /// "At end"
+  /// ```
+  String get reminderGroupEnd => """At end""";
+
+  /// ```dart
+  /// "No reminders here yet."
+  /// ```
+  String get noRemindersHere => """No reminders here yet.""";
+
+  /// ```dart
+  /// "Add a reminder"
+  /// ```
+  String get addReminderHint => """Add a reminder""";
+
+  /// ```dart
+  /// "When to show"
+  /// ```
+  String get reminderWhen => """When to show""";
+
+  /// ```dart
+  /// "At start"
+  /// ```
+  String get whenOnStart => """At start""";
+
+  /// ```dart
+  /// "Between shops"
+  /// ```
+  String get whenOnStoreAdvance => """Between shops""";
+
+  /// ```dart
+  /// "At end"
+  /// ```
+  String get whenOnClose => """At end""";
+
+  /// ```dart
+  /// "Add"
+  /// ```
+  String get add => """Add""";
+
+  /// ```dart
+  /// "Failed to save the reminder."
+  /// ```
+  String get reminderSaveFailed => """Failed to save the reminder.""";
+
+  /// ```dart
+  /// "Failed to delete the reminder."
+  /// ```
+  String get reminderDeleteFailed => """Failed to delete the reminder.""";
+
+  /// ```dart
+  /// "Shopping history"
+  /// ```
+  String get historyTitle => """Shopping history""";
+
+  /// ```dart
+  /// "Mine"
+  /// ```
+  String get scopeMine => """Mine""";
+
+  /// ```dart
+  /// "House"
+  /// ```
+  String get scopeHouse => """House""";
+
+  /// ```dart
+  /// "No store"
+  /// ```
+  String get noStorePath => """No store""";
+
+  /// ```dart
+  /// "${_plural(count, one: '1 item', many: '$count items')}"
+  /// ```
+  String itemsCount(int count) =>
+      """${_plural(count, one: '1 item', many: '$count items')}""";
+
+  /// ```dart
+  /// "Load more"
+  /// ```
+  String get loadMore => """Load more""";
+
+  /// ```dart
+  /// "No shopping trips yet."
+  /// ```
+  String get noTripsYet => """No shopping trips yet.""";
+
+  /// ```dart
+  /// "No shopping trips in this house yet."
+  /// ```
+  String get noHouseTripsYet => """No shopping trips in this house yet.""";
+
+  /// ```dart
+  /// "Failed to load history."
+  /// ```
+  String get loadHistoryFailed => """Failed to load history.""";
+
+  /// ```dart
+  /// "Something went wrong. Please try again."
+  /// ```
+  String get loadFailed => """Something went wrong. Please try again.""";
+
+  /// ```dart
+  /// "Uncategorized"
+  /// ```
+  String get uncategorized => """Uncategorized""";
+}
+
 class ShareMessages {
   final Messages _parent;
   const ShareMessages(this._parent);
@@ -4493,6 +4856,72 @@ Password: pantry-rocks""",
   """photoBoard.sort.captionAZ""": """Caption A–Z""",
   """photoBoard.sort.captionZA""": """Caption Z–A""",
   """photoBoard.sort.custom""": """Custom""",
+  """shopping.startShopping""": """Start shopping""",
+  """shopping.resumeShopping""": """Resume shopping""",
+  """shopping.shoppingHistory""": """Shopping history""",
+  """shopping.resume""": """Resume""",
+  """shopping.bannerShoppingNow""": """Shopping now""",
+  """shopping.startTitle""": """Start shopping""",
+  """shopping.listsToShop""": """Lists to shop""",
+  """shopping.selectAll""": """Select all""",
+  """shopping.selectNone""": """Select none""",
+  """shopping.noListsToShop""": """No lists to shop yet.""",
+  """shopping.storesTitle""": """Stores""",
+  """shopping.storesHint""":
+      """Turn the stores you'll visit on or off, and drag to set the order.""",
+  """shopping.noStoresWithItems""":
+      """None of the selected lists have items assigned to a store.""",
+  """shopping.includeUnassigned""":
+      """Include items not assigned to any store""",
+  """shopping.start""": """Start""",
+  """shopping.startFailed""": """Failed to start shopping.""",
+  """shopping.tripInProgress""":
+      """You already have a shopping trip in progress.""",
+  """shopping.endPreviousTrip""": """End previous trip""",
+  """shopping.endPreviousFailed""": """Failed to end the previous trip.""",
+  """shopping.makePrivate""": """Hide trip from housemates""",
+  """shopping.makePublic""": """Show trip to housemates""",
+  """shopping.privateBadge""": """Private""",
+  """shopping.nextStore""": """Next store""",
+  """shopping.finish""": """Finish""",
+  """shopping.finishTrip""": """Finish trip""",
+  """shopping.allCheckedHere""": """All checked off here""",
+  """shopping.moveOnToNext""": """Move on to the next store.""",
+  """shopping.allDone""": """All done""",
+  """shopping.everythingInCart""": """Everything's in the cart.""",
+  """shopping.nothingToBuyHere""": """Nothing to buy here.""",
+  """shopping.checkFailed""": """Couldn't update the item.""",
+  """shopping.loadItemsFailed""": """Failed to load items.""",
+  """shopping.reviewTitle""": """Review""",
+  """shopping.advanceTitle""": """Next store""",
+  """shopping.actualPaid""": """Actual paid""",
+  """shopping.grandTotal""": """Grand total""",
+  """shopping.anyStore""": """Any store""",
+  """shopping.saveTotalFailed""": """Failed to save the total.""",
+  """shopping.remindersTitle""": """Reminders""",
+  """shopping.manageReminders""": """Manage reminders""",
+  """shopping.reminderGroupStart""": """At start""",
+  """shopping.reminderGroupAdvance""": """Between shops""",
+  """shopping.reminderGroupEnd""": """At end""",
+  """shopping.noRemindersHere""": """No reminders here yet.""",
+  """shopping.addReminderHint""": """Add a reminder""",
+  """shopping.reminderWhen""": """When to show""",
+  """shopping.whenOnStart""": """At start""",
+  """shopping.whenOnStoreAdvance""": """Between shops""",
+  """shopping.whenOnClose""": """At end""",
+  """shopping.add""": """Add""",
+  """shopping.reminderSaveFailed""": """Failed to save the reminder.""",
+  """shopping.reminderDeleteFailed""": """Failed to delete the reminder.""",
+  """shopping.historyTitle""": """Shopping history""",
+  """shopping.scopeMine""": """Mine""",
+  """shopping.scopeHouse""": """House""",
+  """shopping.noStorePath""": """No store""",
+  """shopping.loadMore""": """Load more""",
+  """shopping.noTripsYet""": """No shopping trips yet.""",
+  """shopping.noHouseTripsYet""": """No shopping trips in this house yet.""",
+  """shopping.loadHistoryFailed""": """Failed to load history.""",
+  """shopping.loadFailed""": """Something went wrong. Please try again.""",
+  """shopping.uncategorized""": """Uncategorized""",
   """share.title""": """Share to Pantry""",
   """share.chooseHouse""": """Choose house""",
   """share.choosePhotoDestination""": """Upload to""",

--- a/lib/i18n/messages.i18n.yaml
+++ b/lib/i18n/messages.i18n.yaml
@@ -130,6 +130,10 @@ onboarding:
   priceTitle: "Add prices to your items"
   priceBody: "Give any item a price — a single amount or a range — in your currency of choice. It shows as a chip on the item, and you can filter your list by price to keep a shop on budget."
   priceMockName: "Olive oil"
+  shoppingIntroTitle: "Shop store by store"
+  shoppingIntroBody: "Start a shopping trip over your lists, walk each store in order, and check items off as you go — with a running price total."
+  shoppingMockStoreActive: "Supermarket"
+  shoppingMockStoreNext: "Pharmacy"
   serverRequirementNote(String version): "* Requires Pantry for Nextcloud v${version}+"
   dev:
     showOnboarding: "Show onboarding"

--- a/lib/i18n/messages.i18n.yaml
+++ b/lib/i18n/messages.i18n.yaml
@@ -676,6 +676,86 @@ photoBoard:
     captionZA: "Caption Z–A"
     custom: Custom
 
+shopping:
+  # Entry points / resume banner
+  startShopping: Start shopping
+  resumeShopping: Resume shopping
+  shoppingHistory: Shopping history
+  resume: Resume
+  bannerShoppingAt(String store): "Shopping at ${store}"
+  bannerStoreProgress(int index, int total): "Store $index/$total"
+  bannerShoppingNow: Shopping now
+  # Start screen
+  startTitle: Start shopping
+  listsToShop: Lists to shop
+  selectAll: Select all
+  selectNone: Select none
+  noListsToShop: No lists to shop yet.
+  storesTitle: Stores
+  storesHint: "Turn the stores you'll visit on or off, and drag to set the order."
+  noStoresWithItems: None of the selected lists have items assigned to a store.
+  includeUnassigned: Include items not assigned to any store
+  start: Start
+  startFailed: Failed to start shopping.
+  # One-live-session guard
+  tripInProgress: You already have a shopping trip in progress.
+  tripInProgressElsewhere(String house): "You have a shopping trip in progress in ${house}."
+  endPreviousTrip: End previous trip
+  endPreviousFailed: Failed to end the previous trip.
+  # Dense session screen
+  inCart(int count): "$count in cart"
+  makePrivate: Hide trip from housemates
+  makePublic: Show trip to housemates
+  privateBadge: Private
+  nextStore: Next store
+  finish: Finish
+  finishTrip: Finish trip
+  allCheckedHere: All checked off here
+  moveOnToNext: Move on to the next store.
+  allDone: All done
+  everythingInCart: Everything's in the cart.
+  doneToday(int count): "Done ($count)"
+  nothingToBuyHere: Nothing to buy here.
+  checkFailed: Couldn't update the item.
+  loadItemsFailed: Failed to load items.
+  # Review / close
+  reviewTitle: Review
+  advanceTitle: Next store
+  actualPaid: Actual paid
+  grandTotal: Grand total
+  itemsWithoutPrice(int count): "${_plural(count, one: '1 item without a price', many: '$count items without a price')}"
+  itemsStillUnchecked(int count): "${_plural(count, one: '1 item still unchecked', many: '$count items still unchecked')}"
+  anyStore: Any store
+  saveTotalFailed: Failed to save the total.
+  # Reminders
+  remindersTitle: Reminders
+  manageReminders: Manage reminders
+  reminderGroupStart: At start
+  reminderGroupAdvance: Between shops
+  reminderGroupEnd: At end
+  noRemindersHere: No reminders here yet.
+  addReminderHint: Add a reminder
+  reminderWhen: When to show
+  whenOnStart: At start
+  whenOnStoreAdvance: Between shops
+  whenOnClose: At end
+  add: Add
+  reminderSaveFailed: Failed to save the reminder.
+  reminderDeleteFailed: Failed to delete the reminder.
+  # History
+  historyTitle: Shopping history
+  scopeMine: Mine
+  scopeHouse: House
+  noStorePath: No store
+  itemsCount(int count): "${_plural(count, one: '1 item', many: '$count items')}"
+  loadMore: Load more
+  noTripsYet: No shopping trips yet.
+  noHouseTripsYet: No shopping trips in this house yet.
+  loadHistoryFailed: Failed to load history.
+  # Common
+  loadFailed: Something went wrong. Please try again.
+  uncategorized: Uncategorized
+
 share:
   title: Share to Pantry
   chooseHouse: Choose house

--- a/lib/i18n/messages_de.i18n.dart
+++ b/lib/i18n/messages_de.i18n.dart
@@ -78,6 +78,7 @@ class MessagesDe extends Messages {
   ChecklistsMessagesDe get checklists => ChecklistsMessagesDe(this);
   NotesWallMessagesDe get notesWall => NotesWallMessagesDe(this);
   PhotoBoardMessagesDe get photoBoard => PhotoBoardMessagesDe(this);
+  ShoppingMessagesDe get shopping => ShoppingMessagesDe(this);
   ShareMessagesDe get share => ShareMessagesDe(this);
   RecurrenceMessagesDe get recurrence => RecurrenceMessagesDe(this);
   SyncMessagesDe get sync => SyncMessagesDe(this);
@@ -3562,6 +3563,372 @@ class SortPhotoBoardMessagesDe extends SortPhotoBoardMessages {
   String get custom => """Benutzerdefiniert""";
 }
 
+class ShoppingMessagesDe extends ShoppingMessages {
+  final MessagesDe _parent;
+  const ShoppingMessagesDe(this._parent) : super(_parent);
+
+  /// ```dart
+  /// "Einkaufen starten"
+  /// ```
+  String get startShopping => """Einkaufen starten""";
+
+  /// ```dart
+  /// "Einkauf fortsetzen"
+  /// ```
+  String get resumeShopping => """Einkauf fortsetzen""";
+
+  /// ```dart
+  /// "Einkaufsverlauf"
+  /// ```
+  String get shoppingHistory => """Einkaufsverlauf""";
+
+  /// ```dart
+  /// "Fortsetzen"
+  /// ```
+  String get resume => """Fortsetzen""";
+
+  /// ```dart
+  /// "Einkaufen bei ${store}"
+  /// ```
+  String bannerShoppingAt(String store) => """Einkaufen bei ${store}""";
+
+  /// ```dart
+  /// "Geschäft $index/$total"
+  /// ```
+  String bannerStoreProgress(int index, int total) =>
+      """Geschäft $index/$total""";
+
+  /// ```dart
+  /// "Einkauf läuft"
+  /// ```
+  String get bannerShoppingNow => """Einkauf läuft""";
+
+  /// ```dart
+  /// "Einkaufen starten"
+  /// ```
+  String get startTitle => """Einkaufen starten""";
+
+  /// ```dart
+  /// "Zu kaufende Listen"
+  /// ```
+  String get listsToShop => """Zu kaufende Listen""";
+
+  /// ```dart
+  /// "Alle auswählen"
+  /// ```
+  String get selectAll => """Alle auswählen""";
+
+  /// ```dart
+  /// "Keine auswählen"
+  /// ```
+  String get selectNone => """Keine auswählen""";
+
+  /// ```dart
+  /// "Noch keine Listen zum Einkaufen."
+  /// ```
+  String get noListsToShop => """Noch keine Listen zum Einkaufen.""";
+
+  /// ```dart
+  /// "Geschäfte"
+  /// ```
+  String get storesTitle => """Geschäfte""";
+
+  /// ```dart
+  /// "Schalte die Geschäfte ein oder aus, die du besuchst, und ziehe sie in die richtige Reihenfolge."
+  /// ```
+  String get storesHint =>
+      """Schalte die Geschäfte ein oder aus, die du besuchst, und ziehe sie in die richtige Reihenfolge.""";
+
+  /// ```dart
+  /// "Keine der ausgewählten Listen hat Artikel, die einem Geschäft zugewiesen sind."
+  /// ```
+  String get noStoresWithItems =>
+      """Keine der ausgewählten Listen hat Artikel, die einem Geschäft zugewiesen sind.""";
+
+  /// ```dart
+  /// "Artikel ohne Geschäft einbeziehen"
+  /// ```
+  String get includeUnassigned => """Artikel ohne Geschäft einbeziehen""";
+
+  /// ```dart
+  /// "Starten"
+  /// ```
+  String get start => """Starten""";
+
+  /// ```dart
+  /// "Einkauf konnte nicht gestartet werden."
+  /// ```
+  String get startFailed => """Einkauf konnte nicht gestartet werden.""";
+
+  /// ```dart
+  /// "Du hast bereits einen laufenden Einkauf."
+  /// ```
+  String get tripInProgress => """Du hast bereits einen laufenden Einkauf.""";
+
+  /// ```dart
+  /// "Du hast einen laufenden Einkauf in ${house}."
+  /// ```
+  String tripInProgressElsewhere(String house) =>
+      """Du hast einen laufenden Einkauf in ${house}.""";
+
+  /// ```dart
+  /// "Vorherigen Einkauf beenden"
+  /// ```
+  String get endPreviousTrip => """Vorherigen Einkauf beenden""";
+
+  /// ```dart
+  /// "Vorheriger Einkauf konnte nicht beendet werden."
+  /// ```
+  String get endPreviousFailed =>
+      """Vorheriger Einkauf konnte nicht beendet werden.""";
+
+  /// ```dart
+  /// "$count im Wagen"
+  /// ```
+  String inCart(int count) => """$count im Wagen""";
+
+  /// ```dart
+  /// "Einkauf vor Mitbewohnern verbergen"
+  /// ```
+  String get makePrivate => """Einkauf vor Mitbewohnern verbergen""";
+
+  /// ```dart
+  /// "Einkauf Mitbewohnern zeigen"
+  /// ```
+  String get makePublic => """Einkauf Mitbewohnern zeigen""";
+
+  /// ```dart
+  /// "Privat"
+  /// ```
+  String get privateBadge => """Privat""";
+
+  /// ```dart
+  /// "Nächstes Geschäft"
+  /// ```
+  String get nextStore => """Nächstes Geschäft""";
+
+  /// ```dart
+  /// "Fertig"
+  /// ```
+  String get finish => """Fertig""";
+
+  /// ```dart
+  /// "Einkauf abschließen"
+  /// ```
+  String get finishTrip => """Einkauf abschließen""";
+
+  /// ```dart
+  /// "Hier alles abgehakt"
+  /// ```
+  String get allCheckedHere => """Hier alles abgehakt""";
+
+  /// ```dart
+  /// "Weiter zum nächsten Geschäft."
+  /// ```
+  String get moveOnToNext => """Weiter zum nächsten Geschäft.""";
+
+  /// ```dart
+  /// "Alles erledigt"
+  /// ```
+  String get allDone => """Alles erledigt""";
+
+  /// ```dart
+  /// "Alles ist im Wagen."
+  /// ```
+  String get everythingInCart => """Alles ist im Wagen.""";
+
+  /// ```dart
+  /// "Erledigt ($count)"
+  /// ```
+  String doneToday(int count) => """Erledigt ($count)""";
+
+  /// ```dart
+  /// "Hier gibt es nichts zu kaufen."
+  /// ```
+  String get nothingToBuyHere => """Hier gibt es nichts zu kaufen.""";
+
+  /// ```dart
+  /// "Artikel konnte nicht aktualisiert werden."
+  /// ```
+  String get checkFailed => """Artikel konnte nicht aktualisiert werden.""";
+
+  /// ```dart
+  /// "Artikel konnten nicht geladen werden."
+  /// ```
+  String get loadItemsFailed => """Artikel konnten nicht geladen werden.""";
+
+  /// ```dart
+  /// "Überblick"
+  /// ```
+  String get reviewTitle => """Überblick""";
+
+  /// ```dart
+  /// "Nächstes Geschäft"
+  /// ```
+  String get advanceTitle => """Nächstes Geschäft""";
+
+  /// ```dart
+  /// "Tatsächlich bezahlt"
+  /// ```
+  String get actualPaid => """Tatsächlich bezahlt""";
+
+  /// ```dart
+  /// "Gesamtsumme"
+  /// ```
+  String get grandTotal => """Gesamtsumme""";
+
+  /// ```dart
+  /// "${_plural(count, one: '1 Artikel ohne Preis', many: '$count Artikel ohne Preis')}"
+  /// ```
+  String itemsWithoutPrice(int count) =>
+      """${_plural(count, one: '1 Artikel ohne Preis', many: '$count Artikel ohne Preis')}""";
+
+  /// ```dart
+  /// "${_plural(count, one: '1 Artikel noch nicht abgehakt', many: '$count Artikel noch nicht abgehakt')}"
+  /// ```
+  String itemsStillUnchecked(int count) =>
+      """${_plural(count, one: '1 Artikel noch nicht abgehakt', many: '$count Artikel noch nicht abgehakt')}""";
+
+  /// ```dart
+  /// "Beliebiges Geschäft"
+  /// ```
+  String get anyStore => """Beliebiges Geschäft""";
+
+  /// ```dart
+  /// "Summe konnte nicht gespeichert werden."
+  /// ```
+  String get saveTotalFailed => """Summe konnte nicht gespeichert werden.""";
+
+  /// ```dart
+  /// "Erinnerungen"
+  /// ```
+  String get remindersTitle => """Erinnerungen""";
+
+  /// ```dart
+  /// "Erinnerungen verwalten"
+  /// ```
+  String get manageReminders => """Erinnerungen verwalten""";
+
+  /// ```dart
+  /// "Zu Beginn"
+  /// ```
+  String get reminderGroupStart => """Zu Beginn""";
+
+  /// ```dart
+  /// "Zwischen Geschäften"
+  /// ```
+  String get reminderGroupAdvance => """Zwischen Geschäften""";
+
+  /// ```dart
+  /// "Am Ende"
+  /// ```
+  String get reminderGroupEnd => """Am Ende""";
+
+  /// ```dart
+  /// "Noch keine Erinnerungen hier."
+  /// ```
+  String get noRemindersHere => """Noch keine Erinnerungen hier.""";
+
+  /// ```dart
+  /// "Erinnerung hinzufügen"
+  /// ```
+  String get addReminderHint => """Erinnerung hinzufügen""";
+
+  /// ```dart
+  /// "Wann anzeigen"
+  /// ```
+  String get reminderWhen => """Wann anzeigen""";
+
+  /// ```dart
+  /// "Zu Beginn"
+  /// ```
+  String get whenOnStart => """Zu Beginn""";
+
+  /// ```dart
+  /// "Zwischen Geschäften"
+  /// ```
+  String get whenOnStoreAdvance => """Zwischen Geschäften""";
+
+  /// ```dart
+  /// "Am Ende"
+  /// ```
+  String get whenOnClose => """Am Ende""";
+
+  /// ```dart
+  /// "Hinzufügen"
+  /// ```
+  String get add => """Hinzufügen""";
+
+  /// ```dart
+  /// "Erinnerung konnte nicht gespeichert werden."
+  /// ```
+  String get reminderSaveFailed =>
+      """Erinnerung konnte nicht gespeichert werden.""";
+
+  /// ```dart
+  /// "Erinnerung konnte nicht gelöscht werden."
+  /// ```
+  String get reminderDeleteFailed =>
+      """Erinnerung konnte nicht gelöscht werden.""";
+
+  /// ```dart
+  /// "Einkaufsverlauf"
+  /// ```
+  String get historyTitle => """Einkaufsverlauf""";
+
+  /// ```dart
+  /// "Meine"
+  /// ```
+  String get scopeMine => """Meine""";
+
+  /// ```dart
+  /// "Haushalt"
+  /// ```
+  String get scopeHouse => """Haushalt""";
+
+  /// ```dart
+  /// "Kein Geschäft"
+  /// ```
+  String get noStorePath => """Kein Geschäft""";
+
+  /// ```dart
+  /// "${_plural(count, one: '1 Artikel', many: '$count Artikel')}"
+  /// ```
+  String itemsCount(int count) =>
+      """${_plural(count, one: '1 Artikel', many: '$count Artikel')}""";
+
+  /// ```dart
+  /// "Mehr laden"
+  /// ```
+  String get loadMore => """Mehr laden""";
+
+  /// ```dart
+  /// "Noch keine Einkäufe."
+  /// ```
+  String get noTripsYet => """Noch keine Einkäufe.""";
+
+  /// ```dart
+  /// "Noch keine Einkäufe in diesem Haushalt."
+  /// ```
+  String get noHouseTripsYet => """Noch keine Einkäufe in diesem Haushalt.""";
+
+  /// ```dart
+  /// "Verlauf konnte nicht geladen werden."
+  /// ```
+  String get loadHistoryFailed => """Verlauf konnte nicht geladen werden.""";
+
+  /// ```dart
+  /// "Etwas ist schiefgelaufen. Bitte versuche es erneut."
+  /// ```
+  String get loadFailed =>
+      """Etwas ist schiefgelaufen. Bitte versuche es erneut.""";
+
+  /// ```dart
+  /// "Ohne Kategorie"
+  /// ```
+  String get uncategorized => """Ohne Kategorie""";
+}
+
 class ShareMessagesDe extends ShareMessages {
   final MessagesDe _parent;
   const ShareMessagesDe(this._parent) : super(_parent);
@@ -4576,6 +4943,74 @@ Passwort: pantry-rocks""",
   """photoBoard.sort.captionAZ""": """Beschriftung A–Z""",
   """photoBoard.sort.captionZA""": """Beschriftung Z–A""",
   """photoBoard.sort.custom""": """Benutzerdefiniert""",
+  """shopping.startShopping""": """Einkaufen starten""",
+  """shopping.resumeShopping""": """Einkauf fortsetzen""",
+  """shopping.shoppingHistory""": """Einkaufsverlauf""",
+  """shopping.resume""": """Fortsetzen""",
+  """shopping.bannerShoppingNow""": """Einkauf läuft""",
+  """shopping.startTitle""": """Einkaufen starten""",
+  """shopping.listsToShop""": """Zu kaufende Listen""",
+  """shopping.selectAll""": """Alle auswählen""",
+  """shopping.selectNone""": """Keine auswählen""",
+  """shopping.noListsToShop""": """Noch keine Listen zum Einkaufen.""",
+  """shopping.storesTitle""": """Geschäfte""",
+  """shopping.storesHint""":
+      """Schalte die Geschäfte ein oder aus, die du besuchst, und ziehe sie in die richtige Reihenfolge.""",
+  """shopping.noStoresWithItems""":
+      """Keine der ausgewählten Listen hat Artikel, die einem Geschäft zugewiesen sind.""",
+  """shopping.includeUnassigned""": """Artikel ohne Geschäft einbeziehen""",
+  """shopping.start""": """Starten""",
+  """shopping.startFailed""": """Einkauf konnte nicht gestartet werden.""",
+  """shopping.tripInProgress""": """Du hast bereits einen laufenden Einkauf.""",
+  """shopping.endPreviousTrip""": """Vorherigen Einkauf beenden""",
+  """shopping.endPreviousFailed""":
+      """Vorheriger Einkauf konnte nicht beendet werden.""",
+  """shopping.makePrivate""": """Einkauf vor Mitbewohnern verbergen""",
+  """shopping.makePublic""": """Einkauf Mitbewohnern zeigen""",
+  """shopping.privateBadge""": """Privat""",
+  """shopping.nextStore""": """Nächstes Geschäft""",
+  """shopping.finish""": """Fertig""",
+  """shopping.finishTrip""": """Einkauf abschließen""",
+  """shopping.allCheckedHere""": """Hier alles abgehakt""",
+  """shopping.moveOnToNext""": """Weiter zum nächsten Geschäft.""",
+  """shopping.allDone""": """Alles erledigt""",
+  """shopping.everythingInCart""": """Alles ist im Wagen.""",
+  """shopping.nothingToBuyHere""": """Hier gibt es nichts zu kaufen.""",
+  """shopping.checkFailed""": """Artikel konnte nicht aktualisiert werden.""",
+  """shopping.loadItemsFailed""": """Artikel konnten nicht geladen werden.""",
+  """shopping.reviewTitle""": """Überblick""",
+  """shopping.advanceTitle""": """Nächstes Geschäft""",
+  """shopping.actualPaid""": """Tatsächlich bezahlt""",
+  """shopping.grandTotal""": """Gesamtsumme""",
+  """shopping.anyStore""": """Beliebiges Geschäft""",
+  """shopping.saveTotalFailed""": """Summe konnte nicht gespeichert werden.""",
+  """shopping.remindersTitle""": """Erinnerungen""",
+  """shopping.manageReminders""": """Erinnerungen verwalten""",
+  """shopping.reminderGroupStart""": """Zu Beginn""",
+  """shopping.reminderGroupAdvance""": """Zwischen Geschäften""",
+  """shopping.reminderGroupEnd""": """Am Ende""",
+  """shopping.noRemindersHere""": """Noch keine Erinnerungen hier.""",
+  """shopping.addReminderHint""": """Erinnerung hinzufügen""",
+  """shopping.reminderWhen""": """Wann anzeigen""",
+  """shopping.whenOnStart""": """Zu Beginn""",
+  """shopping.whenOnStoreAdvance""": """Zwischen Geschäften""",
+  """shopping.whenOnClose""": """Am Ende""",
+  """shopping.add""": """Hinzufügen""",
+  """shopping.reminderSaveFailed""":
+      """Erinnerung konnte nicht gespeichert werden.""",
+  """shopping.reminderDeleteFailed""":
+      """Erinnerung konnte nicht gelöscht werden.""",
+  """shopping.historyTitle""": """Einkaufsverlauf""",
+  """shopping.scopeMine""": """Meine""",
+  """shopping.scopeHouse""": """Haushalt""",
+  """shopping.noStorePath""": """Kein Geschäft""",
+  """shopping.loadMore""": """Mehr laden""",
+  """shopping.noTripsYet""": """Noch keine Einkäufe.""",
+  """shopping.noHouseTripsYet""": """Noch keine Einkäufe in diesem Haushalt.""",
+  """shopping.loadHistoryFailed""": """Verlauf konnte nicht geladen werden.""",
+  """shopping.loadFailed""":
+      """Etwas ist schiefgelaufen. Bitte versuche es erneut.""",
+  """shopping.uncategorized""": """Ohne Kategorie""",
   """share.title""": """An Pantry senden""",
   """share.chooseHouse""": """Haus auswählen""",
   """share.choosePhotoDestination""": """Hochladen nach""",

--- a/lib/i18n/messages_de.i18n.dart
+++ b/lib/i18n/messages_de.i18n.dart
@@ -765,6 +765,27 @@ Passwort: pantry-rocks""";
   String get priceMockName => """Olivenöl""";
 
   /// ```dart
+  /// "Geschäft für Geschäft einkaufen"
+  /// ```
+  String get shoppingIntroTitle => """Geschäft für Geschäft einkaufen""";
+
+  /// ```dart
+  /// "Starte einen Einkauf über deine Listen, gehe die Geschäfte der Reihe nach ab und hake Artikel unterwegs ab — mit laufender Preissumme."
+  /// ```
+  String get shoppingIntroBody =>
+      """Starte einen Einkauf über deine Listen, gehe die Geschäfte der Reihe nach ab und hake Artikel unterwegs ab — mit laufender Preissumme.""";
+
+  /// ```dart
+  /// "Supermarkt"
+  /// ```
+  String get shoppingMockStoreActive => """Supermarkt""";
+
+  /// ```dart
+  /// "Apotheke"
+  /// ```
+  String get shoppingMockStoreNext => """Apotheke""";
+
+  /// ```dart
   /// "* Erfordert Pantry für Nextcloud v${version}+"
   /// ```
   String serverRequirementNote(String version) =>
@@ -4407,6 +4428,11 @@ Passwort: pantry-rocks""",
   """onboarding.priceBody""":
       """Geben Sie einem Artikel einen Preis – einen einzelnen Betrag oder eine Spanne – in der Währung Ihrer Wahl. Er erscheint als Chip am Artikel, und Sie können Ihre Liste nach Preis filtern, um im Budget zu bleiben.""",
   """onboarding.priceMockName""": """Olivenöl""",
+  """onboarding.shoppingIntroTitle""": """Geschäft für Geschäft einkaufen""",
+  """onboarding.shoppingIntroBody""":
+      """Starte einen Einkauf über deine Listen, gehe die Geschäfte der Reihe nach ab und hake Artikel unterwegs ab — mit laufender Preissumme.""",
+  """onboarding.shoppingMockStoreActive""": """Supermarkt""",
+  """onboarding.shoppingMockStoreNext""": """Apotheke""",
   """onboarding.dev.showOnboarding""": """Onboarding anzeigen""",
   """onboarding.dev.pickLastSeenTitle""": """Neuigkeiten ansehen""",
   """onboarding.dev.pickLastSeenBody""":

--- a/lib/i18n/messages_de.i18n.yaml
+++ b/lib/i18n/messages_de.i18n.yaml
@@ -130,6 +130,10 @@ onboarding:
   priceTitle: "Preise zu Artikeln hinzufügen"
   priceBody: "Geben Sie einem Artikel einen Preis – einen einzelnen Betrag oder eine Spanne – in der Währung Ihrer Wahl. Er erscheint als Chip am Artikel, und Sie können Ihre Liste nach Preis filtern, um im Budget zu bleiben."
   priceMockName: "Olivenöl"
+  shoppingIntroTitle: "Geschäft für Geschäft einkaufen"
+  shoppingIntroBody: "Starte einen Einkauf über deine Listen, gehe die Geschäfte der Reihe nach ab und hake Artikel unterwegs ab — mit laufender Preissumme."
+  shoppingMockStoreActive: "Supermarkt"
+  shoppingMockStoreNext: "Apotheke"
   serverRequirementNote(String version): "* Erfordert Pantry für Nextcloud v${version}+"
   dev:
     showOnboarding: "Onboarding anzeigen"

--- a/lib/i18n/messages_de.i18n.yaml
+++ b/lib/i18n/messages_de.i18n.yaml
@@ -676,6 +676,78 @@ photoBoard:
     captionZA: "Beschriftung Z–A"
     custom: Benutzerdefiniert
 
+shopping:
+  startShopping: Einkaufen starten
+  resumeShopping: Einkauf fortsetzen
+  shoppingHistory: Einkaufsverlauf
+  resume: Fortsetzen
+  bannerShoppingAt(String store): "Einkaufen bei ${store}"
+  bannerStoreProgress(int index, int total): "Geschäft $index/$total"
+  bannerShoppingNow: Einkauf läuft
+  startTitle: Einkaufen starten
+  listsToShop: Zu kaufende Listen
+  selectAll: Alle auswählen
+  selectNone: Keine auswählen
+  noListsToShop: Noch keine Listen zum Einkaufen.
+  storesTitle: Geschäfte
+  storesHint: "Schalte die Geschäfte ein oder aus, die du besuchst, und ziehe sie in die richtige Reihenfolge."
+  noStoresWithItems: Keine der ausgewählten Listen hat Artikel, die einem Geschäft zugewiesen sind.
+  includeUnassigned: Artikel ohne Geschäft einbeziehen
+  start: Starten
+  startFailed: Einkauf konnte nicht gestartet werden.
+  tripInProgress: Du hast bereits einen laufenden Einkauf.
+  tripInProgressElsewhere(String house): "Du hast einen laufenden Einkauf in ${house}."
+  endPreviousTrip: Vorherigen Einkauf beenden
+  endPreviousFailed: Vorheriger Einkauf konnte nicht beendet werden.
+  inCart(int count): "$count im Wagen"
+  makePrivate: Einkauf vor Mitbewohnern verbergen
+  makePublic: Einkauf Mitbewohnern zeigen
+  privateBadge: Privat
+  nextStore: Nächstes Geschäft
+  finish: Fertig
+  finishTrip: Einkauf abschließen
+  allCheckedHere: Hier alles abgehakt
+  moveOnToNext: Weiter zum nächsten Geschäft.
+  allDone: Alles erledigt
+  everythingInCart: Alles ist im Wagen.
+  doneToday(int count): "Erledigt ($count)"
+  nothingToBuyHere: Hier gibt es nichts zu kaufen.
+  checkFailed: Artikel konnte nicht aktualisiert werden.
+  loadItemsFailed: Artikel konnten nicht geladen werden.
+  reviewTitle: Überblick
+  advanceTitle: Nächstes Geschäft
+  actualPaid: Tatsächlich bezahlt
+  grandTotal: Gesamtsumme
+  itemsWithoutPrice(int count): "${_plural(count, one: '1 Artikel ohne Preis', many: '$count Artikel ohne Preis')}"
+  itemsStillUnchecked(int count): "${_plural(count, one: '1 Artikel noch nicht abgehakt', many: '$count Artikel noch nicht abgehakt')}"
+  anyStore: Beliebiges Geschäft
+  saveTotalFailed: Summe konnte nicht gespeichert werden.
+  remindersTitle: Erinnerungen
+  manageReminders: Erinnerungen verwalten
+  reminderGroupStart: Zu Beginn
+  reminderGroupAdvance: Zwischen Geschäften
+  reminderGroupEnd: Am Ende
+  noRemindersHere: Noch keine Erinnerungen hier.
+  addReminderHint: Erinnerung hinzufügen
+  reminderWhen: Wann anzeigen
+  whenOnStart: Zu Beginn
+  whenOnStoreAdvance: Zwischen Geschäften
+  whenOnClose: Am Ende
+  add: Hinzufügen
+  reminderSaveFailed: Erinnerung konnte nicht gespeichert werden.
+  reminderDeleteFailed: Erinnerung konnte nicht gelöscht werden.
+  historyTitle: Einkaufsverlauf
+  scopeMine: Meine
+  scopeHouse: Haushalt
+  noStorePath: Kein Geschäft
+  itemsCount(int count): "${_plural(count, one: '1 Artikel', many: '$count Artikel')}"
+  loadMore: Mehr laden
+  noTripsYet: Noch keine Einkäufe.
+  noHouseTripsYet: Noch keine Einkäufe in diesem Haushalt.
+  loadHistoryFailed: Verlauf konnte nicht geladen werden.
+  loadFailed: Etwas ist schiefgelaufen. Bitte versuche es erneut.
+  uncategorized: Ohne Kategorie
+
 share:
   title: An Pantry senden
   chooseHouse: Haus auswählen

--- a/lib/i18n/messages_es.i18n.dart
+++ b/lib/i18n/messages_es.i18n.dart
@@ -766,6 +766,27 @@ Contraseña: pantry-rocks""";
   String get priceMockName => """Aceite de oliva""";
 
   /// ```dart
+  /// "Compra tienda por tienda"
+  /// ```
+  String get shoppingIntroTitle => """Compra tienda por tienda""";
+
+  /// ```dart
+  /// "Inicia una compra con tus listas, recorre cada tienda en orden y marca los artículos sobre la marcha, con un total de precio en tiempo real."
+  /// ```
+  String get shoppingIntroBody =>
+      """Inicia una compra con tus listas, recorre cada tienda en orden y marca los artículos sobre la marcha, con un total de precio en tiempo real.""";
+
+  /// ```dart
+  /// "Supermercado"
+  /// ```
+  String get shoppingMockStoreActive => """Supermercado""";
+
+  /// ```dart
+  /// "Farmacia"
+  /// ```
+  String get shoppingMockStoreNext => """Farmacia""";
+
+  /// ```dart
   /// "* Requiere Pantry para Nextcloud v${version}+"
   /// ```
   String serverRequirementNote(String version) =>
@@ -4398,6 +4419,11 @@ Contraseña: pantry-rocks""",
   """onboarding.priceBody""":
       """Dale a cualquier artículo un precio, un importe único o un rango, en la moneda que prefieras. Aparece como una etiqueta en el artículo y puedes filtrar la lista por precio para ajustarte al presupuesto.""",
   """onboarding.priceMockName""": """Aceite de oliva""",
+  """onboarding.shoppingIntroTitle""": """Compra tienda por tienda""",
+  """onboarding.shoppingIntroBody""":
+      """Inicia una compra con tus listas, recorre cada tienda en orden y marca los artículos sobre la marcha, con un total de precio en tiempo real.""",
+  """onboarding.shoppingMockStoreActive""": """Supermercado""",
+  """onboarding.shoppingMockStoreNext""": """Farmacia""",
   """onboarding.dev.showOnboarding""": """Mostrar introducción""",
   """onboarding.dev.pickLastSeenTitle""": """Ver novedades""",
   """onboarding.dev.pickLastSeenBody""":

--- a/lib/i18n/messages_es.i18n.dart
+++ b/lib/i18n/messages_es.i18n.dart
@@ -78,6 +78,7 @@ class MessagesEs extends Messages {
   ChecklistsMessagesEs get checklists => ChecklistsMessagesEs(this);
   NotesWallMessagesEs get notesWall => NotesWallMessagesEs(this);
   PhotoBoardMessagesEs get photoBoard => PhotoBoardMessagesEs(this);
+  ShoppingMessagesEs get shopping => ShoppingMessagesEs(this);
   ShareMessagesEs get share => ShareMessagesEs(this);
   RecurrenceMessagesEs get recurrence => RecurrenceMessagesEs(this);
   SyncMessagesEs get sync => SyncMessagesEs(this);
@@ -3556,6 +3557,368 @@ class SortPhotoBoardMessagesEs extends SortPhotoBoardMessages {
   String get custom => """Personalizado""";
 }
 
+class ShoppingMessagesEs extends ShoppingMessages {
+  final MessagesEs _parent;
+  const ShoppingMessagesEs(this._parent) : super(_parent);
+
+  /// ```dart
+  /// "Empezar a comprar"
+  /// ```
+  String get startShopping => """Empezar a comprar""";
+
+  /// ```dart
+  /// "Reanudar compra"
+  /// ```
+  String get resumeShopping => """Reanudar compra""";
+
+  /// ```dart
+  /// "Historial de compras"
+  /// ```
+  String get shoppingHistory => """Historial de compras""";
+
+  /// ```dart
+  /// "Reanudar"
+  /// ```
+  String get resume => """Reanudar""";
+
+  /// ```dart
+  /// "Comprando en ${store}"
+  /// ```
+  String bannerShoppingAt(String store) => """Comprando en ${store}""";
+
+  /// ```dart
+  /// "Tienda $index/$total"
+  /// ```
+  String bannerStoreProgress(int index, int total) =>
+      """Tienda $index/$total""";
+
+  /// ```dart
+  /// "Comprando ahora"
+  /// ```
+  String get bannerShoppingNow => """Comprando ahora""";
+
+  /// ```dart
+  /// "Empezar a comprar"
+  /// ```
+  String get startTitle => """Empezar a comprar""";
+
+  /// ```dart
+  /// "Listas para comprar"
+  /// ```
+  String get listsToShop => """Listas para comprar""";
+
+  /// ```dart
+  /// "Seleccionar todo"
+  /// ```
+  String get selectAll => """Seleccionar todo""";
+
+  /// ```dart
+  /// "No seleccionar nada"
+  /// ```
+  String get selectNone => """No seleccionar nada""";
+
+  /// ```dart
+  /// "Aún no hay listas para comprar."
+  /// ```
+  String get noListsToShop => """Aún no hay listas para comprar.""";
+
+  /// ```dart
+  /// "Tiendas"
+  /// ```
+  String get storesTitle => """Tiendas""";
+
+  /// ```dart
+  /// "Activa o desactiva las tiendas que visitarás y arrástralas para ordenarlas."
+  /// ```
+  String get storesHint =>
+      """Activa o desactiva las tiendas que visitarás y arrástralas para ordenarlas.""";
+
+  /// ```dart
+  /// "Ninguna de las listas seleccionadas tiene artículos asignados a una tienda."
+  /// ```
+  String get noStoresWithItems =>
+      """Ninguna de las listas seleccionadas tiene artículos asignados a una tienda.""";
+
+  /// ```dart
+  /// "Incluir artículos sin tienda asignada"
+  /// ```
+  String get includeUnassigned => """Incluir artículos sin tienda asignada""";
+
+  /// ```dart
+  /// "Empezar"
+  /// ```
+  String get start => """Empezar""";
+
+  /// ```dart
+  /// "No se pudo empezar a comprar."
+  /// ```
+  String get startFailed => """No se pudo empezar a comprar.""";
+
+  /// ```dart
+  /// "Ya tienes una compra en curso."
+  /// ```
+  String get tripInProgress => """Ya tienes una compra en curso.""";
+
+  /// ```dart
+  /// "Tienes una compra en curso en ${house}."
+  /// ```
+  String tripInProgressElsewhere(String house) =>
+      """Tienes una compra en curso en ${house}.""";
+
+  /// ```dart
+  /// "Terminar compra anterior"
+  /// ```
+  String get endPreviousTrip => """Terminar compra anterior""";
+
+  /// ```dart
+  /// "No se pudo terminar la compra anterior."
+  /// ```
+  String get endPreviousFailed => """No se pudo terminar la compra anterior.""";
+
+  /// ```dart
+  /// "$count en el carrito"
+  /// ```
+  String inCart(int count) => """$count en el carrito""";
+
+  /// ```dart
+  /// "Ocultar compra a los convivientes"
+  /// ```
+  String get makePrivate => """Ocultar compra a los convivientes""";
+
+  /// ```dart
+  /// "Mostrar compra a los convivientes"
+  /// ```
+  String get makePublic => """Mostrar compra a los convivientes""";
+
+  /// ```dart
+  /// "Privada"
+  /// ```
+  String get privateBadge => """Privada""";
+
+  /// ```dart
+  /// "Siguiente tienda"
+  /// ```
+  String get nextStore => """Siguiente tienda""";
+
+  /// ```dart
+  /// "Terminar"
+  /// ```
+  String get finish => """Terminar""";
+
+  /// ```dart
+  /// "Terminar compra"
+  /// ```
+  String get finishTrip => """Terminar compra""";
+
+  /// ```dart
+  /// "Todo marcado aquí"
+  /// ```
+  String get allCheckedHere => """Todo marcado aquí""";
+
+  /// ```dart
+  /// "Pasa a la siguiente tienda."
+  /// ```
+  String get moveOnToNext => """Pasa a la siguiente tienda.""";
+
+  /// ```dart
+  /// "Todo listo"
+  /// ```
+  String get allDone => """Todo listo""";
+
+  /// ```dart
+  /// "Todo está en el carrito."
+  /// ```
+  String get everythingInCart => """Todo está en el carrito.""";
+
+  /// ```dart
+  /// "Hecho ($count)"
+  /// ```
+  String doneToday(int count) => """Hecho ($count)""";
+
+  /// ```dart
+  /// "Nada que comprar aquí."
+  /// ```
+  String get nothingToBuyHere => """Nada que comprar aquí.""";
+
+  /// ```dart
+  /// "No se pudo actualizar el artículo."
+  /// ```
+  String get checkFailed => """No se pudo actualizar el artículo.""";
+
+  /// ```dart
+  /// "No se pudieron cargar los artículos."
+  /// ```
+  String get loadItemsFailed => """No se pudieron cargar los artículos.""";
+
+  /// ```dart
+  /// "Resumen"
+  /// ```
+  String get reviewTitle => """Resumen""";
+
+  /// ```dart
+  /// "Siguiente tienda"
+  /// ```
+  String get advanceTitle => """Siguiente tienda""";
+
+  /// ```dart
+  /// "Pagado real"
+  /// ```
+  String get actualPaid => """Pagado real""";
+
+  /// ```dart
+  /// "Total"
+  /// ```
+  String get grandTotal => """Total""";
+
+  /// ```dart
+  /// "${_plural(count, one: '1 artículo sin precio', many: '$count artículos sin precio')}"
+  /// ```
+  String itemsWithoutPrice(int count) =>
+      """${_plural(count, one: '1 artículo sin precio', many: '$count artículos sin precio')}""";
+
+  /// ```dart
+  /// "${_plural(count, one: '1 artículo sin marcar', many: '$count artículos sin marcar')}"
+  /// ```
+  String itemsStillUnchecked(int count) =>
+      """${_plural(count, one: '1 artículo sin marcar', many: '$count artículos sin marcar')}""";
+
+  /// ```dart
+  /// "Cualquier tienda"
+  /// ```
+  String get anyStore => """Cualquier tienda""";
+
+  /// ```dart
+  /// "No se pudo guardar el total."
+  /// ```
+  String get saveTotalFailed => """No se pudo guardar el total.""";
+
+  /// ```dart
+  /// "Recordatorios"
+  /// ```
+  String get remindersTitle => """Recordatorios""";
+
+  /// ```dart
+  /// "Gestionar recordatorios"
+  /// ```
+  String get manageReminders => """Gestionar recordatorios""";
+
+  /// ```dart
+  /// "Al empezar"
+  /// ```
+  String get reminderGroupStart => """Al empezar""";
+
+  /// ```dart
+  /// "Entre tiendas"
+  /// ```
+  String get reminderGroupAdvance => """Entre tiendas""";
+
+  /// ```dart
+  /// "Al terminar"
+  /// ```
+  String get reminderGroupEnd => """Al terminar""";
+
+  /// ```dart
+  /// "Aún no hay recordatorios aquí."
+  /// ```
+  String get noRemindersHere => """Aún no hay recordatorios aquí.""";
+
+  /// ```dart
+  /// "Añadir un recordatorio"
+  /// ```
+  String get addReminderHint => """Añadir un recordatorio""";
+
+  /// ```dart
+  /// "Cuándo mostrar"
+  /// ```
+  String get reminderWhen => """Cuándo mostrar""";
+
+  /// ```dart
+  /// "Al empezar"
+  /// ```
+  String get whenOnStart => """Al empezar""";
+
+  /// ```dart
+  /// "Entre tiendas"
+  /// ```
+  String get whenOnStoreAdvance => """Entre tiendas""";
+
+  /// ```dart
+  /// "Al terminar"
+  /// ```
+  String get whenOnClose => """Al terminar""";
+
+  /// ```dart
+  /// "Añadir"
+  /// ```
+  String get add => """Añadir""";
+
+  /// ```dart
+  /// "No se pudo guardar el recordatorio."
+  /// ```
+  String get reminderSaveFailed => """No se pudo guardar el recordatorio.""";
+
+  /// ```dart
+  /// "No se pudo eliminar el recordatorio."
+  /// ```
+  String get reminderDeleteFailed => """No se pudo eliminar el recordatorio.""";
+
+  /// ```dart
+  /// "Historial de compras"
+  /// ```
+  String get historyTitle => """Historial de compras""";
+
+  /// ```dart
+  /// "Mías"
+  /// ```
+  String get scopeMine => """Mías""";
+
+  /// ```dart
+  /// "Casa"
+  /// ```
+  String get scopeHouse => """Casa""";
+
+  /// ```dart
+  /// "Sin tienda"
+  /// ```
+  String get noStorePath => """Sin tienda""";
+
+  /// ```dart
+  /// "${_plural(count, one: '1 artículo', many: '$count artículos')}"
+  /// ```
+  String itemsCount(int count) =>
+      """${_plural(count, one: '1 artículo', many: '$count artículos')}""";
+
+  /// ```dart
+  /// "Cargar más"
+  /// ```
+  String get loadMore => """Cargar más""";
+
+  /// ```dart
+  /// "Aún no hay compras."
+  /// ```
+  String get noTripsYet => """Aún no hay compras.""";
+
+  /// ```dart
+  /// "Aún no hay compras en esta casa."
+  /// ```
+  String get noHouseTripsYet => """Aún no hay compras en esta casa.""";
+
+  /// ```dart
+  /// "No se pudo cargar el historial."
+  /// ```
+  String get loadHistoryFailed => """No se pudo cargar el historial.""";
+
+  /// ```dart
+  /// "Algo salió mal. Inténtalo de nuevo."
+  /// ```
+  String get loadFailed => """Algo salió mal. Inténtalo de nuevo.""";
+
+  /// ```dart
+  /// "Sin categoría"
+  /// ```
+  String get uncategorized => """Sin categoría""";
+}
+
 class ShareMessagesEs extends ShareMessages {
   final MessagesEs _parent;
   const ShareMessagesEs(this._parent) : super(_parent);
@@ -4550,6 +4913,72 @@ Contraseña: pantry-rocks""",
   """photoBoard.sort.captionAZ""": """Descripción A–Z""",
   """photoBoard.sort.captionZA""": """Descripción Z–A""",
   """photoBoard.sort.custom""": """Personalizado""",
+  """shopping.startShopping""": """Empezar a comprar""",
+  """shopping.resumeShopping""": """Reanudar compra""",
+  """shopping.shoppingHistory""": """Historial de compras""",
+  """shopping.resume""": """Reanudar""",
+  """shopping.bannerShoppingNow""": """Comprando ahora""",
+  """shopping.startTitle""": """Empezar a comprar""",
+  """shopping.listsToShop""": """Listas para comprar""",
+  """shopping.selectAll""": """Seleccionar todo""",
+  """shopping.selectNone""": """No seleccionar nada""",
+  """shopping.noListsToShop""": """Aún no hay listas para comprar.""",
+  """shopping.storesTitle""": """Tiendas""",
+  """shopping.storesHint""":
+      """Activa o desactiva las tiendas que visitarás y arrástralas para ordenarlas.""",
+  """shopping.noStoresWithItems""":
+      """Ninguna de las listas seleccionadas tiene artículos asignados a una tienda.""",
+  """shopping.includeUnassigned""": """Incluir artículos sin tienda asignada""",
+  """shopping.start""": """Empezar""",
+  """shopping.startFailed""": """No se pudo empezar a comprar.""",
+  """shopping.tripInProgress""": """Ya tienes una compra en curso.""",
+  """shopping.endPreviousTrip""": """Terminar compra anterior""",
+  """shopping.endPreviousFailed""":
+      """No se pudo terminar la compra anterior.""",
+  """shopping.makePrivate""": """Ocultar compra a los convivientes""",
+  """shopping.makePublic""": """Mostrar compra a los convivientes""",
+  """shopping.privateBadge""": """Privada""",
+  """shopping.nextStore""": """Siguiente tienda""",
+  """shopping.finish""": """Terminar""",
+  """shopping.finishTrip""": """Terminar compra""",
+  """shopping.allCheckedHere""": """Todo marcado aquí""",
+  """shopping.moveOnToNext""": """Pasa a la siguiente tienda.""",
+  """shopping.allDone""": """Todo listo""",
+  """shopping.everythingInCart""": """Todo está en el carrito.""",
+  """shopping.nothingToBuyHere""": """Nada que comprar aquí.""",
+  """shopping.checkFailed""": """No se pudo actualizar el artículo.""",
+  """shopping.loadItemsFailed""": """No se pudieron cargar los artículos.""",
+  """shopping.reviewTitle""": """Resumen""",
+  """shopping.advanceTitle""": """Siguiente tienda""",
+  """shopping.actualPaid""": """Pagado real""",
+  """shopping.grandTotal""": """Total""",
+  """shopping.anyStore""": """Cualquier tienda""",
+  """shopping.saveTotalFailed""": """No se pudo guardar el total.""",
+  """shopping.remindersTitle""": """Recordatorios""",
+  """shopping.manageReminders""": """Gestionar recordatorios""",
+  """shopping.reminderGroupStart""": """Al empezar""",
+  """shopping.reminderGroupAdvance""": """Entre tiendas""",
+  """shopping.reminderGroupEnd""": """Al terminar""",
+  """shopping.noRemindersHere""": """Aún no hay recordatorios aquí.""",
+  """shopping.addReminderHint""": """Añadir un recordatorio""",
+  """shopping.reminderWhen""": """Cuándo mostrar""",
+  """shopping.whenOnStart""": """Al empezar""",
+  """shopping.whenOnStoreAdvance""": """Entre tiendas""",
+  """shopping.whenOnClose""": """Al terminar""",
+  """shopping.add""": """Añadir""",
+  """shopping.reminderSaveFailed""": """No se pudo guardar el recordatorio.""",
+  """shopping.reminderDeleteFailed""":
+      """No se pudo eliminar el recordatorio.""",
+  """shopping.historyTitle""": """Historial de compras""",
+  """shopping.scopeMine""": """Mías""",
+  """shopping.scopeHouse""": """Casa""",
+  """shopping.noStorePath""": """Sin tienda""",
+  """shopping.loadMore""": """Cargar más""",
+  """shopping.noTripsYet""": """Aún no hay compras.""",
+  """shopping.noHouseTripsYet""": """Aún no hay compras en esta casa.""",
+  """shopping.loadHistoryFailed""": """No se pudo cargar el historial.""",
+  """shopping.loadFailed""": """Algo salió mal. Inténtalo de nuevo.""",
+  """shopping.uncategorized""": """Sin categoría""",
   """share.title""": """Compartir con Pantry""",
   """share.chooseHouse""": """Elegir casa""",
   """share.choosePhotoDestination""": """Subir a""",

--- a/lib/i18n/messages_es.i18n.yaml
+++ b/lib/i18n/messages_es.i18n.yaml
@@ -676,6 +676,78 @@ photoBoard:
     captionZA: "Descripción Z–A"
     custom: Personalizado
 
+shopping:
+  startShopping: Empezar a comprar
+  resumeShopping: Reanudar compra
+  shoppingHistory: Historial de compras
+  resume: Reanudar
+  bannerShoppingAt(String store): "Comprando en ${store}"
+  bannerStoreProgress(int index, int total): "Tienda $index/$total"
+  bannerShoppingNow: Comprando ahora
+  startTitle: Empezar a comprar
+  listsToShop: Listas para comprar
+  selectAll: Seleccionar todo
+  selectNone: No seleccionar nada
+  noListsToShop: Aún no hay listas para comprar.
+  storesTitle: Tiendas
+  storesHint: "Activa o desactiva las tiendas que visitarás y arrástralas para ordenarlas."
+  noStoresWithItems: Ninguna de las listas seleccionadas tiene artículos asignados a una tienda.
+  includeUnassigned: Incluir artículos sin tienda asignada
+  start: Empezar
+  startFailed: No se pudo empezar a comprar.
+  tripInProgress: Ya tienes una compra en curso.
+  tripInProgressElsewhere(String house): "Tienes una compra en curso en ${house}."
+  endPreviousTrip: Terminar compra anterior
+  endPreviousFailed: No se pudo terminar la compra anterior.
+  inCart(int count): "$count en el carrito"
+  makePrivate: Ocultar compra a los convivientes
+  makePublic: Mostrar compra a los convivientes
+  privateBadge: Privada
+  nextStore: Siguiente tienda
+  finish: Terminar
+  finishTrip: Terminar compra
+  allCheckedHere: Todo marcado aquí
+  moveOnToNext: Pasa a la siguiente tienda.
+  allDone: Todo listo
+  everythingInCart: Todo está en el carrito.
+  doneToday(int count): "Hecho ($count)"
+  nothingToBuyHere: Nada que comprar aquí.
+  checkFailed: No se pudo actualizar el artículo.
+  loadItemsFailed: No se pudieron cargar los artículos.
+  reviewTitle: Resumen
+  advanceTitle: Siguiente tienda
+  actualPaid: Pagado real
+  grandTotal: Total
+  itemsWithoutPrice(int count): "${_plural(count, one: '1 artículo sin precio', many: '$count artículos sin precio')}"
+  itemsStillUnchecked(int count): "${_plural(count, one: '1 artículo sin marcar', many: '$count artículos sin marcar')}"
+  anyStore: Cualquier tienda
+  saveTotalFailed: No se pudo guardar el total.
+  remindersTitle: Recordatorios
+  manageReminders: Gestionar recordatorios
+  reminderGroupStart: Al empezar
+  reminderGroupAdvance: Entre tiendas
+  reminderGroupEnd: Al terminar
+  noRemindersHere: Aún no hay recordatorios aquí.
+  addReminderHint: Añadir un recordatorio
+  reminderWhen: Cuándo mostrar
+  whenOnStart: Al empezar
+  whenOnStoreAdvance: Entre tiendas
+  whenOnClose: Al terminar
+  add: Añadir
+  reminderSaveFailed: No se pudo guardar el recordatorio.
+  reminderDeleteFailed: No se pudo eliminar el recordatorio.
+  historyTitle: Historial de compras
+  scopeMine: Mías
+  scopeHouse: Casa
+  noStorePath: Sin tienda
+  itemsCount(int count): "${_plural(count, one: '1 artículo', many: '$count artículos')}"
+  loadMore: Cargar más
+  noTripsYet: Aún no hay compras.
+  noHouseTripsYet: Aún no hay compras en esta casa.
+  loadHistoryFailed: No se pudo cargar el historial.
+  loadFailed: Algo salió mal. Inténtalo de nuevo.
+  uncategorized: Sin categoría
+
 share:
   title: Compartir con Pantry
   chooseHouse: Elegir casa

--- a/lib/i18n/messages_es.i18n.yaml
+++ b/lib/i18n/messages_es.i18n.yaml
@@ -130,6 +130,10 @@ onboarding:
   priceTitle: "Añade precios a tus artículos"
   priceBody: "Dale a cualquier artículo un precio, un importe único o un rango, en la moneda que prefieras. Aparece como una etiqueta en el artículo y puedes filtrar la lista por precio para ajustarte al presupuesto."
   priceMockName: "Aceite de oliva"
+  shoppingIntroTitle: "Compra tienda por tienda"
+  shoppingIntroBody: "Inicia una compra con tus listas, recorre cada tienda en orden y marca los artículos sobre la marcha, con un total de precio en tiempo real."
+  shoppingMockStoreActive: "Supermercado"
+  shoppingMockStoreNext: "Farmacia"
   serverRequirementNote(String version): "* Requiere Pantry para Nextcloud v${version}+"
   dev:
     showOnboarding: "Mostrar introducción"

--- a/lib/i18n/messages_fr.i18n.dart
+++ b/lib/i18n/messages_fr.i18n.dart
@@ -78,6 +78,7 @@ class MessagesFr extends Messages {
   ChecklistsMessagesFr get checklists => ChecklistsMessagesFr(this);
   NotesWallMessagesFr get notesWall => NotesWallMessagesFr(this);
   PhotoBoardMessagesFr get photoBoard => PhotoBoardMessagesFr(this);
+  ShoppingMessagesFr get shopping => ShoppingMessagesFr(this);
   ShareMessagesFr get share => ShareMessagesFr(this);
   RecurrenceMessagesFr get recurrence => RecurrenceMessagesFr(this);
   SyncMessagesFr get sync => SyncMessagesFr(this);
@@ -3560,6 +3561,370 @@ class SortPhotoBoardMessagesFr extends SortPhotoBoardMessages {
   String get custom => """Personnalisé""";
 }
 
+class ShoppingMessagesFr extends ShoppingMessages {
+  final MessagesFr _parent;
+  const ShoppingMessagesFr(this._parent) : super(_parent);
+
+  /// ```dart
+  /// "Commencer les courses"
+  /// ```
+  String get startShopping => """Commencer les courses""";
+
+  /// ```dart
+  /// "Reprendre les courses"
+  /// ```
+  String get resumeShopping => """Reprendre les courses""";
+
+  /// ```dart
+  /// "Historique des courses"
+  /// ```
+  String get shoppingHistory => """Historique des courses""";
+
+  /// ```dart
+  /// "Reprendre"
+  /// ```
+  String get resume => """Reprendre""";
+
+  /// ```dart
+  /// "Courses chez ${store}"
+  /// ```
+  String bannerShoppingAt(String store) => """Courses chez ${store}""";
+
+  /// ```dart
+  /// "Magasin $index/$total"
+  /// ```
+  String bannerStoreProgress(int index, int total) =>
+      """Magasin $index/$total""";
+
+  /// ```dart
+  /// "Courses en cours"
+  /// ```
+  String get bannerShoppingNow => """Courses en cours""";
+
+  /// ```dart
+  /// "Commencer les courses"
+  /// ```
+  String get startTitle => """Commencer les courses""";
+
+  /// ```dart
+  /// "Listes à faire"
+  /// ```
+  String get listsToShop => """Listes à faire""";
+
+  /// ```dart
+  /// "Tout sélectionner"
+  /// ```
+  String get selectAll => """Tout sélectionner""";
+
+  /// ```dart
+  /// "Ne rien sélectionner"
+  /// ```
+  String get selectNone => """Ne rien sélectionner""";
+
+  /// ```dart
+  /// "Aucune liste à faire pour l'instant."
+  /// ```
+  String get noListsToShop => """Aucune liste à faire pour l'instant.""";
+
+  /// ```dart
+  /// "Magasins"
+  /// ```
+  String get storesTitle => """Magasins""";
+
+  /// ```dart
+  /// "Activez ou désactivez les magasins que vous visiterez, et glissez pour définir l'ordre."
+  /// ```
+  String get storesHint =>
+      """Activez ou désactivez les magasins que vous visiterez, et glissez pour définir l'ordre.""";
+
+  /// ```dart
+  /// "Aucune des listes sélectionnées n'a d'articles assignés à un magasin."
+  /// ```
+  String get noStoresWithItems =>
+      """Aucune des listes sélectionnées n'a d'articles assignés à un magasin.""";
+
+  /// ```dart
+  /// "Inclure les articles sans magasin"
+  /// ```
+  String get includeUnassigned => """Inclure les articles sans magasin""";
+
+  /// ```dart
+  /// "Commencer"
+  /// ```
+  String get start => """Commencer""";
+
+  /// ```dart
+  /// "Impossible de commencer les courses."
+  /// ```
+  String get startFailed => """Impossible de commencer les courses.""";
+
+  /// ```dart
+  /// "Vous avez déjà des courses en cours."
+  /// ```
+  String get tripInProgress => """Vous avez déjà des courses en cours.""";
+
+  /// ```dart
+  /// "Vous avez des courses en cours dans ${house}."
+  /// ```
+  String tripInProgressElsewhere(String house) =>
+      """Vous avez des courses en cours dans ${house}.""";
+
+  /// ```dart
+  /// "Terminer les courses précédentes"
+  /// ```
+  String get endPreviousTrip => """Terminer les courses précédentes""";
+
+  /// ```dart
+  /// "Impossible de terminer les courses précédentes."
+  /// ```
+  String get endPreviousFailed =>
+      """Impossible de terminer les courses précédentes.""";
+
+  /// ```dart
+  /// "$count dans le panier"
+  /// ```
+  String inCart(int count) => """$count dans le panier""";
+
+  /// ```dart
+  /// "Masquer les courses aux colocataires"
+  /// ```
+  String get makePrivate => """Masquer les courses aux colocataires""";
+
+  /// ```dart
+  /// "Montrer les courses aux colocataires"
+  /// ```
+  String get makePublic => """Montrer les courses aux colocataires""";
+
+  /// ```dart
+  /// "Privé"
+  /// ```
+  String get privateBadge => """Privé""";
+
+  /// ```dart
+  /// "Magasin suivant"
+  /// ```
+  String get nextStore => """Magasin suivant""";
+
+  /// ```dart
+  /// "Terminer"
+  /// ```
+  String get finish => """Terminer""";
+
+  /// ```dart
+  /// "Terminer les courses"
+  /// ```
+  String get finishTrip => """Terminer les courses""";
+
+  /// ```dart
+  /// "Tout est coché ici"
+  /// ```
+  String get allCheckedHere => """Tout est coché ici""";
+
+  /// ```dart
+  /// "Passez au magasin suivant."
+  /// ```
+  String get moveOnToNext => """Passez au magasin suivant.""";
+
+  /// ```dart
+  /// "Tout est fait"
+  /// ```
+  String get allDone => """Tout est fait""";
+
+  /// ```dart
+  /// "Tout est dans le panier."
+  /// ```
+  String get everythingInCart => """Tout est dans le panier.""";
+
+  /// ```dart
+  /// "Fait ($count)"
+  /// ```
+  String doneToday(int count) => """Fait ($count)""";
+
+  /// ```dart
+  /// "Rien à acheter ici."
+  /// ```
+  String get nothingToBuyHere => """Rien à acheter ici.""";
+
+  /// ```dart
+  /// "Impossible de mettre à jour l'article."
+  /// ```
+  String get checkFailed => """Impossible de mettre à jour l'article.""";
+
+  /// ```dart
+  /// "Impossible de charger les articles."
+  /// ```
+  String get loadItemsFailed => """Impossible de charger les articles.""";
+
+  /// ```dart
+  /// "Récapitulatif"
+  /// ```
+  String get reviewTitle => """Récapitulatif""";
+
+  /// ```dart
+  /// "Magasin suivant"
+  /// ```
+  String get advanceTitle => """Magasin suivant""";
+
+  /// ```dart
+  /// "Payé réel"
+  /// ```
+  String get actualPaid => """Payé réel""";
+
+  /// ```dart
+  /// "Total général"
+  /// ```
+  String get grandTotal => """Total général""";
+
+  /// ```dart
+  /// "${_plural(count, one: '1 article sans prix', many: '$count articles sans prix')}"
+  /// ```
+  String itemsWithoutPrice(int count) =>
+      """${_plural(count, one: '1 article sans prix', many: '$count articles sans prix')}""";
+
+  /// ```dart
+  /// "${_plural(count, one: '1 article non coché', many: '$count articles non cochés')}"
+  /// ```
+  String itemsStillUnchecked(int count) =>
+      """${_plural(count, one: '1 article non coché', many: '$count articles non cochés')}""";
+
+  /// ```dart
+  /// "N'importe quel magasin"
+  /// ```
+  String get anyStore => """N'importe quel magasin""";
+
+  /// ```dart
+  /// "Impossible d'enregistrer le total."
+  /// ```
+  String get saveTotalFailed => """Impossible d'enregistrer le total.""";
+
+  /// ```dart
+  /// "Rappels"
+  /// ```
+  String get remindersTitle => """Rappels""";
+
+  /// ```dart
+  /// "Gérer les rappels"
+  /// ```
+  String get manageReminders => """Gérer les rappels""";
+
+  /// ```dart
+  /// "Au début"
+  /// ```
+  String get reminderGroupStart => """Au début""";
+
+  /// ```dart
+  /// "Entre les magasins"
+  /// ```
+  String get reminderGroupAdvance => """Entre les magasins""";
+
+  /// ```dart
+  /// "À la fin"
+  /// ```
+  String get reminderGroupEnd => """À la fin""";
+
+  /// ```dart
+  /// "Aucun rappel ici pour l'instant."
+  /// ```
+  String get noRemindersHere => """Aucun rappel ici pour l'instant.""";
+
+  /// ```dart
+  /// "Ajouter un rappel"
+  /// ```
+  String get addReminderHint => """Ajouter un rappel""";
+
+  /// ```dart
+  /// "Quand l'afficher"
+  /// ```
+  String get reminderWhen => """Quand l'afficher""";
+
+  /// ```dart
+  /// "Au début"
+  /// ```
+  String get whenOnStart => """Au début""";
+
+  /// ```dart
+  /// "Entre les magasins"
+  /// ```
+  String get whenOnStoreAdvance => """Entre les magasins""";
+
+  /// ```dart
+  /// "À la fin"
+  /// ```
+  String get whenOnClose => """À la fin""";
+
+  /// ```dart
+  /// "Ajouter"
+  /// ```
+  String get add => """Ajouter""";
+
+  /// ```dart
+  /// "Impossible d'enregistrer le rappel."
+  /// ```
+  String get reminderSaveFailed => """Impossible d'enregistrer le rappel.""";
+
+  /// ```dart
+  /// "Impossible de supprimer le rappel."
+  /// ```
+  String get reminderDeleteFailed => """Impossible de supprimer le rappel.""";
+
+  /// ```dart
+  /// "Historique des courses"
+  /// ```
+  String get historyTitle => """Historique des courses""";
+
+  /// ```dart
+  /// "Les miennes"
+  /// ```
+  String get scopeMine => """Les miennes""";
+
+  /// ```dart
+  /// "Maison"
+  /// ```
+  String get scopeHouse => """Maison""";
+
+  /// ```dart
+  /// "Aucun magasin"
+  /// ```
+  String get noStorePath => """Aucun magasin""";
+
+  /// ```dart
+  /// "${_plural(count, one: '1 article', many: '$count articles')}"
+  /// ```
+  String itemsCount(int count) =>
+      """${_plural(count, one: '1 article', many: '$count articles')}""";
+
+  /// ```dart
+  /// "Charger plus"
+  /// ```
+  String get loadMore => """Charger plus""";
+
+  /// ```dart
+  /// "Aucune course pour l'instant."
+  /// ```
+  String get noTripsYet => """Aucune course pour l'instant.""";
+
+  /// ```dart
+  /// "Aucune course dans cette maison pour l'instant."
+  /// ```
+  String get noHouseTripsYet =>
+      """Aucune course dans cette maison pour l'instant.""";
+
+  /// ```dart
+  /// "Impossible de charger l'historique."
+  /// ```
+  String get loadHistoryFailed => """Impossible de charger l'historique.""";
+
+  /// ```dart
+  /// "Une erreur s'est produite. Veuillez réessayer."
+  /// ```
+  String get loadFailed => """Une erreur s'est produite. Veuillez réessayer.""";
+
+  /// ```dart
+  /// "Sans catégorie"
+  /// ```
+  String get uncategorized => """Sans catégorie""";
+}
+
 class ShareMessagesFr extends ShareMessages {
   final MessagesFr _parent;
   const ShareMessagesFr(this._parent) : super(_parent);
@@ -4567,6 +4932,73 @@ Mot de passe : pantry-rocks""",
   """photoBoard.sort.captionAZ""": """Légende A–Z""",
   """photoBoard.sort.captionZA""": """Légende Z–A""",
   """photoBoard.sort.custom""": """Personnalisé""",
+  """shopping.startShopping""": """Commencer les courses""",
+  """shopping.resumeShopping""": """Reprendre les courses""",
+  """shopping.shoppingHistory""": """Historique des courses""",
+  """shopping.resume""": """Reprendre""",
+  """shopping.bannerShoppingNow""": """Courses en cours""",
+  """shopping.startTitle""": """Commencer les courses""",
+  """shopping.listsToShop""": """Listes à faire""",
+  """shopping.selectAll""": """Tout sélectionner""",
+  """shopping.selectNone""": """Ne rien sélectionner""",
+  """shopping.noListsToShop""": """Aucune liste à faire pour l'instant.""",
+  """shopping.storesTitle""": """Magasins""",
+  """shopping.storesHint""":
+      """Activez ou désactivez les magasins que vous visiterez, et glissez pour définir l'ordre.""",
+  """shopping.noStoresWithItems""":
+      """Aucune des listes sélectionnées n'a d'articles assignés à un magasin.""",
+  """shopping.includeUnassigned""": """Inclure les articles sans magasin""",
+  """shopping.start""": """Commencer""",
+  """shopping.startFailed""": """Impossible de commencer les courses.""",
+  """shopping.tripInProgress""": """Vous avez déjà des courses en cours.""",
+  """shopping.endPreviousTrip""": """Terminer les courses précédentes""",
+  """shopping.endPreviousFailed""":
+      """Impossible de terminer les courses précédentes.""",
+  """shopping.makePrivate""": """Masquer les courses aux colocataires""",
+  """shopping.makePublic""": """Montrer les courses aux colocataires""",
+  """shopping.privateBadge""": """Privé""",
+  """shopping.nextStore""": """Magasin suivant""",
+  """shopping.finish""": """Terminer""",
+  """shopping.finishTrip""": """Terminer les courses""",
+  """shopping.allCheckedHere""": """Tout est coché ici""",
+  """shopping.moveOnToNext""": """Passez au magasin suivant.""",
+  """shopping.allDone""": """Tout est fait""",
+  """shopping.everythingInCart""": """Tout est dans le panier.""",
+  """shopping.nothingToBuyHere""": """Rien à acheter ici.""",
+  """shopping.checkFailed""": """Impossible de mettre à jour l'article.""",
+  """shopping.loadItemsFailed""": """Impossible de charger les articles.""",
+  """shopping.reviewTitle""": """Récapitulatif""",
+  """shopping.advanceTitle""": """Magasin suivant""",
+  """shopping.actualPaid""": """Payé réel""",
+  """shopping.grandTotal""": """Total général""",
+  """shopping.anyStore""": """N'importe quel magasin""",
+  """shopping.saveTotalFailed""": """Impossible d'enregistrer le total.""",
+  """shopping.remindersTitle""": """Rappels""",
+  """shopping.manageReminders""": """Gérer les rappels""",
+  """shopping.reminderGroupStart""": """Au début""",
+  """shopping.reminderGroupAdvance""": """Entre les magasins""",
+  """shopping.reminderGroupEnd""": """À la fin""",
+  """shopping.noRemindersHere""": """Aucun rappel ici pour l'instant.""",
+  """shopping.addReminderHint""": """Ajouter un rappel""",
+  """shopping.reminderWhen""": """Quand l'afficher""",
+  """shopping.whenOnStart""": """Au début""",
+  """shopping.whenOnStoreAdvance""": """Entre les magasins""",
+  """shopping.whenOnClose""": """À la fin""",
+  """shopping.add""": """Ajouter""",
+  """shopping.reminderSaveFailed""": """Impossible d'enregistrer le rappel.""",
+  """shopping.reminderDeleteFailed""": """Impossible de supprimer le rappel.""",
+  """shopping.historyTitle""": """Historique des courses""",
+  """shopping.scopeMine""": """Les miennes""",
+  """shopping.scopeHouse""": """Maison""",
+  """shopping.noStorePath""": """Aucun magasin""",
+  """shopping.loadMore""": """Charger plus""",
+  """shopping.noTripsYet""": """Aucune course pour l'instant.""",
+  """shopping.noHouseTripsYet""":
+      """Aucune course dans cette maison pour l'instant.""",
+  """shopping.loadHistoryFailed""": """Impossible de charger l'historique.""",
+  """shopping.loadFailed""":
+      """Une erreur s'est produite. Veuillez réessayer.""",
+  """shopping.uncategorized""": """Sans catégorie""",
   """share.title""": """Partager vers Pantry""",
   """share.chooseHouse""": """Choisir une maison""",
   """share.choosePhotoDestination""": """Téléverser vers""",

--- a/lib/i18n/messages_fr.i18n.dart
+++ b/lib/i18n/messages_fr.i18n.dart
@@ -768,6 +768,27 @@ Mot de passe : pantry-rocks""";
   String get priceMockName => """Huile d'olive""";
 
   /// ```dart
+  /// "Fais tes courses magasin par magasin"
+  /// ```
+  String get shoppingIntroTitle => """Fais tes courses magasin par magasin""";
+
+  /// ```dart
+  /// "Lance une virée à partir de tes listes, parcours chaque magasin dans l'ordre et coche les articles au fur et à mesure — avec un total des prix en direct."
+  /// ```
+  String get shoppingIntroBody =>
+      """Lance une virée à partir de tes listes, parcours chaque magasin dans l'ordre et coche les articles au fur et à mesure — avec un total des prix en direct.""";
+
+  /// ```dart
+  /// "Supermarché"
+  /// ```
+  String get shoppingMockStoreActive => """Supermarché""";
+
+  /// ```dart
+  /// "Pharmacie"
+  /// ```
+  String get shoppingMockStoreNext => """Pharmacie""";
+
+  /// ```dart
   /// "* Nécessite Pantry pour Nextcloud v${version}+"
   /// ```
   String serverRequirementNote(String version) =>
@@ -4407,6 +4428,12 @@ Mot de passe : pantry-rocks""",
   """onboarding.priceBody""":
       """Donnez à un article un prix — un montant unique ou une fourchette — dans la devise de votre choix. Il apparaît sous forme d'étiquette sur l'article, et vous pouvez filtrer votre liste par prix pour respecter votre budget.""",
   """onboarding.priceMockName""": """Huile d'olive""",
+  """onboarding.shoppingIntroTitle""":
+      """Fais tes courses magasin par magasin""",
+  """onboarding.shoppingIntroBody""":
+      """Lance une virée à partir de tes listes, parcours chaque magasin dans l'ordre et coche les articles au fur et à mesure — avec un total des prix en direct.""",
+  """onboarding.shoppingMockStoreActive""": """Supermarché""",
+  """onboarding.shoppingMockStoreNext""": """Pharmacie""",
   """onboarding.dev.showOnboarding""": """Afficher l'intro""",
   """onboarding.dev.pickLastSeenTitle""": """Aperçu des nouveautés""",
   """onboarding.dev.pickLastSeenBody""":

--- a/lib/i18n/messages_fr.i18n.yaml
+++ b/lib/i18n/messages_fr.i18n.yaml
@@ -676,6 +676,78 @@ photoBoard:
     captionZA: "Légende Z–A"
     custom: "Personnalisé"
 
+shopping:
+  startShopping: Commencer les courses
+  resumeShopping: Reprendre les courses
+  shoppingHistory: Historique des courses
+  resume: Reprendre
+  bannerShoppingAt(String store): "Courses chez ${store}"
+  bannerStoreProgress(int index, int total): "Magasin $index/$total"
+  bannerShoppingNow: Courses en cours
+  startTitle: Commencer les courses
+  listsToShop: Listes à faire
+  selectAll: Tout sélectionner
+  selectNone: Ne rien sélectionner
+  noListsToShop: Aucune liste à faire pour l'instant.
+  storesTitle: Magasins
+  storesHint: "Activez ou désactivez les magasins que vous visiterez, et glissez pour définir l'ordre."
+  noStoresWithItems: Aucune des listes sélectionnées n'a d'articles assignés à un magasin.
+  includeUnassigned: Inclure les articles sans magasin
+  start: Commencer
+  startFailed: Impossible de commencer les courses.
+  tripInProgress: Vous avez déjà des courses en cours.
+  tripInProgressElsewhere(String house): "Vous avez des courses en cours dans ${house}."
+  endPreviousTrip: Terminer les courses précédentes
+  endPreviousFailed: Impossible de terminer les courses précédentes.
+  inCart(int count): "$count dans le panier"
+  makePrivate: Masquer les courses aux colocataires
+  makePublic: Montrer les courses aux colocataires
+  privateBadge: Privé
+  nextStore: Magasin suivant
+  finish: Terminer
+  finishTrip: Terminer les courses
+  allCheckedHere: Tout est coché ici
+  moveOnToNext: Passez au magasin suivant.
+  allDone: Tout est fait
+  everythingInCart: Tout est dans le panier.
+  doneToday(int count): "Fait ($count)"
+  nothingToBuyHere: Rien à acheter ici.
+  checkFailed: Impossible de mettre à jour l'article.
+  loadItemsFailed: Impossible de charger les articles.
+  reviewTitle: Récapitulatif
+  advanceTitle: Magasin suivant
+  actualPaid: Payé réel
+  grandTotal: Total général
+  itemsWithoutPrice(int count): "${_plural(count, one: '1 article sans prix', many: '$count articles sans prix')}"
+  itemsStillUnchecked(int count): "${_plural(count, one: '1 article non coché', many: '$count articles non cochés')}"
+  anyStore: N'importe quel magasin
+  saveTotalFailed: Impossible d'enregistrer le total.
+  remindersTitle: Rappels
+  manageReminders: Gérer les rappels
+  reminderGroupStart: Au début
+  reminderGroupAdvance: Entre les magasins
+  reminderGroupEnd: À la fin
+  noRemindersHere: Aucun rappel ici pour l'instant.
+  addReminderHint: Ajouter un rappel
+  reminderWhen: Quand l'afficher
+  whenOnStart: Au début
+  whenOnStoreAdvance: Entre les magasins
+  whenOnClose: À la fin
+  add: Ajouter
+  reminderSaveFailed: Impossible d'enregistrer le rappel.
+  reminderDeleteFailed: Impossible de supprimer le rappel.
+  historyTitle: Historique des courses
+  scopeMine: Les miennes
+  scopeHouse: Maison
+  noStorePath: Aucun magasin
+  itemsCount(int count): "${_plural(count, one: '1 article', many: '$count articles')}"
+  loadMore: Charger plus
+  noTripsYet: Aucune course pour l'instant.
+  noHouseTripsYet: Aucune course dans cette maison pour l'instant.
+  loadHistoryFailed: Impossible de charger l'historique.
+  loadFailed: Une erreur s'est produite. Veuillez réessayer.
+  uncategorized: Sans catégorie
+
 share:
   title: Partager vers Pantry
   chooseHouse: Choisir une maison

--- a/lib/i18n/messages_fr.i18n.yaml
+++ b/lib/i18n/messages_fr.i18n.yaml
@@ -130,6 +130,10 @@ onboarding:
   priceTitle: "Ajoutez des prix à vos articles"
   priceBody: "Donnez à un article un prix — un montant unique ou une fourchette — dans la devise de votre choix. Il apparaît sous forme d'étiquette sur l'article, et vous pouvez filtrer votre liste par prix pour respecter votre budget."
   priceMockName: "Huile d'olive"
+  shoppingIntroTitle: "Fais tes courses magasin par magasin"
+  shoppingIntroBody: "Lance une virée à partir de tes listes, parcours chaque magasin dans l'ordre et coche les articles au fur et à mesure — avec un total des prix en direct."
+  shoppingMockStoreActive: "Supermarché"
+  shoppingMockStoreNext: "Pharmacie"
   serverRequirementNote(String version): "* Nécessite Pantry pour Nextcloud v${version}+"
   dev:
     showOnboarding: "Afficher l'intro"

--- a/lib/i18n/messages_he.i18n.dart
+++ b/lib/i18n/messages_he.i18n.dart
@@ -761,6 +761,27 @@ class OnboardingMessagesHe extends OnboardingMessages {
   String get priceMockName => """שמן זית""";
 
   /// ```dart
+  /// "קונים חנות אחר חנות"
+  /// ```
+  String get shoppingIntroTitle => """קונים חנות אחר חנות""";
+
+  /// ```dart
+  /// "התחילו מסע קניות על הרשימות שלכם, עברו בין החנויות לפי הסדר וסמנו פריטים תוך כדי — עם סכום מחירים מתעדכן."
+  /// ```
+  String get shoppingIntroBody =>
+      """התחילו מסע קניות על הרשימות שלכם, עברו בין החנויות לפי הסדר וסמנו פריטים תוך כדי — עם סכום מחירים מתעדכן.""";
+
+  /// ```dart
+  /// "סופרמרקט"
+  /// ```
+  String get shoppingMockStoreActive => """סופרמרקט""";
+
+  /// ```dart
+  /// "בית מרקחת"
+  /// ```
+  String get shoppingMockStoreNext => """בית מרקחת""";
+
+  /// ```dart
   /// "* דורש את Pantry ל-Nextcloud בגרסה ${version}+"
   /// ```
   String serverRequirementNote(String version) =>
@@ -4361,6 +4382,11 @@ Map<String, String> get messagesHeMap => {
   """onboarding.priceBody""":
       """תנו לכל פריט מחיר — סכום יחיד או טווח — במטבע שתבחרו. הוא מוצג כתגית על הפריט, ותוכלו לסנן את הרשימה לפי מחיר כדי לעמוד בתקציב.""",
   """onboarding.priceMockName""": """שמן זית""",
+  """onboarding.shoppingIntroTitle""": """קונים חנות אחר חנות""",
+  """onboarding.shoppingIntroBody""":
+      """התחילו מסע קניות על הרשימות שלכם, עברו בין החנויות לפי הסדר וסמנו פריטים תוך כדי — עם סכום מחירים מתעדכן.""",
+  """onboarding.shoppingMockStoreActive""": """סופרמרקט""",
+  """onboarding.shoppingMockStoreNext""": """בית מרקחת""",
   """onboarding.dev.showOnboarding""": """הצג היכרות""",
   """onboarding.dev.pickLastSeenTitle""": """תצוגה מקדימה של החדש""",
   """onboarding.dev.pickLastSeenBody""":

--- a/lib/i18n/messages_he.i18n.dart
+++ b/lib/i18n/messages_he.i18n.dart
@@ -78,6 +78,7 @@ class MessagesHe extends Messages {
   ChecklistsMessagesHe get checklists => ChecklistsMessagesHe(this);
   NotesWallMessagesHe get notesWall => NotesWallMessagesHe(this);
   PhotoBoardMessagesHe get photoBoard => PhotoBoardMessagesHe(this);
+  ShoppingMessagesHe get shopping => ShoppingMessagesHe(this);
   ShareMessagesHe get share => ShareMessagesHe(this);
   RecurrenceMessagesHe get recurrence => RecurrenceMessagesHe(this);
   SyncMessagesHe get sync => SyncMessagesHe(this);
@@ -3530,6 +3531,367 @@ class SortPhotoBoardMessagesHe extends SortPhotoBoardMessages {
   String get custom => """מותאם אישית""";
 }
 
+class ShoppingMessagesHe extends ShoppingMessages {
+  final MessagesHe _parent;
+  const ShoppingMessagesHe(this._parent) : super(_parent);
+
+  /// ```dart
+  /// "התחלת קניות"
+  /// ```
+  String get startShopping => """התחלת קניות""";
+
+  /// ```dart
+  /// "המשך קניות"
+  /// ```
+  String get resumeShopping => """המשך קניות""";
+
+  /// ```dart
+  /// "היסטוריית קניות"
+  /// ```
+  String get shoppingHistory => """היסטוריית קניות""";
+
+  /// ```dart
+  /// "המשך"
+  /// ```
+  String get resume => """המשך""";
+
+  /// ```dart
+  /// "קונים ב-${store}"
+  /// ```
+  String bannerShoppingAt(String store) => """קונים ב-${store}""";
+
+  /// ```dart
+  /// "חנות $index/$total"
+  /// ```
+  String bannerStoreProgress(int index, int total) => """חנות $index/$total""";
+
+  /// ```dart
+  /// "קונים עכשיו"
+  /// ```
+  String get bannerShoppingNow => """קונים עכשיו""";
+
+  /// ```dart
+  /// "התחלת קניות"
+  /// ```
+  String get startTitle => """התחלת קניות""";
+
+  /// ```dart
+  /// "רשימות לקנייה"
+  /// ```
+  String get listsToShop => """רשימות לקנייה""";
+
+  /// ```dart
+  /// "בחירת הכול"
+  /// ```
+  String get selectAll => """בחירת הכול""";
+
+  /// ```dart
+  /// "ביטול הבחירה"
+  /// ```
+  String get selectNone => """ביטול הבחירה""";
+
+  /// ```dart
+  /// "אין עדיין רשימות לקנייה."
+  /// ```
+  String get noListsToShop => """אין עדיין רשימות לקנייה.""";
+
+  /// ```dart
+  /// "חנויות"
+  /// ```
+  String get storesTitle => """חנויות""";
+
+  /// ```dart
+  /// "הפעילו או כבו את החנויות שתבקרו בהן, וגררו כדי לקבוע את הסדר."
+  /// ```
+  String get storesHint =>
+      """הפעילו או כבו את החנויות שתבקרו בהן, וגררו כדי לקבוע את הסדר.""";
+
+  /// ```dart
+  /// "לאף אחת מהרשימות שנבחרו אין פריטים המשויכים לחנות."
+  /// ```
+  String get noStoresWithItems =>
+      """לאף אחת מהרשימות שנבחרו אין פריטים המשויכים לחנות.""";
+
+  /// ```dart
+  /// "לכלול פריטים שאינם משויכים לחנות"
+  /// ```
+  String get includeUnassigned => """לכלול פריטים שאינם משויכים לחנות""";
+
+  /// ```dart
+  /// "התחלה"
+  /// ```
+  String get start => """התחלה""";
+
+  /// ```dart
+  /// "התחלת הקנייה נכשלה."
+  /// ```
+  String get startFailed => """התחלת הקנייה נכשלה.""";
+
+  /// ```dart
+  /// "כבר יש לך קנייה פעילה."
+  /// ```
+  String get tripInProgress => """כבר יש לך קנייה פעילה.""";
+
+  /// ```dart
+  /// "יש לך קנייה פעילה ב-${house}."
+  /// ```
+  String tripInProgressElsewhere(String house) =>
+      """יש לך קנייה פעילה ב-${house}.""";
+
+  /// ```dart
+  /// "סיום הקנייה הקודמת"
+  /// ```
+  String get endPreviousTrip => """סיום הקנייה הקודמת""";
+
+  /// ```dart
+  /// "סיום הקנייה הקודמת נכשל."
+  /// ```
+  String get endPreviousFailed => """סיום הקנייה הקודמת נכשל.""";
+
+  /// ```dart
+  /// "$count בעגלה"
+  /// ```
+  String inCart(int count) => """$count בעגלה""";
+
+  /// ```dart
+  /// "הסתרת הקנייה משותפי הבית"
+  /// ```
+  String get makePrivate => """הסתרת הקנייה משותפי הבית""";
+
+  /// ```dart
+  /// "הצגת הקנייה לשותפי הבית"
+  /// ```
+  String get makePublic => """הצגת הקנייה לשותפי הבית""";
+
+  /// ```dart
+  /// "פרטי"
+  /// ```
+  String get privateBadge => """פרטי""";
+
+  /// ```dart
+  /// "החנות הבאה"
+  /// ```
+  String get nextStore => """החנות הבאה""";
+
+  /// ```dart
+  /// "סיום"
+  /// ```
+  String get finish => """סיום""";
+
+  /// ```dart
+  /// "סיום הקנייה"
+  /// ```
+  String get finishTrip => """סיום הקנייה""";
+
+  /// ```dart
+  /// "הכול סומן כאן"
+  /// ```
+  String get allCheckedHere => """הכול סומן כאן""";
+
+  /// ```dart
+  /// "אפשר לעבור לחנות הבאה."
+  /// ```
+  String get moveOnToNext => """אפשר לעבור לחנות הבאה.""";
+
+  /// ```dart
+  /// "הכול הושלם"
+  /// ```
+  String get allDone => """הכול הושלם""";
+
+  /// ```dart
+  /// "הכול בעגלה."
+  /// ```
+  String get everythingInCart => """הכול בעגלה.""";
+
+  /// ```dart
+  /// "הושלם ($count)"
+  /// ```
+  String doneToday(int count) => """הושלם ($count)""";
+
+  /// ```dart
+  /// "אין מה לקנות כאן."
+  /// ```
+  String get nothingToBuyHere => """אין מה לקנות כאן.""";
+
+  /// ```dart
+  /// "עדכון הפריט נכשל."
+  /// ```
+  String get checkFailed => """עדכון הפריט נכשל.""";
+
+  /// ```dart
+  /// "טעינת הפריטים נכשלה."
+  /// ```
+  String get loadItemsFailed => """טעינת הפריטים נכשלה.""";
+
+  /// ```dart
+  /// "סיכום"
+  /// ```
+  String get reviewTitle => """סיכום""";
+
+  /// ```dart
+  /// "החנות הבאה"
+  /// ```
+  String get advanceTitle => """החנות הבאה""";
+
+  /// ```dart
+  /// "שולם בפועל"
+  /// ```
+  String get actualPaid => """שולם בפועל""";
+
+  /// ```dart
+  /// "סך הכול"
+  /// ```
+  String get grandTotal => """סך הכול""";
+
+  /// ```dart
+  /// "${_plural(count, one: 'פריט אחד ללא מחיר', many: '$count פריטים ללא מחיר')}"
+  /// ```
+  String itemsWithoutPrice(int count) =>
+      """${_plural(count, one: 'פריט אחד ללא מחיר', many: '$count פריטים ללא מחיר')}""";
+
+  /// ```dart
+  /// "${_plural(count, one: 'פריט אחד עדיין לא סומן', many: '$count פריטים עדיין לא סומנו')}"
+  /// ```
+  String itemsStillUnchecked(int count) =>
+      """${_plural(count, one: 'פריט אחד עדיין לא סומן', many: '$count פריטים עדיין לא סומנו')}""";
+
+  /// ```dart
+  /// "כל חנות"
+  /// ```
+  String get anyStore => """כל חנות""";
+
+  /// ```dart
+  /// "שמירת הסכום נכשלה."
+  /// ```
+  String get saveTotalFailed => """שמירת הסכום נכשלה.""";
+
+  /// ```dart
+  /// "תזכורות"
+  /// ```
+  String get remindersTitle => """תזכורות""";
+
+  /// ```dart
+  /// "ניהול תזכורות"
+  /// ```
+  String get manageReminders => """ניהול תזכורות""";
+
+  /// ```dart
+  /// "בהתחלה"
+  /// ```
+  String get reminderGroupStart => """בהתחלה""";
+
+  /// ```dart
+  /// "בין חנויות"
+  /// ```
+  String get reminderGroupAdvance => """בין חנויות""";
+
+  /// ```dart
+  /// "בסיום"
+  /// ```
+  String get reminderGroupEnd => """בסיום""";
+
+  /// ```dart
+  /// "אין עדיין תזכורות כאן."
+  /// ```
+  String get noRemindersHere => """אין עדיין תזכורות כאן.""";
+
+  /// ```dart
+  /// "הוספת תזכורת"
+  /// ```
+  String get addReminderHint => """הוספת תזכורת""";
+
+  /// ```dart
+  /// "מתי להציג"
+  /// ```
+  String get reminderWhen => """מתי להציג""";
+
+  /// ```dart
+  /// "בהתחלה"
+  /// ```
+  String get whenOnStart => """בהתחלה""";
+
+  /// ```dart
+  /// "בין חנויות"
+  /// ```
+  String get whenOnStoreAdvance => """בין חנויות""";
+
+  /// ```dart
+  /// "בסיום"
+  /// ```
+  String get whenOnClose => """בסיום""";
+
+  /// ```dart
+  /// "הוספה"
+  /// ```
+  String get add => """הוספה""";
+
+  /// ```dart
+  /// "שמירת התזכורת נכשלה."
+  /// ```
+  String get reminderSaveFailed => """שמירת התזכורת נכשלה.""";
+
+  /// ```dart
+  /// "מחיקת התזכורת נכשלה."
+  /// ```
+  String get reminderDeleteFailed => """מחיקת התזכורת נכשלה.""";
+
+  /// ```dart
+  /// "היסטוריית קניות"
+  /// ```
+  String get historyTitle => """היסטוריית קניות""";
+
+  /// ```dart
+  /// "שלי"
+  /// ```
+  String get scopeMine => """שלי""";
+
+  /// ```dart
+  /// "הבית"
+  /// ```
+  String get scopeHouse => """הבית""";
+
+  /// ```dart
+  /// "ללא חנות"
+  /// ```
+  String get noStorePath => """ללא חנות""";
+
+  /// ```dart
+  /// "${_plural(count, one: 'פריט אחד', many: '$count פריטים')}"
+  /// ```
+  String itemsCount(int count) =>
+      """${_plural(count, one: 'פריט אחד', many: '$count פריטים')}""";
+
+  /// ```dart
+  /// "טעינת עוד"
+  /// ```
+  String get loadMore => """טעינת עוד""";
+
+  /// ```dart
+  /// "אין עדיין קניות."
+  /// ```
+  String get noTripsYet => """אין עדיין קניות.""";
+
+  /// ```dart
+  /// "אין עדיין קניות בבית הזה."
+  /// ```
+  String get noHouseTripsYet => """אין עדיין קניות בבית הזה.""";
+
+  /// ```dart
+  /// "טעינת ההיסטוריה נכשלה."
+  /// ```
+  String get loadHistoryFailed => """טעינת ההיסטוריה נכשלה.""";
+
+  /// ```dart
+  /// "משהו השתבש. נסו שוב."
+  /// ```
+  String get loadFailed => """משהו השתבש. נסו שוב.""";
+
+  /// ```dart
+  /// "ללא קטגוריה"
+  /// ```
+  String get uncategorized => """ללא קטגוריה""";
+}
+
 class ShareMessagesHe extends ShareMessages {
   final MessagesHe _parent;
   const ShareMessagesHe(this._parent) : super(_parent);
@@ -4490,6 +4852,70 @@ Map<String, String> get messagesHeMap => {
   """photoBoard.sort.captionAZ""": """כיתוב א–ת""",
   """photoBoard.sort.captionZA""": """כיתוב ת–א""",
   """photoBoard.sort.custom""": """מותאם אישית""",
+  """shopping.startShopping""": """התחלת קניות""",
+  """shopping.resumeShopping""": """המשך קניות""",
+  """shopping.shoppingHistory""": """היסטוריית קניות""",
+  """shopping.resume""": """המשך""",
+  """shopping.bannerShoppingNow""": """קונים עכשיו""",
+  """shopping.startTitle""": """התחלת קניות""",
+  """shopping.listsToShop""": """רשימות לקנייה""",
+  """shopping.selectAll""": """בחירת הכול""",
+  """shopping.selectNone""": """ביטול הבחירה""",
+  """shopping.noListsToShop""": """אין עדיין רשימות לקנייה.""",
+  """shopping.storesTitle""": """חנויות""",
+  """shopping.storesHint""":
+      """הפעילו או כבו את החנויות שתבקרו בהן, וגררו כדי לקבוע את הסדר.""",
+  """shopping.noStoresWithItems""":
+      """לאף אחת מהרשימות שנבחרו אין פריטים המשויכים לחנות.""",
+  """shopping.includeUnassigned""": """לכלול פריטים שאינם משויכים לחנות""",
+  """shopping.start""": """התחלה""",
+  """shopping.startFailed""": """התחלת הקנייה נכשלה.""",
+  """shopping.tripInProgress""": """כבר יש לך קנייה פעילה.""",
+  """shopping.endPreviousTrip""": """סיום הקנייה הקודמת""",
+  """shopping.endPreviousFailed""": """סיום הקנייה הקודמת נכשל.""",
+  """shopping.makePrivate""": """הסתרת הקנייה משותפי הבית""",
+  """shopping.makePublic""": """הצגת הקנייה לשותפי הבית""",
+  """shopping.privateBadge""": """פרטי""",
+  """shopping.nextStore""": """החנות הבאה""",
+  """shopping.finish""": """סיום""",
+  """shopping.finishTrip""": """סיום הקנייה""",
+  """shopping.allCheckedHere""": """הכול סומן כאן""",
+  """shopping.moveOnToNext""": """אפשר לעבור לחנות הבאה.""",
+  """shopping.allDone""": """הכול הושלם""",
+  """shopping.everythingInCart""": """הכול בעגלה.""",
+  """shopping.nothingToBuyHere""": """אין מה לקנות כאן.""",
+  """shopping.checkFailed""": """עדכון הפריט נכשל.""",
+  """shopping.loadItemsFailed""": """טעינת הפריטים נכשלה.""",
+  """shopping.reviewTitle""": """סיכום""",
+  """shopping.advanceTitle""": """החנות הבאה""",
+  """shopping.actualPaid""": """שולם בפועל""",
+  """shopping.grandTotal""": """סך הכול""",
+  """shopping.anyStore""": """כל חנות""",
+  """shopping.saveTotalFailed""": """שמירת הסכום נכשלה.""",
+  """shopping.remindersTitle""": """תזכורות""",
+  """shopping.manageReminders""": """ניהול תזכורות""",
+  """shopping.reminderGroupStart""": """בהתחלה""",
+  """shopping.reminderGroupAdvance""": """בין חנויות""",
+  """shopping.reminderGroupEnd""": """בסיום""",
+  """shopping.noRemindersHere""": """אין עדיין תזכורות כאן.""",
+  """shopping.addReminderHint""": """הוספת תזכורת""",
+  """shopping.reminderWhen""": """מתי להציג""",
+  """shopping.whenOnStart""": """בהתחלה""",
+  """shopping.whenOnStoreAdvance""": """בין חנויות""",
+  """shopping.whenOnClose""": """בסיום""",
+  """shopping.add""": """הוספה""",
+  """shopping.reminderSaveFailed""": """שמירת התזכורת נכשלה.""",
+  """shopping.reminderDeleteFailed""": """מחיקת התזכורת נכשלה.""",
+  """shopping.historyTitle""": """היסטוריית קניות""",
+  """shopping.scopeMine""": """שלי""",
+  """shopping.scopeHouse""": """הבית""",
+  """shopping.noStorePath""": """ללא חנות""",
+  """shopping.loadMore""": """טעינת עוד""",
+  """shopping.noTripsYet""": """אין עדיין קניות.""",
+  """shopping.noHouseTripsYet""": """אין עדיין קניות בבית הזה.""",
+  """shopping.loadHistoryFailed""": """טעינת ההיסטוריה נכשלה.""",
+  """shopping.loadFailed""": """משהו השתבש. נסו שוב.""",
+  """shopping.uncategorized""": """ללא קטגוריה""",
   """share.title""": """שיתוף ל-Pantry""",
   """share.chooseHouse""": """בחר בית""",
   """share.choosePhotoDestination""": """העלה אל""",

--- a/lib/i18n/messages_he.i18n.yaml
+++ b/lib/i18n/messages_he.i18n.yaml
@@ -676,6 +676,78 @@ photoBoard:
     captionZA: "כיתוב ת–א"
     custom: מותאם אישית
 
+shopping:
+  startShopping: התחלת קניות
+  resumeShopping: המשך קניות
+  shoppingHistory: היסטוריית קניות
+  resume: המשך
+  bannerShoppingAt(String store): "קונים ב-${store}"
+  bannerStoreProgress(int index, int total): "חנות $index/$total"
+  bannerShoppingNow: קונים עכשיו
+  startTitle: התחלת קניות
+  listsToShop: רשימות לקנייה
+  selectAll: בחירת הכול
+  selectNone: ביטול הבחירה
+  noListsToShop: אין עדיין רשימות לקנייה.
+  storesTitle: חנויות
+  storesHint: "הפעילו או כבו את החנויות שתבקרו בהן, וגררו כדי לקבוע את הסדר."
+  noStoresWithItems: לאף אחת מהרשימות שנבחרו אין פריטים המשויכים לחנות.
+  includeUnassigned: לכלול פריטים שאינם משויכים לחנות
+  start: התחלה
+  startFailed: התחלת הקנייה נכשלה.
+  tripInProgress: כבר יש לך קנייה פעילה.
+  tripInProgressElsewhere(String house): "יש לך קנייה פעילה ב-${house}."
+  endPreviousTrip: סיום הקנייה הקודמת
+  endPreviousFailed: סיום הקנייה הקודמת נכשל.
+  inCart(int count): "$count בעגלה"
+  makePrivate: הסתרת הקנייה משותפי הבית
+  makePublic: הצגת הקנייה לשותפי הבית
+  privateBadge: פרטי
+  nextStore: החנות הבאה
+  finish: סיום
+  finishTrip: סיום הקנייה
+  allCheckedHere: הכול סומן כאן
+  moveOnToNext: אפשר לעבור לחנות הבאה.
+  allDone: הכול הושלם
+  everythingInCart: הכול בעגלה.
+  doneToday(int count): "הושלם ($count)"
+  nothingToBuyHere: אין מה לקנות כאן.
+  checkFailed: עדכון הפריט נכשל.
+  loadItemsFailed: טעינת הפריטים נכשלה.
+  reviewTitle: סיכום
+  advanceTitle: החנות הבאה
+  actualPaid: שולם בפועל
+  grandTotal: סך הכול
+  itemsWithoutPrice(int count): "${_plural(count, one: 'פריט אחד ללא מחיר', many: '$count פריטים ללא מחיר')}"
+  itemsStillUnchecked(int count): "${_plural(count, one: 'פריט אחד עדיין לא סומן', many: '$count פריטים עדיין לא סומנו')}"
+  anyStore: כל חנות
+  saveTotalFailed: שמירת הסכום נכשלה.
+  remindersTitle: תזכורות
+  manageReminders: ניהול תזכורות
+  reminderGroupStart: בהתחלה
+  reminderGroupAdvance: בין חנויות
+  reminderGroupEnd: בסיום
+  noRemindersHere: אין עדיין תזכורות כאן.
+  addReminderHint: הוספת תזכורת
+  reminderWhen: מתי להציג
+  whenOnStart: בהתחלה
+  whenOnStoreAdvance: בין חנויות
+  whenOnClose: בסיום
+  add: הוספה
+  reminderSaveFailed: שמירת התזכורת נכשלה.
+  reminderDeleteFailed: מחיקת התזכורת נכשלה.
+  historyTitle: היסטוריית קניות
+  scopeMine: שלי
+  scopeHouse: הבית
+  noStorePath: ללא חנות
+  itemsCount(int count): "${_plural(count, one: 'פריט אחד', many: '$count פריטים')}"
+  loadMore: טעינת עוד
+  noTripsYet: אין עדיין קניות.
+  noHouseTripsYet: אין עדיין קניות בבית הזה.
+  loadHistoryFailed: טעינת ההיסטוריה נכשלה.
+  loadFailed: משהו השתבש. נסו שוב.
+  uncategorized: ללא קטגוריה
+
 share:
   title: שיתוף ל-Pantry
   chooseHouse: בחר בית

--- a/lib/i18n/messages_he.i18n.yaml
+++ b/lib/i18n/messages_he.i18n.yaml
@@ -130,6 +130,10 @@ onboarding:
   priceTitle: "הוסף מחירים לפריטים שלך"
   priceBody: "תנו לכל פריט מחיר — סכום יחיד או טווח — במטבע שתבחרו. הוא מוצג כתגית על הפריט, ותוכלו לסנן את הרשימה לפי מחיר כדי לעמוד בתקציב."
   priceMockName: "שמן זית"
+  shoppingIntroTitle: "קונים חנות אחר חנות"
+  shoppingIntroBody: "התחילו מסע קניות על הרשימות שלכם, עברו בין החנויות לפי הסדר וסמנו פריטים תוך כדי — עם סכום מחירים מתעדכן."
+  shoppingMockStoreActive: "סופרמרקט"
+  shoppingMockStoreNext: "בית מרקחת"
   serverRequirementNote(String version): "* דורש את Pantry ל-Nextcloud בגרסה ${version}+"
   dev:
     showOnboarding: "הצג היכרות"

--- a/lib/i18n/messages_nn.i18n.dart
+++ b/lib/i18n/messages_nn.i18n.dart
@@ -764,6 +764,27 @@ Passord: pantry""";
   String get priceMockName => """Olivenolje""";
 
   /// ```dart
+  /// "Handle butikk for butikk"
+  /// ```
+  String get shoppingIntroTitle => """Handle butikk for butikk""";
+
+  /// ```dart
+  /// "Start ein handletur over listene dine, gå gjennom kvar butikk i rekkjefølgje og kryss av varer undervegs — med ei løpande prissum."
+  /// ```
+  String get shoppingIntroBody =>
+      """Start ein handletur over listene dine, gå gjennom kvar butikk i rekkjefølgje og kryss av varer undervegs — med ei løpande prissum.""";
+
+  /// ```dart
+  /// "Supermarknad"
+  /// ```
+  String get shoppingMockStoreActive => """Supermarknad""";
+
+  /// ```dart
+  /// "Apotek"
+  /// ```
+  String get shoppingMockStoreNext => """Apotek""";
+
+  /// ```dart
   /// "* Krev Pantry for Nextcloud v${version}+"
   /// ```
   String serverRequirementNote(String version) =>
@@ -4386,6 +4407,11 @@ Passord: pantry""",
   """onboarding.priceBody""":
       """Gje ei kvar oppføring ein pris – eit enkelt beløp eller eit område – i valutaen du vil. Han vert vist som ein brikke på oppføringa, og du kan filtrere lista etter pris for å halde deg innanfor budsjettet.""",
   """onboarding.priceMockName""": """Olivenolje""",
+  """onboarding.shoppingIntroTitle""": """Handle butikk for butikk""",
+  """onboarding.shoppingIntroBody""":
+      """Start ein handletur over listene dine, gå gjennom kvar butikk i rekkjefølgje og kryss av varer undervegs — med ei løpande prissum.""",
+  """onboarding.shoppingMockStoreActive""": """Supermarknad""",
+  """onboarding.shoppingMockStoreNext""": """Apotek""",
   """onboarding.dev.showOnboarding""": """Vis oppstartshjelp""",
   """onboarding.dev.pickLastSeenTitle""": """Førehandsvis kva som er nytt""",
   """onboarding.dev.pickLastSeenBody""":

--- a/lib/i18n/messages_nn.i18n.dart
+++ b/lib/i18n/messages_nn.i18n.dart
@@ -78,6 +78,7 @@ class MessagesNn extends Messages {
   ChecklistsMessagesNn get checklists => ChecklistsMessagesNn(this);
   NotesWallMessagesNn get notesWall => NotesWallMessagesNn(this);
   PhotoBoardMessagesNn get photoBoard => PhotoBoardMessagesNn(this);
+  ShoppingMessagesNn get shopping => ShoppingMessagesNn(this);
   ShareMessagesNn get share => ShareMessagesNn(this);
   RecurrenceMessagesNn get recurrence => RecurrenceMessagesNn(this);
   SyncMessagesNn get sync => SyncMessagesNn(this);
@@ -3547,6 +3548,368 @@ class SortPhotoBoardMessagesNn extends SortPhotoBoardMessages {
   String get custom => """Sjølvvald""";
 }
 
+class ShoppingMessagesNn extends ShoppingMessages {
+  final MessagesNn _parent;
+  const ShoppingMessagesNn(this._parent) : super(_parent);
+
+  /// ```dart
+  /// "Start handel"
+  /// ```
+  String get startShopping => """Start handel""";
+
+  /// ```dart
+  /// "Hald fram handelen"
+  /// ```
+  String get resumeShopping => """Hald fram handelen""";
+
+  /// ```dart
+  /// "Handelshistorikk"
+  /// ```
+  String get shoppingHistory => """Handelshistorikk""";
+
+  /// ```dart
+  /// "Hald fram"
+  /// ```
+  String get resume => """Hald fram""";
+
+  /// ```dart
+  /// "Handlar på ${store}"
+  /// ```
+  String bannerShoppingAt(String store) => """Handlar på ${store}""";
+
+  /// ```dart
+  /// "Butikk $index/$total"
+  /// ```
+  String bannerStoreProgress(int index, int total) =>
+      """Butikk $index/$total""";
+
+  /// ```dart
+  /// "Handlar no"
+  /// ```
+  String get bannerShoppingNow => """Handlar no""";
+
+  /// ```dart
+  /// "Start handel"
+  /// ```
+  String get startTitle => """Start handel""";
+
+  /// ```dart
+  /// "Lister å handle"
+  /// ```
+  String get listsToShop => """Lister å handle""";
+
+  /// ```dart
+  /// "Vel alle"
+  /// ```
+  String get selectAll => """Vel alle""";
+
+  /// ```dart
+  /// "Vel ingen"
+  /// ```
+  String get selectNone => """Vel ingen""";
+
+  /// ```dart
+  /// "Ingen lister å handle enno."
+  /// ```
+  String get noListsToShop => """Ingen lister å handle enno.""";
+
+  /// ```dart
+  /// "Butikkar"
+  /// ```
+  String get storesTitle => """Butikkar""";
+
+  /// ```dart
+  /// "Slå på eller av butikkane du skal innom, og dra for å setje rekkjefølgja."
+  /// ```
+  String get storesHint =>
+      """Slå på eller av butikkane du skal innom, og dra for å setje rekkjefølgja.""";
+
+  /// ```dart
+  /// "Ingen av dei valde listene har varer knytte til ein butikk."
+  /// ```
+  String get noStoresWithItems =>
+      """Ingen av dei valde listene har varer knytte til ein butikk.""";
+
+  /// ```dart
+  /// "Ta med varer utan butikk"
+  /// ```
+  String get includeUnassigned => """Ta med varer utan butikk""";
+
+  /// ```dart
+  /// "Start"
+  /// ```
+  String get start => """Start""";
+
+  /// ```dart
+  /// "Klarte ikkje å starte handelen."
+  /// ```
+  String get startFailed => """Klarte ikkje å starte handelen.""";
+
+  /// ```dart
+  /// "Du har allereie ein handel i gang."
+  /// ```
+  String get tripInProgress => """Du har allereie ein handel i gang.""";
+
+  /// ```dart
+  /// "Du har ein handel i gang i ${house}."
+  /// ```
+  String tripInProgressElsewhere(String house) =>
+      """Du har ein handel i gang i ${house}.""";
+
+  /// ```dart
+  /// "Avslutt førre handel"
+  /// ```
+  String get endPreviousTrip => """Avslutt førre handel""";
+
+  /// ```dart
+  /// "Klarte ikkje å avslutte førre handel."
+  /// ```
+  String get endPreviousFailed => """Klarte ikkje å avslutte førre handel.""";
+
+  /// ```dart
+  /// "$count i korga"
+  /// ```
+  String inCart(int count) => """$count i korga""";
+
+  /// ```dart
+  /// "Skjul handelen for husfellane"
+  /// ```
+  String get makePrivate => """Skjul handelen for husfellane""";
+
+  /// ```dart
+  /// "Vis handelen for husfellane"
+  /// ```
+  String get makePublic => """Vis handelen for husfellane""";
+
+  /// ```dart
+  /// "Privat"
+  /// ```
+  String get privateBadge => """Privat""";
+
+  /// ```dart
+  /// "Neste butikk"
+  /// ```
+  String get nextStore => """Neste butikk""";
+
+  /// ```dart
+  /// "Fullfør"
+  /// ```
+  String get finish => """Fullfør""";
+
+  /// ```dart
+  /// "Fullfør handelen"
+  /// ```
+  String get finishTrip => """Fullfør handelen""";
+
+  /// ```dart
+  /// "Alt kryssa av her"
+  /// ```
+  String get allCheckedHere => """Alt kryssa av her""";
+
+  /// ```dart
+  /// "Gå vidare til neste butikk."
+  /// ```
+  String get moveOnToNext => """Gå vidare til neste butikk.""";
+
+  /// ```dart
+  /// "Alt ferdig"
+  /// ```
+  String get allDone => """Alt ferdig""";
+
+  /// ```dart
+  /// "Alt er i korga."
+  /// ```
+  String get everythingInCart => """Alt er i korga.""";
+
+  /// ```dart
+  /// "Ferdig ($count)"
+  /// ```
+  String doneToday(int count) => """Ferdig ($count)""";
+
+  /// ```dart
+  /// "Ingenting å kjøpe her."
+  /// ```
+  String get nothingToBuyHere => """Ingenting å kjøpe her.""";
+
+  /// ```dart
+  /// "Klarte ikkje å oppdatere vara."
+  /// ```
+  String get checkFailed => """Klarte ikkje å oppdatere vara.""";
+
+  /// ```dart
+  /// "Klarte ikkje å laste varene."
+  /// ```
+  String get loadItemsFailed => """Klarte ikkje å laste varene.""";
+
+  /// ```dart
+  /// "Oppsummering"
+  /// ```
+  String get reviewTitle => """Oppsummering""";
+
+  /// ```dart
+  /// "Neste butikk"
+  /// ```
+  String get advanceTitle => """Neste butikk""";
+
+  /// ```dart
+  /// "Faktisk betalt"
+  /// ```
+  String get actualPaid => """Faktisk betalt""";
+
+  /// ```dart
+  /// "Totalsum"
+  /// ```
+  String get grandTotal => """Totalsum""";
+
+  /// ```dart
+  /// "${_plural(count, one: '1 vare utan pris', many: '$count varer utan pris')}"
+  /// ```
+  String itemsWithoutPrice(int count) =>
+      """${_plural(count, one: '1 vare utan pris', many: '$count varer utan pris')}""";
+
+  /// ```dart
+  /// "${_plural(count, one: '1 vare enno ikkje kryssa av', many: '$count varer enno ikkje kryssa av')}"
+  /// ```
+  String itemsStillUnchecked(int count) =>
+      """${_plural(count, one: '1 vare enno ikkje kryssa av', many: '$count varer enno ikkje kryssa av')}""";
+
+  /// ```dart
+  /// "Kva som helst butikk"
+  /// ```
+  String get anyStore => """Kva som helst butikk""";
+
+  /// ```dart
+  /// "Klarte ikkje å lagre summen."
+  /// ```
+  String get saveTotalFailed => """Klarte ikkje å lagre summen.""";
+
+  /// ```dart
+  /// "Påminningar"
+  /// ```
+  String get remindersTitle => """Påminningar""";
+
+  /// ```dart
+  /// "Handter påminningar"
+  /// ```
+  String get manageReminders => """Handter påminningar""";
+
+  /// ```dart
+  /// "Ved start"
+  /// ```
+  String get reminderGroupStart => """Ved start""";
+
+  /// ```dart
+  /// "Mellom butikkar"
+  /// ```
+  String get reminderGroupAdvance => """Mellom butikkar""";
+
+  /// ```dart
+  /// "Ved slutt"
+  /// ```
+  String get reminderGroupEnd => """Ved slutt""";
+
+  /// ```dart
+  /// "Ingen påminningar her enno."
+  /// ```
+  String get noRemindersHere => """Ingen påminningar her enno.""";
+
+  /// ```dart
+  /// "Legg til ei påminning"
+  /// ```
+  String get addReminderHint => """Legg til ei påminning""";
+
+  /// ```dart
+  /// "Når skal ho visast"
+  /// ```
+  String get reminderWhen => """Når skal ho visast""";
+
+  /// ```dart
+  /// "Ved start"
+  /// ```
+  String get whenOnStart => """Ved start""";
+
+  /// ```dart
+  /// "Mellom butikkar"
+  /// ```
+  String get whenOnStoreAdvance => """Mellom butikkar""";
+
+  /// ```dart
+  /// "Ved slutt"
+  /// ```
+  String get whenOnClose => """Ved slutt""";
+
+  /// ```dart
+  /// "Legg til"
+  /// ```
+  String get add => """Legg til""";
+
+  /// ```dart
+  /// "Klarte ikkje å lagre påminninga."
+  /// ```
+  String get reminderSaveFailed => """Klarte ikkje å lagre påminninga.""";
+
+  /// ```dart
+  /// "Klarte ikkje å slette påminninga."
+  /// ```
+  String get reminderDeleteFailed => """Klarte ikkje å slette påminninga.""";
+
+  /// ```dart
+  /// "Handelshistorikk"
+  /// ```
+  String get historyTitle => """Handelshistorikk""";
+
+  /// ```dart
+  /// "Mine"
+  /// ```
+  String get scopeMine => """Mine""";
+
+  /// ```dart
+  /// "Hus"
+  /// ```
+  String get scopeHouse => """Hus""";
+
+  /// ```dart
+  /// "Ingen butikk"
+  /// ```
+  String get noStorePath => """Ingen butikk""";
+
+  /// ```dart
+  /// "${_plural(count, one: '1 vare', many: '$count varer')}"
+  /// ```
+  String itemsCount(int count) =>
+      """${_plural(count, one: '1 vare', many: '$count varer')}""";
+
+  /// ```dart
+  /// "Last inn meir"
+  /// ```
+  String get loadMore => """Last inn meir""";
+
+  /// ```dart
+  /// "Ingen handlar enno."
+  /// ```
+  String get noTripsYet => """Ingen handlar enno.""";
+
+  /// ```dart
+  /// "Ingen handlar i dette huset enno."
+  /// ```
+  String get noHouseTripsYet => """Ingen handlar i dette huset enno.""";
+
+  /// ```dart
+  /// "Klarte ikkje å laste historikken."
+  /// ```
+  String get loadHistoryFailed => """Klarte ikkje å laste historikken.""";
+
+  /// ```dart
+  /// "Noko gjekk gale. Prøv igjen."
+  /// ```
+  String get loadFailed => """Noko gjekk gale. Prøv igjen.""";
+
+  /// ```dart
+  /// "Utan kategori"
+  /// ```
+  String get uncategorized => """Utan kategori""";
+}
+
 class ShareMessagesNn extends ShareMessages {
   final MessagesNn _parent;
   const ShareMessagesNn(this._parent) : super(_parent);
@@ -4533,6 +4896,70 @@ Passord: pantry""",
   """photoBoard.sort.captionAZ""": """Bilettekst A-Z""",
   """photoBoard.sort.captionZA""": """Bilettekst Z-a""",
   """photoBoard.sort.custom""": """Sjølvvald""",
+  """shopping.startShopping""": """Start handel""",
+  """shopping.resumeShopping""": """Hald fram handelen""",
+  """shopping.shoppingHistory""": """Handelshistorikk""",
+  """shopping.resume""": """Hald fram""",
+  """shopping.bannerShoppingNow""": """Handlar no""",
+  """shopping.startTitle""": """Start handel""",
+  """shopping.listsToShop""": """Lister å handle""",
+  """shopping.selectAll""": """Vel alle""",
+  """shopping.selectNone""": """Vel ingen""",
+  """shopping.noListsToShop""": """Ingen lister å handle enno.""",
+  """shopping.storesTitle""": """Butikkar""",
+  """shopping.storesHint""":
+      """Slå på eller av butikkane du skal innom, og dra for å setje rekkjefølgja.""",
+  """shopping.noStoresWithItems""":
+      """Ingen av dei valde listene har varer knytte til ein butikk.""",
+  """shopping.includeUnassigned""": """Ta med varer utan butikk""",
+  """shopping.start""": """Start""",
+  """shopping.startFailed""": """Klarte ikkje å starte handelen.""",
+  """shopping.tripInProgress""": """Du har allereie ein handel i gang.""",
+  """shopping.endPreviousTrip""": """Avslutt førre handel""",
+  """shopping.endPreviousFailed""": """Klarte ikkje å avslutte førre handel.""",
+  """shopping.makePrivate""": """Skjul handelen for husfellane""",
+  """shopping.makePublic""": """Vis handelen for husfellane""",
+  """shopping.privateBadge""": """Privat""",
+  """shopping.nextStore""": """Neste butikk""",
+  """shopping.finish""": """Fullfør""",
+  """shopping.finishTrip""": """Fullfør handelen""",
+  """shopping.allCheckedHere""": """Alt kryssa av her""",
+  """shopping.moveOnToNext""": """Gå vidare til neste butikk.""",
+  """shopping.allDone""": """Alt ferdig""",
+  """shopping.everythingInCart""": """Alt er i korga.""",
+  """shopping.nothingToBuyHere""": """Ingenting å kjøpe her.""",
+  """shopping.checkFailed""": """Klarte ikkje å oppdatere vara.""",
+  """shopping.loadItemsFailed""": """Klarte ikkje å laste varene.""",
+  """shopping.reviewTitle""": """Oppsummering""",
+  """shopping.advanceTitle""": """Neste butikk""",
+  """shopping.actualPaid""": """Faktisk betalt""",
+  """shopping.grandTotal""": """Totalsum""",
+  """shopping.anyStore""": """Kva som helst butikk""",
+  """shopping.saveTotalFailed""": """Klarte ikkje å lagre summen.""",
+  """shopping.remindersTitle""": """Påminningar""",
+  """shopping.manageReminders""": """Handter påminningar""",
+  """shopping.reminderGroupStart""": """Ved start""",
+  """shopping.reminderGroupAdvance""": """Mellom butikkar""",
+  """shopping.reminderGroupEnd""": """Ved slutt""",
+  """shopping.noRemindersHere""": """Ingen påminningar her enno.""",
+  """shopping.addReminderHint""": """Legg til ei påminning""",
+  """shopping.reminderWhen""": """Når skal ho visast""",
+  """shopping.whenOnStart""": """Ved start""",
+  """shopping.whenOnStoreAdvance""": """Mellom butikkar""",
+  """shopping.whenOnClose""": """Ved slutt""",
+  """shopping.add""": """Legg til""",
+  """shopping.reminderSaveFailed""": """Klarte ikkje å lagre påminninga.""",
+  """shopping.reminderDeleteFailed""": """Klarte ikkje å slette påminninga.""",
+  """shopping.historyTitle""": """Handelshistorikk""",
+  """shopping.scopeMine""": """Mine""",
+  """shopping.scopeHouse""": """Hus""",
+  """shopping.noStorePath""": """Ingen butikk""",
+  """shopping.loadMore""": """Last inn meir""",
+  """shopping.noTripsYet""": """Ingen handlar enno.""",
+  """shopping.noHouseTripsYet""": """Ingen handlar i dette huset enno.""",
+  """shopping.loadHistoryFailed""": """Klarte ikkje å laste historikken.""",
+  """shopping.loadFailed""": """Noko gjekk gale. Prøv igjen.""",
+  """shopping.uncategorized""": """Utan kategori""",
   """share.title""": """Del til Pantry""",
   """share.chooseHouse""": """Vel hus""",
   """share.choosePhotoDestination""": """Last opp til""",

--- a/lib/i18n/messages_nn.i18n.yaml
+++ b/lib/i18n/messages_nn.i18n.yaml
@@ -799,6 +799,78 @@ photoBoard:
     captionAZ: Bilettekst A-Z
     captionZA: Bilettekst Z-a
     custom: Sjølvvald
+shopping:
+  startShopping: Start handel
+  resumeShopping: Hald fram handelen
+  shoppingHistory: Handelshistorikk
+  resume: Hald fram
+  bannerShoppingAt(String store): "Handlar på ${store}"
+  bannerStoreProgress(int index, int total): "Butikk $index/$total"
+  bannerShoppingNow: Handlar no
+  startTitle: Start handel
+  listsToShop: Lister å handle
+  selectAll: Vel alle
+  selectNone: Vel ingen
+  noListsToShop: Ingen lister å handle enno.
+  storesTitle: Butikkar
+  storesHint: "Slå på eller av butikkane du skal innom, og dra for å setje rekkjefølgja."
+  noStoresWithItems: Ingen av dei valde listene har varer knytte til ein butikk.
+  includeUnassigned: Ta med varer utan butikk
+  start: Start
+  startFailed: Klarte ikkje å starte handelen.
+  tripInProgress: Du har allereie ein handel i gang.
+  tripInProgressElsewhere(String house): "Du har ein handel i gang i ${house}."
+  endPreviousTrip: Avslutt førre handel
+  endPreviousFailed: Klarte ikkje å avslutte førre handel.
+  inCart(int count): "$count i korga"
+  makePrivate: Skjul handelen for husfellane
+  makePublic: Vis handelen for husfellane
+  privateBadge: Privat
+  nextStore: Neste butikk
+  finish: Fullfør
+  finishTrip: Fullfør handelen
+  allCheckedHere: Alt kryssa av her
+  moveOnToNext: Gå vidare til neste butikk.
+  allDone: Alt ferdig
+  everythingInCart: Alt er i korga.
+  doneToday(int count): "Ferdig ($count)"
+  nothingToBuyHere: Ingenting å kjøpe her.
+  checkFailed: Klarte ikkje å oppdatere vara.
+  loadItemsFailed: Klarte ikkje å laste varene.
+  reviewTitle: Oppsummering
+  advanceTitle: Neste butikk
+  actualPaid: Faktisk betalt
+  grandTotal: Totalsum
+  itemsWithoutPrice(int count): "${_plural(count, one: '1 vare utan pris', many: '$count varer utan pris')}"
+  itemsStillUnchecked(int count): "${_plural(count, one: '1 vare enno ikkje kryssa av', many: '$count varer enno ikkje kryssa av')}"
+  anyStore: Kva som helst butikk
+  saveTotalFailed: Klarte ikkje å lagre summen.
+  remindersTitle: Påminningar
+  manageReminders: Handter påminningar
+  reminderGroupStart: Ved start
+  reminderGroupAdvance: Mellom butikkar
+  reminderGroupEnd: Ved slutt
+  noRemindersHere: Ingen påminningar her enno.
+  addReminderHint: Legg til ei påminning
+  reminderWhen: Når skal ho visast
+  whenOnStart: Ved start
+  whenOnStoreAdvance: Mellom butikkar
+  whenOnClose: Ved slutt
+  add: Legg til
+  reminderSaveFailed: Klarte ikkje å lagre påminninga.
+  reminderDeleteFailed: Klarte ikkje å slette påminninga.
+  historyTitle: Handelshistorikk
+  scopeMine: Mine
+  scopeHouse: Hus
+  noStorePath: Ingen butikk
+  itemsCount(int count): "${_plural(count, one: '1 vare', many: '$count varer')}"
+  loadMore: Last inn meir
+  noTripsYet: Ingen handlar enno.
+  noHouseTripsYet: Ingen handlar i dette huset enno.
+  loadHistoryFailed: Klarte ikkje å laste historikken.
+  loadFailed: Noko gjekk gale. Prøv igjen.
+  uncategorized: Utan kategori
+
 share:
   title: Del til Pantry
   chooseHouse: Vel hus

--- a/lib/i18n/messages_nn.i18n.yaml
+++ b/lib/i18n/messages_nn.i18n.yaml
@@ -193,6 +193,10 @@ onboarding:
   priceTitle: "Legg til prisar på oppføringane dine"
   priceBody: "Gje ei kvar oppføring ein pris – eit enkelt beløp eller eit område – i valutaen du vil. Han vert vist som ein brikke på oppføringa, og du kan filtrere lista etter pris for å halde deg innanfor budsjettet."
   priceMockName: Olivenolje
+  shoppingIntroTitle: "Handle butikk for butikk"
+  shoppingIntroBody: "Start ein handletur over listene dine, gå gjennom kvar butikk i rekkjefølgje og kryss av varer undervegs — med ei løpande prissum."
+  shoppingMockStoreActive: "Supermarknad"
+  shoppingMockStoreNext: "Apotek"
   serverRequirementNote(String version): "* Krev Pantry for Nextcloud v${version}+"
   dev:
     showOnboarding: Vis oppstartshjelp

--- a/lib/models/shopping_estimate.dart
+++ b/lib/models/shopping_estimate.dart
@@ -1,0 +1,108 @@
+import 'package:pantry/utils/currencies.dart';
+
+/// A single per-currency estimate range within a [ShoppingEstimate]. `min`
+/// equals `max` when the underlying items all carry a `set` price; otherwise
+/// it spans the summed range of the `range`-priced items. Amounts are in the
+/// currency's own units (no conversion happens across currencies).
+class CurrencyRange {
+  final String currency;
+  final double min;
+  final double max;
+
+  const CurrencyRange({
+    required this.currency,
+    required this.min,
+    required this.max,
+  });
+
+  factory CurrencyRange.fromJson(Map<String, dynamic> json) => CurrencyRange(
+    currency: json['currency'] as String,
+    min: (json['min'] as num).toDouble(),
+    max: (json['max'] as num).toDouble(),
+  );
+
+  Map<String, dynamic> toJson() => {
+    'currency': currency,
+    'min': min,
+    'max': max,
+  };
+
+  /// Renders this range as a chip/label, e.g. `$12.50` when `min == max` or
+  /// `≈$12.50–$18` otherwise. Trailing zeros are trimmed per the currency's
+  /// decimals, matching [formatPrice].
+  String get label {
+    final c = resolveCurrency(currency);
+    String amount(double v) {
+      final rounded = double.parse(v.toStringAsFixed(c.decimals));
+      final body = rounded == rounded.truncateToDouble()
+          ? rounded.toInt().toString()
+          : rounded.toString();
+      return c.symbolBefore ? '${c.symbol}$body' : '$body${c.symbol}';
+    }
+
+    if (min == max) return amount(min);
+    return '≈${amount(min)}–${amount(max)}';
+  }
+}
+
+/// A per-currency array of ranges. Used everywhere a total is estimated from
+/// item prices — session/store review, done-today and (as a distinct amount
+/// shape) history. See [CurrencyRange].
+typedef ShoppingEstimate = List<CurrencyRange>;
+
+/// Parse a raw `ShoppingEstimate` payload (a JSON array) into typed ranges.
+ShoppingEstimate parseShoppingEstimate(dynamic raw) =>
+    ((raw as List?) ?? const [])
+        .map((e) => CurrencyRange.fromJson(e as Map<String, dynamic>))
+        .toList();
+
+/// Render a whole estimate as one label, each currency on `sep` (e.g. `$12 · 40₪`).
+/// Returns null when the estimate is empty (nothing priced).
+String? formatShoppingEstimate(
+  ShoppingEstimate estimate, {
+  String sep = ' · ',
+}) {
+  if (estimate.isEmpty) return null;
+  return estimate.map((r) => r.label).join(sep);
+}
+
+/// Render a list of realized amounts (history grand totals) as one label.
+/// Returns null when empty.
+String? formatCurrencyAmounts(
+  List<CurrencyAmount> amounts, {
+  String sep = ' · ',
+}) {
+  if (amounts.isEmpty) return null;
+  return amounts.map((a) => a.label).join(sep);
+}
+
+/// A single realized per-currency amount, as returned by history rows'
+/// `grandTotal` (a summed billed/estimated figure, not a range).
+class CurrencyAmount {
+  final String currency;
+  final double amount;
+
+  const CurrencyAmount({required this.currency, required this.amount});
+
+  factory CurrencyAmount.fromJson(Map<String, dynamic> json) => CurrencyAmount(
+    currency: json['currency'] as String,
+    amount: (json['amount'] as num).toDouble(),
+  );
+
+  Map<String, dynamic> toJson() => {'currency': currency, 'amount': amount};
+
+  /// Renders this amount as a label, e.g. `$12.50`, trimming trailing zeros.
+  String get label {
+    final c = resolveCurrency(currency);
+    final rounded = double.parse(amount.toStringAsFixed(c.decimals));
+    final body = rounded == rounded.truncateToDouble()
+        ? rounded.toInt().toString()
+        : rounded.toString();
+    return c.symbolBefore ? '${c.symbol}$body' : '$body${c.symbol}';
+  }
+}
+
+List<CurrencyAmount> parseCurrencyAmounts(dynamic raw) =>
+    ((raw as List?) ?? const [])
+        .map((e) => CurrencyAmount.fromJson(e as Map<String, dynamic>))
+        .toList();

--- a/lib/models/shopping_history_row.dart
+++ b/lib/models/shopping_history_row.dart
@@ -1,0 +1,38 @@
+import 'package:pantry/models/shopping_estimate.dart';
+
+/// A closed trip in the history list. [stores] are store names in visit order
+/// ("Store A → Store B"); [grandTotal] is a per-currency realized amount
+/// (billed where entered, else estimated). Scope (mine vs house) is applied
+/// server-side per each session's `isPrivate`.
+class ShoppingHistoryRow {
+  final int id;
+  final String userId;
+  final int createdAt;
+  final int? closedAt;
+  final List<String> stores;
+  final int itemCount;
+  final List<CurrencyAmount> grandTotal;
+
+  const ShoppingHistoryRow({
+    required this.id,
+    required this.userId,
+    required this.createdAt,
+    required this.closedAt,
+    required this.stores,
+    required this.itemCount,
+    required this.grandTotal,
+  });
+
+  factory ShoppingHistoryRow.fromJson(Map<String, dynamic> json) =>
+      ShoppingHistoryRow(
+        id: json['id'] as int,
+        userId: json['userId'] as String,
+        createdAt: json['createdAt'] as int,
+        closedAt: json['closedAt'] as int?,
+        stores: ((json['stores'] as List?) ?? const [])
+            .map((e) => e as String)
+            .toList(),
+        itemCount: json['itemCount'] as int,
+        grandTotal: parseCurrencyAmounts(json['grandTotal']),
+      );
+}

--- a/lib/models/shopping_presence_entry.dart
+++ b/lib/models/shopping_presence_entry.dart
@@ -1,0 +1,28 @@
+/// A housemate currently out shopping, derived from live sessions + heartbeat.
+/// [activeStoreId] attributes them to a store (null = live but no store
+/// chosen). Resolve avatar/name from [userId]. The list is not self-filtered —
+/// the caller decides whether to render itself.
+class ShoppingPresenceEntry {
+  final String userId;
+  final int? activeStoreId;
+  final int lastSeenAt;
+
+  const ShoppingPresenceEntry({
+    required this.userId,
+    required this.activeStoreId,
+    required this.lastSeenAt,
+  });
+
+  factory ShoppingPresenceEntry.fromJson(Map<String, dynamic> json) =>
+      ShoppingPresenceEntry(
+        userId: json['userId'] as String,
+        activeStoreId: json['activeStoreId'] as int?,
+        lastSeenAt: json['lastSeenAt'] as int,
+      );
+
+  Map<String, dynamic> toJson() => {
+    'userId': userId,
+    'activeStoreId': activeStoreId,
+    'lastSeenAt': lastSeenAt,
+  };
+}

--- a/lib/models/shopping_reminder.dart
+++ b/lib/models/shopping_reminder.dart
@@ -1,0 +1,83 @@
+/// The moment at which a reminder surfaces. One [showOn] per reminder row —
+/// the same text at two moments is two rows.
+enum ShoppingReminderMoment {
+  onStart('on_start'),
+  onStoreAdvance('on_store_advance'),
+  onClose('on_close');
+
+  const ShoppingReminderMoment(this.wire);
+
+  /// The wire value exchanged with the server.
+  final String wire;
+
+  static ShoppingReminderMoment fromWire(String value) =>
+      ShoppingReminderMoment.values.firstWhere(
+        (m) => m.wire == value,
+        orElse: () => ShoppingReminderMoment.onStart,
+      );
+}
+
+/// A house-scoped, user-defined shopping prompt. Surfaced (filtered to
+/// [enabled], ordered by [position]) as a non-blocking block at the matching
+/// [showOn] moment; acknowledgement is client-local only and never persists.
+class ShoppingReminder {
+  final int id;
+  final int houseId;
+  final String text;
+  final ShoppingReminderMoment showOn;
+  final int position;
+  final bool enabled;
+  final int createdAt;
+  final int updatedAt;
+
+  const ShoppingReminder({
+    required this.id,
+    required this.houseId,
+    required this.text,
+    required this.showOn,
+    required this.position,
+    required this.enabled,
+    required this.createdAt,
+    required this.updatedAt,
+  });
+
+  factory ShoppingReminder.fromJson(Map<String, dynamic> json) =>
+      ShoppingReminder(
+        id: json['id'] as int,
+        houseId: json['houseId'] as int,
+        text: json['text'] as String,
+        showOn: ShoppingReminderMoment.fromWire(json['showOn'] as String),
+        position: json['position'] as int,
+        enabled: json['enabled'] as bool,
+        createdAt: json['createdAt'] as int,
+        updatedAt: json['updatedAt'] as int,
+      );
+
+  Map<String, dynamic> toJson() => {
+    'id': id,
+    'houseId': houseId,
+    'text': text,
+    'showOn': showOn.wire,
+    'position': position,
+    'enabled': enabled,
+    'createdAt': createdAt,
+    'updatedAt': updatedAt,
+  };
+
+  ShoppingReminder copyWith({
+    String? text,
+    ShoppingReminderMoment? showOn,
+    int? position,
+    bool? enabled,
+    int? updatedAt,
+  }) => ShoppingReminder(
+    id: id,
+    houseId: houseId,
+    text: text ?? this.text,
+    showOn: showOn ?? this.showOn,
+    position: position ?? this.position,
+    enabled: enabled ?? this.enabled,
+    createdAt: createdAt,
+    updatedAt: updatedAt ?? this.updatedAt,
+  );
+}

--- a/lib/models/shopping_review.dart
+++ b/lib/models/shopping_review.dart
@@ -1,0 +1,85 @@
+import 'package:pantry/models/checklist.dart';
+import 'package:pantry/models/shopping_estimate.dart';
+
+/// One store's slice of a shopping review: the checked items bought there, the
+/// per-currency [estimate] of their prices, how many carried no price, and the
+/// user-entered [billedTotal]/[billedCurrency] actuals (null until entered).
+/// [storeId] is null for the storeless / unassigned bucket ("Any store").
+class ShoppingReviewStore {
+  final int? storeId;
+  final List<ListItem> items;
+  final ShoppingEstimate estimate;
+  final int noPriceCount;
+  final double? billedTotal;
+  final String? billedCurrency;
+
+  const ShoppingReviewStore({
+    required this.storeId,
+    required this.items,
+    required this.estimate,
+    required this.noPriceCount,
+    this.billedTotal,
+    this.billedCurrency,
+  });
+
+  factory ShoppingReviewStore.fromJson(Map<String, dynamic> json) =>
+      ShoppingReviewStore(
+        storeId: json['storeId'] as int?,
+        items: ((json['items'] as List?) ?? const [])
+            .map((e) => ListItem.fromJson(e as Map<String, dynamic>))
+            .toList(),
+        estimate: parseShoppingEstimate(json['estimate']),
+        noPriceCount: json['noPriceCount'] as int,
+        billedTotal: (json['billedTotal'] as num?)?.toDouble(),
+        billedCurrency: json['billedCurrency'] as String?,
+      );
+}
+
+/// The checked log of a trip, grouped by store and server-computed. Rendered
+/// per-store on advance (just the active store), or in full on close/history.
+class ShoppingReview {
+  final List<ShoppingReviewStore> stores;
+  final ShoppingEstimate grandTotal;
+  final int uncheckedCount;
+
+  const ShoppingReview({
+    required this.stores,
+    required this.grandTotal,
+    required this.uncheckedCount,
+  });
+
+  factory ShoppingReview.fromJson(Map<String, dynamic> json) => ShoppingReview(
+    stores: ((json['stores'] as List?) ?? const [])
+        .map((e) => ShoppingReviewStore.fromJson(e as Map<String, dynamic>))
+        .toList(),
+    grandTotal: parseShoppingEstimate(json['grandTotal']),
+    uncheckedCount: json['uncheckedCount'] as int,
+  );
+}
+
+/// My check-log rows whose `checkedAt` falls within today (my timezone),
+/// house-scoped. Surfaced in the dense view's "Done today" drawer. Distinct
+/// from an item's own `doneAt` — strictly shopping-mode checks.
+class ShoppingDoneToday {
+  final List<ListItem> items;
+  final ShoppingEstimate estimate;
+  final int noPriceCount;
+  final int count;
+
+  const ShoppingDoneToday({
+    required this.items,
+    required this.estimate,
+    required this.noPriceCount,
+    required this.count,
+  });
+
+  factory ShoppingDoneToday.fromJson(Map<String, dynamic> json) =>
+      ShoppingDoneToday(
+        items: ((json['items'] as List?) ?? const [])
+            .map((e) => ListItem.fromJson(e as Map<String, dynamic>))
+            .toList(),
+        estimate: parseShoppingEstimate(json['estimate']),
+        noPriceCount: json['noPriceCount'] as int,
+        count: json['count'] as int,
+      );
+}

--- a/lib/models/shopping_session.dart
+++ b/lib/models/shopping_session.dart
@@ -1,0 +1,146 @@
+/// One store leg of a shopping session, ordered by [position]. [billedTotal] /
+/// [billedCurrency] are the user-entered actual paid at that store's till
+/// (null until entered); they take precedence over the estimate in the grand
+/// total. See [ShoppingSession].
+class ShoppingSessionStore {
+  final int storeId;
+  final int position;
+  final double? billedTotal;
+  final String? billedCurrency;
+
+  const ShoppingSessionStore({
+    required this.storeId,
+    required this.position,
+    this.billedTotal,
+    this.billedCurrency,
+  });
+
+  factory ShoppingSessionStore.fromJson(Map<String, dynamic> json) =>
+      ShoppingSessionStore(
+        storeId: json['storeId'] as int,
+        position: json['position'] as int,
+        billedTotal: (json['billedTotal'] as num?)?.toDouble(),
+        billedCurrency: json['billedCurrency'] as String?,
+      );
+
+  Map<String, dynamic> toJson() => {
+    'storeId': storeId,
+    'position': position,
+    'billedTotal': billedTotal,
+    'billedCurrency': billedCurrency,
+  };
+}
+
+/// The lean session DTO — scope + lifecycle only, never item arrays. Returned
+/// by create / advance / close / privacy / current. Fetch the two item
+/// collections separately: `…/items` (what to buy now) and `…/review` (what
+/// was bought).
+class ShoppingSession {
+  final int id;
+  final int houseId;
+  final String userId;
+  final List<int> listIds;
+
+  /// Ordered by [ShoppingSessionStore.position]. Empty for a storeless trip.
+  final List<ShoppingSessionStore> stores;
+
+  /// The store the shopper is currently at — a `storeId` present in [stores],
+  /// or null when no store is chosen (storeless trip, or not yet advanced).
+  /// The narrowing key for `…/items` and the presence attribution key.
+  final int? activeStoreId;
+
+  final bool includeUnassigned;
+  final bool isPrivate;
+
+  /// Storeless-session grand-total fallback (actual paid), null until entered.
+  final double? billedTotal;
+  final String? billedCurrency;
+
+  final int lastSeenAt;
+
+  /// Server-derived: `closedAt == null && fresh`.
+  final bool live;
+  final int? closedAt;
+  final int createdAt;
+  final int updatedAt;
+
+  const ShoppingSession({
+    required this.id,
+    required this.houseId,
+    required this.userId,
+    required this.listIds,
+    required this.stores,
+    required this.activeStoreId,
+    required this.includeUnassigned,
+    required this.isPrivate,
+    this.billedTotal,
+    this.billedCurrency,
+    required this.lastSeenAt,
+    required this.live,
+    this.closedAt,
+    required this.createdAt,
+    required this.updatedAt,
+  });
+
+  factory ShoppingSession.fromJson(Map<String, dynamic> json) =>
+      ShoppingSession(
+        id: json['id'] as int,
+        houseId: json['houseId'] as int,
+        userId: json['userId'] as String,
+        listIds: ((json['listIds'] as List?) ?? const [])
+            .map((e) => e as int)
+            .toList(),
+        stores: ((json['stores'] as List?) ?? const [])
+            .map(
+              (e) => ShoppingSessionStore.fromJson(e as Map<String, dynamic>),
+            )
+            .toList(),
+        activeStoreId: json['activeStoreId'] as int?,
+        includeUnassigned: json['includeUnassigned'] as bool,
+        isPrivate: json['isPrivate'] as bool,
+        billedTotal: (json['billedTotal'] as num?)?.toDouble(),
+        billedCurrency: json['billedCurrency'] as String?,
+        lastSeenAt: json['lastSeenAt'] as int,
+        live: json['live'] as bool,
+        closedAt: json['closedAt'] as int?,
+        createdAt: json['createdAt'] as int,
+        updatedAt: json['updatedAt'] as int,
+      );
+
+  Map<String, dynamic> toJson() => {
+    'id': id,
+    'houseId': houseId,
+    'userId': userId,
+    'listIds': listIds,
+    'stores': stores.map((e) => e.toJson()).toList(),
+    'activeStoreId': activeStoreId,
+    'includeUnassigned': includeUnassigned,
+    'isPrivate': isPrivate,
+    'billedTotal': billedTotal,
+    'billedCurrency': billedCurrency,
+    'lastSeenAt': lastSeenAt,
+    'live': live,
+    'closedAt': closedAt,
+    'createdAt': createdAt,
+    'updatedAt': updatedAt,
+  };
+
+  /// Store ids in position order. `activeStoreId`'s "next store" is computed
+  /// from this sequence client-side.
+  List<int> get orderedStoreIds {
+    final sorted = [...stores]
+      ..sort((a, b) => a.position.compareTo(b.position));
+    return sorted.map((s) => s.storeId).toList();
+  }
+
+  /// The store leg after [activeStoreId] in position order, or null when the
+  /// active store is the last one (or there is no active store). Backs the
+  /// "Next store" affordance.
+  int? get nextStoreId {
+    final ordered = orderedStoreIds;
+    if (activeStoreId == null) return ordered.isEmpty ? null : ordered.first;
+    final idx = ordered.indexOf(activeStoreId!);
+    if (idx < 0 || idx + 1 >= ordered.length) return null;
+    return ordered[idx + 1];
+  }
+}

--- a/lib/services/shopping_service.dart
+++ b/lib/services/shopping_service.dart
@@ -1,0 +1,358 @@
+import 'dart:convert';
+
+import 'package:pantry/models/checklist.dart';
+import 'package:pantry/models/shopping_history_row.dart';
+import 'package:pantry/models/shopping_presence_entry.dart';
+import 'package:pantry/models/shopping_reminder.dart';
+import 'package:pantry/models/shopping_review.dart';
+import 'package:pantry/models/shopping_session.dart';
+import 'package:pantry/services/api_client.dart';
+import 'package:pantry/services/cache_store.dart';
+
+/// Scope of a history query: the caller's own trips, or every visible trip in
+/// the house (housemates' private trips excluded server-side).
+enum ShoppingHistoryScope {
+  mine('mine'),
+  house('house');
+
+  const ShoppingHistoryScope(this.wire);
+  final String wire;
+}
+
+/// Singleton wrapping the 21 Shopping Mode endpoints via [ApiClient.instance].
+/// Mirrors [StoreService]. Live session/item/presence data is polled, so it is
+/// not cached; reminders are cached for offline surfacing.
+class ShoppingService {
+  ShoppingService._();
+  static final ShoppingService instance = ShoppingService._();
+
+  final cache = CacheStore('shopping_cache.json');
+
+  ApiClient get _api => ApiClient.instance;
+
+  String _base(int houseId) => '/houses/$houseId/shopping';
+
+  // -- Sessions --------------------------------------------------------------
+
+  /// (1) Global discovery of the caller's single live session, or null when
+  /// idle. Not house-scoped; the returned session carries its own `houseId`.
+  /// Safe to call on launch and before the start screen — no side effects.
+  Future<ShoppingSession?> getCurrentSession() {
+    return _api.get<dynamic, ShoppingSession?>(
+      '/shopping/sessions/current',
+      fromJson: _sessionOrNull,
+    );
+  }
+
+  /// (2) Create a session over the given scope. Sessions start public; toggle
+  /// privacy later via [setPrivacy]. Throws [ShoppingSessionConflict] (from a
+  /// 409) carrying the existing live session when one is already in progress.
+  Future<ShoppingSession> createSession(
+    int houseId, {
+    required List<int> listIds,
+    required List<int> storeIds,
+    bool includeUnassigned = true,
+  }) async {
+    try {
+      return await _api.post<Map<String, dynamic>, ShoppingSession>(
+        '${_base(houseId)}/sessions',
+        body: {
+          'listIds': listIds,
+          'storeIds': storeIds,
+          'includeUnassigned': includeUnassigned,
+        },
+        fromJson: ShoppingSession.fromJson,
+      );
+    } on ApiException catch (e) {
+      final existing = _sessionFromErrorBody(e);
+      if (e.statusCode == 409 && existing != null) {
+        throw ShoppingSessionConflict(existing);
+      }
+      rethrow;
+    }
+  }
+
+  /// (3) Move to [storeId] (must be one of the session's stores). Sets
+  /// `activeStoreId` and returns the updated session.
+  Future<ShoppingSession> advance(
+    int houseId,
+    int sessionId, {
+    required int storeId,
+  }) {
+    return _api.post<Map<String, dynamic>, ShoppingSession>(
+      '${_base(houseId)}/sessions/$sessionId/advance',
+      body: {'storeId': storeId},
+      fromJson: ShoppingSession.fromJson,
+    );
+  }
+
+  /// (4) Close the session (irreversible). Throws [ShoppingSessionConflict]
+  /// (from a 409) carrying the already-closed session when called twice.
+  Future<ShoppingSession> close(int houseId, int sessionId) async {
+    try {
+      return await _api.post<Map<String, dynamic>, ShoppingSession>(
+        '${_base(houseId)}/sessions/$sessionId/close',
+        fromJson: ShoppingSession.fromJson,
+      );
+    } on ApiException catch (e) {
+      final existing = _sessionFromErrorBody(e);
+      if (e.statusCode == 409 && existing != null) {
+        throw ShoppingSessionConflict(existing);
+      }
+      rethrow;
+    }
+  }
+
+  /// (5) Toggle whether the session is hidden from housemates' presence and
+  /// house-scoped history.
+  Future<ShoppingSession> setPrivacy(
+    int houseId,
+    int sessionId, {
+    required bool isPrivate,
+  }) {
+    return _api.patch<Map<String, dynamic>, ShoppingSession>(
+      '${_base(houseId)}/sessions/$sessionId/privacy',
+      body: {'isPrivate': isPrivate},
+      fromJson: ShoppingSession.fromJson,
+    );
+  }
+
+  /// (6) Set the session-level billed total (storeless grand-total fallback).
+  Future<ShoppingSession> setSessionBilled(
+    int houseId,
+    int sessionId, {
+    double? billedTotal,
+    String? billedCurrency,
+  }) {
+    return _api.patch<Map<String, dynamic>, ShoppingSession>(
+      '${_base(houseId)}/sessions/$sessionId',
+      body: {'billedTotal': billedTotal, 'billedCurrency': billedCurrency},
+      fromJson: ShoppingSession.fromJson,
+    );
+  }
+
+  /// (7) Set a per-store billed total (the actual paid at that store's till).
+  Future<ShoppingSession> setStoreBilled(
+    int houseId,
+    int sessionId,
+    int storeId, {
+    double? billedTotal,
+    String? billedCurrency,
+  }) {
+    return _api.patch<Map<String, dynamic>, ShoppingSession>(
+      '${_base(houseId)}/sessions/$sessionId/stores/$storeId',
+      body: {'billedTotal': billedTotal, 'billedCurrency': billedCurrency},
+      fromJson: ShoppingSession.fromJson,
+    );
+  }
+
+  // -- Items -----------------------------------------------------------------
+
+  /// (8) The flat, ordered, store-narrowed list of what to buy now (unchecked
+  /// & in-scope). Client groups by category. Re-query each poll.
+  Future<List<ListItem>> getItems(int houseId, int sessionId) {
+    return _api.get<List, List<ListItem>>(
+      '${_base(houseId)}/sessions/$sessionId/items',
+      fromJson: (data) => data
+          .map((e) => ListItem.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+  }
+
+  /// (9) Mark an item bought — an explicit action, not a field edit. Returns
+  /// only success; re-fetch [getItems] to reconcile.
+  Future<void> checkItem(int houseId, int sessionId, int itemId) async {
+    await _api.post<Map<String, dynamic>, void>(
+      '${_base(houseId)}/sessions/$sessionId/items/$itemId/check',
+      fromJson: (_) {},
+    );
+  }
+
+  /// (10) Reverse a check. Returns only success; re-fetch [getItems].
+  Future<void> uncheckItem(int houseId, int sessionId, int itemId) async {
+    await _api.post<Map<String, dynamic>, void>(
+      '${_base(houseId)}/sessions/$sessionId/items/$itemId/uncheck',
+      fromJson: (_) {},
+    );
+  }
+
+  // -- Review / done-today ---------------------------------------------------
+
+  /// (11) The bought log grouped by store (server-computed, authoritative).
+  Future<ShoppingReview> getReview(int houseId, int sessionId) {
+    return _api.get<Map<String, dynamic>, ShoppingReview>(
+      '${_base(houseId)}/sessions/$sessionId/review',
+      fromJson: ShoppingReview.fromJson,
+    );
+  }
+
+  /// (12) My check-log for today (my timezone), house-scoped. Polled in the
+  /// dense view's Done-today drawer.
+  Future<ShoppingDoneToday> getDoneToday(int houseId) {
+    return _api.get<Map<String, dynamic>, ShoppingDoneToday>(
+      '${_base(houseId)}/sessions/done-today',
+      fromJson: ShoppingDoneToday.fromJson,
+    );
+  }
+
+  // -- Presence --------------------------------------------------------------
+
+  /// (13) Stamp liveness and get the current house presence in one round-trip.
+  /// Called ~1 min by an active shopper; pause on blur, fire on refocus.
+  Future<List<ShoppingPresenceEntry>> heartbeat(int houseId) {
+    return _api.post<List, List<ShoppingPresenceEntry>>(
+      '${_base(houseId)}/presence/heartbeat',
+      fromJson: _parsePresence,
+    );
+  }
+
+  /// (14) Read-only house presence; needs no live session (someone at home can
+  /// watch who's out).
+  Future<List<ShoppingPresenceEntry>> getPresence(int houseId) {
+    return _api.get<List, List<ShoppingPresenceEntry>>(
+      '${_base(houseId)}/presence',
+      fromJson: _parsePresence,
+    );
+  }
+
+  // -- Reminders -------------------------------------------------------------
+
+  List<ShoppingReminder>? getCachedReminders(int houseId) =>
+      cache.getKeyedList('reminders', '$houseId', ShoppingReminder.fromJson);
+
+  /// (15) List the house's reminders (all moments, all enabled states).
+  Future<List<ShoppingReminder>> getReminders(int houseId) async {
+    final reminders = await _api.get<List, List<ShoppingReminder>>(
+      '${_base(houseId)}/reminders',
+      fromJson: (data) => data
+          .map((e) => ShoppingReminder.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+    cache.setKeyedList('reminders', '$houseId', reminders, (r) => r.toJson());
+    return reminders;
+  }
+
+  /// (16) Create a reminder at a moment.
+  Future<ShoppingReminder> createReminder(
+    int houseId, {
+    required String text,
+    required ShoppingReminderMoment showOn,
+    bool? enabled,
+  }) {
+    return _api.post<Map<String, dynamic>, ShoppingReminder>(
+      '${_base(houseId)}/reminders',
+      body: {'text': text, 'showOn': showOn.wire, 'enabled': ?enabled},
+      fromJson: ShoppingReminder.fromJson,
+    );
+  }
+
+  /// (17) Edit a reminder's text, moment, enabled state, or position.
+  Future<ShoppingReminder> updateReminder(
+    int houseId,
+    int reminderId, {
+    String? text,
+    ShoppingReminderMoment? showOn,
+    bool? enabled,
+    int? position,
+  }) {
+    return _api.patch<Map<String, dynamic>, ShoppingReminder>(
+      '${_base(houseId)}/reminders/$reminderId',
+      body: {
+        'text': ?text,
+        'showOn': ?showOn?.wire,
+        'enabled': ?enabled,
+        'position': ?position,
+      },
+      fromJson: ShoppingReminder.fromJson,
+    );
+  }
+
+  /// (18) Delete a reminder.
+  Future<void> deleteReminder(int houseId, int reminderId) {
+    return _api.delete('${_base(houseId)}/reminders/$reminderId');
+  }
+
+  /// (19) Reorder reminders in one call — [reminderIds] in the desired order
+  /// become their new positions.
+  Future<List<ShoppingReminder>> reorderReminders(
+    int houseId,
+    List<int> reminderIds,
+  ) {
+    return _api.patch<List, List<ShoppingReminder>>(
+      '${_base(houseId)}/reminders/reorder',
+      body: {'reminderIds': reminderIds},
+      fromJson: (data) => data
+          .map((e) => ShoppingReminder.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+  }
+
+  // -- History ---------------------------------------------------------------
+
+  /// (20) Read-only list of closed trips (Phase 3). Scope selects mine vs
+  /// house-wide.
+  Future<List<ShoppingHistoryRow>> getHistory(
+    int houseId, {
+    ShoppingHistoryScope scope = ShoppingHistoryScope.mine,
+    int limit = 30,
+    int offset = 0,
+  }) {
+    return _api.get<List, List<ShoppingHistoryRow>>(
+      '${_base(houseId)}/sessions/history',
+      query: {'scope': scope.wire, 'limit': '$limit', 'offset': '$offset'},
+      fromJson: (data) => data
+          .map((e) => ShoppingHistoryRow.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+  }
+
+  /// (21) The read-only review of one past trip (same shape as live review).
+  Future<ShoppingReview> getSummary(int houseId, int sessionId) {
+    return _api.get<Map<String, dynamic>, ShoppingReview>(
+      '${_base(houseId)}/sessions/$sessionId/summary',
+      fromJson: ShoppingReview.fromJson,
+    );
+  }
+
+  // -- Helpers ---------------------------------------------------------------
+
+  static List<ShoppingPresenceEntry> _parsePresence(List data) => data
+      .map((e) => ShoppingPresenceEntry.fromJson(e as Map<String, dynamic>))
+      .toList();
+
+  /// `GET /current` returns `null` (or an empty payload) when idle; only build
+  /// a session from a non-empty object.
+  static ShoppingSession? _sessionOrNull(dynamic data) {
+    if (data == null) return null;
+    if (data is Map<String, dynamic>) {
+      if (data.isEmpty || data['id'] == null) return null;
+      return ShoppingSession.fromJson(data);
+    }
+    return null;
+  }
+
+  /// Extract the live/closed session the server echoes in a 409 body. The body
+  /// is the raw OCS envelope string; dig out `ocs.data`.
+  static ShoppingSession? _sessionFromErrorBody(ApiException e) {
+    try {
+      final decoded = jsonDecode(e.message);
+      final data = decoded is Map ? (decoded['ocs']?['data'] ?? decoded) : null;
+      if (data is Map<String, dynamic> && data['id'] != null) {
+        return ShoppingSession.fromJson(data);
+      }
+    } catch (_) {
+      // Not a JSON body / unexpected shape — caller falls back to the raw error.
+    }
+    return null;
+  }
+}
+
+/// Thrown by [ShoppingService.createSession] / [ShoppingService.close] on a 409,
+/// carrying the session the server returned so the UI can offer Resume / End.
+class ShoppingSessionConflict implements Exception {
+  final ShoppingSession session;
+  const ShoppingSessionConflict(this.session);
+
+  @override
+  String toString() => 'ShoppingSessionConflict(session ${session.id})';
+}

--- a/lib/sync/sync_executor.dart
+++ b/lib/sync/sync_executor.dart
@@ -5,6 +5,7 @@ import 'package:pantry/models/store.dart';
 import 'package:pantry/services/category_service.dart';
 import 'package:pantry/services/checklist_service.dart';
 import 'package:pantry/services/note_service.dart';
+import 'package:pantry/services/shopping_service.dart';
 import 'package:pantry/services/store_service.dart';
 import 'package:pantry/sync/sync_op.dart';
 
@@ -38,6 +39,28 @@ class SyncExecutor {
         return _executeStore(op);
       case SyncEntity.note:
         return _executeNote(op);
+      case SyncEntity.shoppingCheck:
+        return _executeShoppingCheck(op);
+    }
+  }
+
+  /// A Shopping Mode check-log write: `create` checks the item off, `delete`
+  /// reverses it. `parentId` is the session id, `entityId` the item id. Both
+  /// endpoints return only `{success:true}`, so there's no entity to bind.
+  Future<SyncResult> _executeShoppingCheck(SyncOp op) async {
+    final svc = ShoppingService.instance;
+    final sessionId = op.parentId;
+    final itemId = op.entityId;
+    if (sessionId == null || itemId == null) return SyncResult.empty;
+    switch (op.op) {
+      case SyncOpKind.create:
+        await svc.checkItem(op.houseId, sessionId, itemId);
+        return SyncResult.empty;
+      case SyncOpKind.delete:
+        await svc.uncheckItem(op.houseId, sessionId, itemId);
+        return SyncResult.empty;
+      default:
+        return SyncResult.empty;
     }
   }
 

--- a/lib/sync/sync_manager.dart
+++ b/lib/sync/sync_manager.dart
@@ -209,8 +209,26 @@ class SyncManager {
         case SyncEntity.category:
         case SyncEntity.store:
         case SyncEntity.note:
+        case SyncEntity.shoppingCheck:
           break;
       }
+    }
+    return out;
+  }
+
+  /// Item ids in [sessionId] that still have a pending Shopping Mode *check*
+  /// (create) op queued for [houseId]. The dense shopping view hides these from
+  /// its to-buy list so an un-synced offline check — or a still-flushing one —
+  /// isn't resurrected by a poll. Uncheck (delete) ops are excluded: they must
+  /// bring the item back, not hide it.
+  Set<int> pendingShoppingCheckedIds(int houseId, int sessionId) {
+    final out = <int>{};
+    for (final raw in _queue.all()) {
+      if (raw.entity != SyncEntity.shoppingCheck) continue;
+      if (raw.houseId != houseId || raw.parentId != sessionId) continue;
+      if (raw.op != SyncOpKind.create) continue;
+      final id = raw.entityId;
+      if (id != null) out.add(id);
     }
     return out;
   }
@@ -462,6 +480,10 @@ class SyncManager {
           );
         }
       case SyncEntity.note:
+        break;
+      case SyncEntity.shoppingCheck:
+        // Shopping checks reference real item/session ids, never a temp create,
+        // so they can't hold a dead reference.
         break;
     }
     return o;

--- a/lib/sync/sync_op.dart
+++ b/lib/sync/sync_op.dart
@@ -1,4 +1,16 @@
-enum SyncEntity { checklistList, checklistItem, category, store, note }
+enum SyncEntity {
+  checklistList,
+  checklistItem,
+  category,
+  store,
+  note,
+
+  /// A Shopping Mode item check-log write. [SyncOp.op] is [SyncOpKind.create]
+  /// for a check and [SyncOpKind.delete] for an uncheck; [SyncOp.entityId] is
+  /// the item id and [SyncOp.parentId] is the session id. Queued (not sent
+  /// direct) so checking items off survives spotty in-store connectivity.
+  shoppingCheck,
+}
 
 enum SyncOpKind {
   create,

--- a/lib/utils/color.dart
+++ b/lib/utils/color.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/material.dart';
+
+/// Parse a `#RRGGBB` / `RRGGBB` (or `#AARRGGBB`) hex string into a [Color],
+/// or null when the string is empty or malformed. Mirrors the inline parser
+/// used by the checklist item tile.
+Color? parseHexColor(String? hex) {
+  if (hex == null || hex.isEmpty) return null;
+  var h = hex.replaceFirst('#', '');
+  if (h.length == 6) h = 'FF$h';
+  final value = int.tryParse(h, radix: 16);
+  return value != null ? Color(value) : null;
+}

--- a/lib/views/checklists/checklists_controller.dart
+++ b/lib/views/checklists/checklists_controller.dart
@@ -2268,6 +2268,9 @@ class ChecklistsController extends ChangeNotifier {
           notifyListeners();
         }
       case SyncEntity.note:
+      case SyncEntity.shoppingCheck:
+        // Not surfaced in the checklists view — the shopping session controller
+        // reconciles its own check ops.
         break;
     }
   }

--- a/lib/views/checklists/checklists_view.dart
+++ b/lib/views/checklists/checklists_view.dart
@@ -307,18 +307,17 @@ class _BodyState extends State<_Body> with WidgetsBindingObserver {
     ChecklistsController controller,
     ChecklistList? list,
   ) {
-    final composeReserve = controller.isSoftView ? 0.0 : 76.0;
-    final fabShown =
-        hasFeature('shopping') &&
-        !controller.isSoftView &&
-        !controller.selectionMode;
+    if (controller.isSoftView) return 36;
+    // Clears the resting compose bar plus a little breathing room.
+    const composeReserve = 112.0;
+    final fabShown = hasFeature('shopping') && !controller.selectionMode;
     if (!fabShown) return composeReserve;
-    // Mirror the FAB's own bottom offset (88 above a compose bar, else 16),
-    // plus the extended FAB's height and a gap.
+    // The FAB's own bottom offset (88 above a compose bar, else 16) plus the
+    // extended FAB's height and a small gap.
     final fabBottom = (list != null && controller.canAddItemsHere)
         ? 88.0
         : 16.0;
-    final fabReserve = fabBottom + 64;
+    final fabReserve = fabBottom + 56 + 8;
     return fabReserve > composeReserve ? fabReserve : composeReserve;
   }
 
@@ -709,33 +708,29 @@ class _BodyState extends State<_Body> with WidgetsBindingObserver {
                             ? _NoMatchesEmptyState()
                             : Stack(
                                 children: [
-                                  Padding(
-                                    // Reserve enough room for the resting
-                                    // compose bar so the last item is always
-                                    // reachable without the bar overlapping it.
-                                    // Soft views (trash/archive) have no compose
-                                    // bar, so the reservation would just leave a
-                                    // blank bar at the bottom (issue #105).
-                                    padding: EdgeInsets.only(
-                                      bottom: _listBottomInset(
-                                        controller,
-                                        list,
-                                      ),
-                                    ),
-                                    child: _ItemList(
-                                      controller: controller,
-                                      activeItems: activeItems,
-                                      doneItems: doneItems,
-                                      canReorder: canReorder,
-                                      isCards: isCards,
-                                      doneCollapsed: doneCollapsed,
-                                      groupByCategory:
-                                          controller.sortBy == 'category',
-                                      onToggleDoneCollapsed: () =>
-                                          prefs.setChecklistDoneCollapsed(
-                                            !doneCollapsed,
-                                          ),
-                                      scrollController: widget.scrollController,
+                                  // The room for the resting compose bar and the
+                                  // floating shopping FAB is reserved as trailing
+                                  // scroll padding *inside* the list (not an outer
+                                  // gap), so items use the full viewport and are
+                                  // never clipped mid-list — the extra space only
+                                  // appears once scrolled to the bottom.
+                                  _ItemList(
+                                    controller: controller,
+                                    activeItems: activeItems,
+                                    doneItems: doneItems,
+                                    canReorder: canReorder,
+                                    isCards: isCards,
+                                    doneCollapsed: doneCollapsed,
+                                    groupByCategory:
+                                        controller.sortBy == 'category',
+                                    onToggleDoneCollapsed: () =>
+                                        prefs.setChecklistDoneCollapsed(
+                                          !doneCollapsed,
+                                        ),
+                                    scrollController: widget.scrollController,
+                                    bottomInset: _listBottomInset(
+                                      controller,
+                                      list,
                                     ),
                                   ),
                                   if (controller.isRefreshing)
@@ -2645,6 +2640,12 @@ class _ItemList extends StatefulWidget {
   final VoidCallback onToggleDoneCollapsed;
   final ScrollController? scrollController;
 
+  /// Extra scrollable space appended below the last item so the resting
+  /// compose bar / floating shopping FAB don't cover it once scrolled to the
+  /// bottom. Applied as trailing scroll padding (not an outer gap), so items
+  /// use the full viewport and are never clipped mid-list.
+  final double bottomInset;
+
   const _ItemList({
     required this.controller,
     required this.activeItems,
@@ -2655,6 +2656,7 @@ class _ItemList extends StatefulWidget {
     required this.groupByCategory,
     required this.onToggleDoneCollapsed,
     this.scrollController,
+    this.bottomInset = 0,
   });
 
   @override
@@ -2751,7 +2753,13 @@ class _ItemListState extends State<_ItemList> {
       }
     }
 
-    slivers.add(const SliverPadding(padding: EdgeInsets.only(bottom: 36)));
+    slivers.add(
+      SliverPadding(
+        padding: EdgeInsets.only(
+          bottom: widget.bottomInset > 36 ? widget.bottomInset : 36,
+        ),
+      ),
+    );
 
     return RefreshIndicator(
       onRefresh: widget.controller.refresh,

--- a/lib/views/checklists/checklists_view.dart
+++ b/lib/views/checklists/checklists_view.dart
@@ -13,11 +13,13 @@ import 'package:pantry/models/category.dart' as models;
 import 'package:pantry/models/store.dart' as models;
 import 'package:pantry/models/checklist.dart';
 import 'package:pantry/models/house.dart';
+import 'package:pantry/models/shopping_session.dart';
 import 'package:pantry/services/checklist_service.dart';
 import 'package:pantry/services/house_service.dart';
 import 'package:pantry/services/local_notifications_service.dart';
 import 'package:pantry/services/prefs_service.dart';
 import 'package:pantry/services/server_version_service.dart';
+import 'package:pantry/services/shopping_service.dart';
 import 'package:pantry/utils/category_icons.dart';
 import 'package:pantry/utils/checklist_icons.dart';
 import 'package:pantry/utils/currencies.dart';
@@ -25,8 +27,12 @@ import 'package:pantry/utils/item_modal_route.dart';
 import 'package:pantry/utils/price.dart';
 import 'package:pantry/utils/store_icons.dart';
 import 'package:pantry/utils/platform_info.dart';
+import 'package:pantry/utils/text_direction.dart';
 import 'package:pantry/utils/undo_snackbar.dart';
 import 'package:pantry/views/categories/categories_view.dart';
+import 'package:pantry/views/shopping/shopping_history_view.dart';
+import 'package:pantry/views/shopping/shopping_session_view.dart';
+import 'package:pantry/views/shopping/shopping_start_view.dart';
 import 'package:pantry/views/stores/stores_view.dart';
 import 'package:pantry/widgets/create_category_dialog.dart';
 import 'package:pantry/widgets/create_store_dialog.dart';
@@ -197,7 +203,7 @@ class _Body extends StatefulWidget {
   State<_Body> createState() => _BodyState();
 }
 
-class _BodyState extends State<_Body> {
+class _BodyState extends State<_Body> with WidgetsBindingObserver {
   bool _searchOpen = false;
   bool _composeActive = false;
   final _searchCtrl = TextEditingController();
@@ -217,12 +223,174 @@ class _BodyState extends State<_Body> {
   /// re-renders without leaking into other per-list views.
   int? _composeTargetListId;
 
+  /// The caller's live shopping session (any house), polled to drive the
+  /// resume banner and the Start/Resume FAB. Null when there's no live trip or
+  /// the server lacks the `shopping` capability.
+  ShoppingSession? _shoppingSession;
+
   String get _query => _searchCtrl.text.trim().toLowerCase();
 
   @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+    WidgetsBinding.instance.addPostFrameCallback(
+      (_) => _refreshShoppingSession(),
+    );
+  }
+
+  @override
   void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
     _searchCtrl.dispose();
     super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed) _refreshShoppingSession();
+  }
+
+  /// Re-fetch the caller's live session so the banner / FAB stay current.
+  /// Cheap and side-effect-free (`GET /current`); gated on the capability.
+  Future<void> _refreshShoppingSession() async {
+    if (!hasFeature('shopping')) return;
+    try {
+      final session = await ShoppingService.instance.getCurrentSession();
+      if (!mounted) return;
+      setState(
+        () => _shoppingSession = (session?.live ?? false) ? session : null,
+      );
+    } catch (_) {
+      /* keep the last-known state */
+    }
+  }
+
+  /// Open the shopping flow: resume the live session, or run the start screen
+  /// (which returns a freshly created session to navigate into). Refreshes the
+  /// banner / FAB on return.
+  Future<void> _openShopping(ChecklistsController controller) async {
+    final existing = _shoppingSession;
+    if (existing != null) {
+      await Navigator.of(context).push(
+        MaterialPageRoute(
+          builder: (_) => ShoppingSessionView(session: existing),
+        ),
+      );
+    } else {
+      final currentId = controller.currentList?.id;
+      final created = await Navigator.of(context).push<ShoppingSession?>(
+        MaterialPageRoute(
+          builder: (_) => ShoppingStartView(
+            houseId: controller.houseId,
+            preselectListId: (currentId != null && currentId > 0)
+                ? currentId
+                : null,
+          ),
+        ),
+      );
+      if (created != null && mounted) {
+        await Navigator.of(context).push(
+          MaterialPageRoute(
+            builder: (_) => ShoppingSessionView(session: created),
+          ),
+        );
+      }
+    }
+    await _refreshShoppingSession();
+  }
+
+  /// Bottom inset reserved under the item list so neither the resting compose
+  /// bar nor the floating Start/Resume-shopping FAB overlaps the last row. Takes
+  /// the larger of the two reservations that apply.
+  double _listBottomInset(
+    ChecklistsController controller,
+    ChecklistList? list,
+  ) {
+    final composeReserve = controller.isSoftView ? 0.0 : 76.0;
+    final fabShown =
+        hasFeature('shopping') &&
+        !controller.isSoftView &&
+        !controller.selectionMode;
+    if (!fabShown) return composeReserve;
+    // Mirror the FAB's own bottom offset (88 above a compose bar, else 16),
+    // plus the extended FAB's height and a gap.
+    final fabBottom = (list != null && controller.canAddItemsHere)
+        ? 88.0
+        : 16.0;
+    final fabReserve = fabBottom + 64;
+    return fabReserve > composeReserve ? fabReserve : composeReserve;
+  }
+
+  Future<void> _openShoppingHistory(ChecklistsController controller) async {
+    await Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => ShoppingHistoryView(houseId: controller.houseId),
+      ),
+    );
+    await _refreshShoppingSession();
+  }
+
+  /// The "you're shopping at {store} · [Resume]" banner shown atop the list
+  /// while a trip is live. Resolves the active store's name from the
+  /// controller's already-loaded store map.
+  Widget _buildResumeBanner(ChecklistsController controller) {
+    final session = _shoppingSession!;
+    final theme = Theme.of(context);
+    final cs = theme.colorScheme;
+    final activeId = session.activeStoreId;
+    final store = activeId != null ? controller.stores[activeId] : null;
+    final ordered = session.orderedStoreIds;
+    final idx = activeId != null ? ordered.indexOf(activeId) : -1;
+    final label = store != null
+        ? m.shopping.bannerShoppingAt(store.name)
+        : m.shopping.bannerShoppingNow;
+
+    return Material(
+      color: cs.primaryContainer,
+      child: InkWell(
+        onTap: () => _openShopping(controller),
+        child: Padding(
+          padding: const EdgeInsetsDirectional.symmetric(
+            horizontal: 16,
+            vertical: 10,
+          ),
+          child: Row(
+            children: [
+              Icon(Icons.shopping_cart, color: cs.onPrimaryContainer, size: 20),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      label,
+                      textDirection: detectTextDirection(store?.name),
+                      style: theme.textTheme.bodyMedium?.copyWith(
+                        color: cs.onPrimaryContainer,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                    if (idx >= 0 && ordered.length > 1)
+                      Text(
+                        m.shopping.bannerStoreProgress(idx + 1, ordered.length),
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: cs.onPrimaryContainer,
+                        ),
+                      ),
+                  ],
+                ),
+              ),
+              const SizedBox(width: 8),
+              FilledButton(
+                onPressed: () => _openShopping(controller),
+                child: Text(m.shopping.resume),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
   }
 
   List<ListItem> _applyFilters(List<ListItem> items, Set<int> selectedListIds) {
@@ -406,6 +574,9 @@ class _BodyState extends State<_Body> {
           children: [
             Column(
               children: [
+                // Live shopping trip in progress — offer a one-tap resume.
+                if (_shoppingSession != null && hasFeature('shopping'))
+                  _buildResumeBanner(controller),
                 // Animate the search row sliding/fading in and out below
                 // the AppBar instead of popping in instantly.
                 AnimatedSize(
@@ -546,7 +717,10 @@ class _BodyState extends State<_Body> {
                                     // bar, so the reservation would just leave a
                                     // blank bar at the bottom (issue #105).
                                     padding: EdgeInsets.only(
-                                      bottom: controller.isSoftView ? 0 : 76,
+                                      bottom: _listBottomInset(
+                                        controller,
+                                        list,
+                                      ),
                                     ),
                                     child: _ItemList(
                                       controller: controller,
@@ -716,6 +890,31 @@ class _BodyState extends State<_Body> {
                 end: 0,
                 bottom: 0,
                 child: _SelectionActionBar(controller: controller),
+              ),
+            // Start / resume shopping. Hidden in soft (trash/archive) and
+            // selection modes, and while the add-item sheet is active (it would
+            // float over the sheet); lifted above the resting compose bar.
+            if (hasFeature('shopping') &&
+                !controller.isSoftView &&
+                !controller.selectionMode &&
+                !_composeActive)
+              PositionedDirectional(
+                end: 16,
+                bottom: (list != null && controller.canAddItemsHere) ? 88 : 16,
+                child: FloatingActionButton.extended(
+                  heroTag: 'shopping-fab',
+                  onPressed: () => _openShopping(controller),
+                  icon: Icon(
+                    _shoppingSession != null
+                        ? Icons.play_arrow
+                        : Icons.shopping_cart,
+                  ),
+                  label: Text(
+                    _shoppingSession != null
+                        ? m.shopping.resumeShopping
+                        : m.shopping.startShopping,
+                  ),
+                ),
               ),
           ],
         );
@@ -1291,6 +1490,14 @@ class _BodyState extends State<_Body> {
             label: m.checklists.markdown.importTitle,
           ),
       ],
+      if (hasFeature('shopping')) ...[
+        const PopupMenuDivider(),
+        _menuRow(
+          value: 'shopping_history',
+          leading: const Icon(Icons.history, size: 18),
+          label: m.shopping.shoppingHistory,
+        ),
+      ],
       if (!PlatformInfo.isDesktop) ...[
         if (controller.permissions.canEditLists)
           _menuRow(
@@ -1440,6 +1647,8 @@ class _BodyState extends State<_Body> {
         await _openManageCategories(context, controller);
       case 'manage_stores':
         await _openManageStores(context, controller);
+      case 'shopping_history':
+        await _openShoppingHistory(controller);
       case 'export_markdown':
         await _openExport(context, controller);
       case 'import_markdown':

--- a/lib/views/onboarding/onboarding_pages.dart
+++ b/lib/views/onboarding/onboarding_pages.dart
@@ -15,6 +15,7 @@ import 'pages/pinned_notes_page.dart';
 import 'pages/progress_hero_dismiss_page.dart';
 import 'pages/progress_hero_page.dart';
 import 'pages/quick_actions_page.dart';
+import 'pages/shopping_mode_page.dart';
 import 'pages/swipe_actions_page.dart';
 
 /// The first app version that ships an onboarding flow. New users that haven't
@@ -134,6 +135,9 @@ final Map<String, List<OnboardingPageEntry>> kAppOnboardingPages = {
       showWhen: onboardingMobileOnly,
     ),
     OnboardingPageEntry(builder: (_) => const ItemPriceOnboardingPage()),
+  ],
+  '0.25.0': [
+    OnboardingPageEntry(builder: (_) => const ShoppingModeOnboardingPage()),
   ],
 };
 

--- a/lib/views/onboarding/pages/shopping_mode_page.dart
+++ b/lib/views/onboarding/pages/shopping_mode_page.dart
@@ -40,11 +40,73 @@ class ShoppingModeOnboardingPage extends StatelessWidget {
             ),
             textAlign: TextAlign.center,
           ),
-          const SizedBox(height: 32),
+          const SizedBox(height: 28),
+          // The Start-shopping FAB, with an arrow leading down into the screen
+          // it opens.
+          Align(
+            alignment: AlignmentDirectional.centerEnd,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.end,
+              children: [
+                const _MockFab(),
+                const SizedBox(height: 4),
+                Padding(
+                  padding: const EdgeInsetsDirectional.only(end: 24),
+                  child: Icon(
+                    Icons.arrow_downward_rounded,
+                    size: 30,
+                    color: cs.primary,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 6),
           const _MockShoppingCard(),
           const ServerRequirementNote(
             feature: 'shopping',
             requiredVersion: '0.25.0',
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// A static facsimile of the extended "Start shopping" FAB that lives on the
+/// checklists screen.
+class _MockFab extends StatelessWidget {
+  const _MockFab();
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 14),
+      decoration: BoxDecoration(
+        color: cs.primaryContainer,
+        borderRadius: BorderRadius.circular(16),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.2),
+            blurRadius: 8,
+            offset: const Offset(0, 3),
+          ),
+        ],
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(Icons.shopping_cart, size: 20, color: cs.onPrimaryContainer),
+          const SizedBox(width: 12),
+          Text(
+            m.shopping.startShopping,
+            style: TextStyle(
+              fontSize: 15,
+              fontWeight: FontWeight.w700,
+              color: cs.onPrimaryContainer,
+            ),
           ),
         ],
       ),

--- a/lib/views/onboarding/pages/shopping_mode_page.dart
+++ b/lib/views/onboarding/pages/shopping_mode_page.dart
@@ -1,0 +1,224 @@
+import 'package:flutter/material.dart';
+
+import 'package:pantry/i18n.dart';
+import 'package:pantry/views/onboarding/widgets/server_requirement_note.dart';
+
+/// Introduces Shopping Mode. Shows a mock of the dense shopping screen — a
+/// store bar with the active store, an "in cart" progress row, and a couple of
+/// category-grouped rows (one already checked) — so users recognise the
+/// walk-the-aisles flow. Always shown; when the server doesn't report the
+/// `shopping` capability, a footnote spells out the Pantry version it needs.
+class ShoppingModeOnboardingPage extends StatelessWidget {
+  const ShoppingModeOnboardingPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final cs = theme.colorScheme;
+    final ob = m.onboarding;
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(24, 16, 24, 16),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Text(
+            ob.shoppingIntroTitle,
+            style: theme.textTheme.headlineSmall?.copyWith(
+              fontWeight: FontWeight.w800,
+              letterSpacing: -0.3,
+            ),
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 12),
+          Text(
+            ob.shoppingIntroBody,
+            style: theme.textTheme.bodyMedium?.copyWith(
+              color: cs.onSurfaceVariant,
+              height: 1.4,
+            ),
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 32),
+          const _MockShoppingCard(),
+          const ServerRequirementNote(
+            feature: 'shopping',
+            requiredVersion: '0.25.0',
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// A compact, non-interactive facsimile of the dense shopping screen.
+class _MockShoppingCard extends StatelessWidget {
+  const _MockShoppingCard();
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return Container(
+      decoration: BoxDecoration(
+        color: cs.surface,
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: cs.outlineVariant),
+      ),
+      padding: const EdgeInsets.all(12),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          // Store bar: active store filled, next store dimmed.
+          Row(
+            children: [
+              _StorePill(
+                label: m.onboarding.shoppingMockStoreActive,
+                active: true,
+              ),
+              const SizedBox(width: 8),
+              _StorePill(
+                label: m.onboarding.shoppingMockStoreNext,
+                active: false,
+              ),
+            ],
+          ),
+          const SizedBox(height: 12),
+          // Progress row: "in cart" + bar.
+          Row(
+            children: [
+              Text(
+                m.shopping.inCart(3),
+                style: TextStyle(
+                  fontSize: 12,
+                  fontWeight: FontWeight.w700,
+                  color: cs.onSurfaceVariant,
+                ),
+              ),
+              const SizedBox(width: 10),
+              Expanded(
+                child: ClipRRect(
+                  borderRadius: BorderRadius.circular(4),
+                  child: LinearProgressIndicator(
+                    value: 0.6,
+                    minHeight: 6,
+                    backgroundColor: cs.surfaceContainerHighest,
+                    color: Colors.green,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 14),
+          // Category header + item rows.
+          _CategoryHeader(label: m.onboarding.mockItemCategory),
+          _ItemRow(label: m.onboarding.mockBulkItemThird, checked: false),
+          _ItemRow(label: m.onboarding.mockItemName, checked: true),
+        ],
+      ),
+    );
+  }
+}
+
+class _StorePill extends StatelessWidget {
+  final String label;
+  final bool active;
+
+  const _StorePill({required this.label, required this.active});
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return Opacity(
+      opacity: active ? 1 : 0.5,
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 7),
+        decoration: BoxDecoration(
+          color: active ? cs.primaryContainer : cs.surfaceContainerHighest,
+          borderRadius: BorderRadius.circular(20),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              Icons.storefront,
+              size: 15,
+              color: active ? cs.onPrimaryContainer : cs.onSurfaceVariant,
+            ),
+            const SizedBox(width: 6),
+            Text(
+              label,
+              style: TextStyle(
+                fontSize: 13,
+                fontWeight: FontWeight.w700,
+                color: active ? cs.onPrimaryContainer : cs.onSurface,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _CategoryHeader extends StatelessWidget {
+  final String label;
+
+  const _CategoryHeader({required this.label});
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 4),
+      child: Row(
+        children: [
+          Icon(Icons.local_offer_outlined, size: 14, color: cs.primary),
+          const SizedBox(width: 6),
+          Text(
+            label,
+            style: TextStyle(
+              fontSize: 12,
+              fontWeight: FontWeight.w700,
+              color: cs.primary,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ItemRow extends StatelessWidget {
+  final String label;
+  final bool checked;
+
+  const _ItemRow({required this.label, required this.checked});
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 7),
+      child: Row(
+        children: [
+          Icon(
+            checked ? Icons.check_circle : Icons.circle_outlined,
+            size: 20,
+            color: checked ? Colors.green : cs.outline,
+          ),
+          const SizedBox(width: 12),
+          Text(
+            label,
+            style: TextStyle(
+              fontSize: 15,
+              fontWeight: FontWeight.w600,
+              color: checked ? cs.onSurfaceVariant : cs.onSurface,
+              decoration: checked ? TextDecoration.lineThrough : null,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/views/shopping/shopping_history_view.dart
+++ b/lib/views/shopping/shopping_history_view.dart
@@ -1,0 +1,408 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+import 'package:pantry/i18n.dart';
+import 'package:pantry/models/shopping_estimate.dart';
+import 'package:pantry/models/shopping_history_row.dart';
+import 'package:pantry/models/store.dart';
+import 'package:pantry/services/house_service.dart';
+import 'package:pantry/services/shopping_service.dart';
+import 'package:pantry/services/store_service.dart';
+import 'package:pantry/utils/date_format.dart';
+import 'package:pantry/utils/text_direction.dart';
+import 'package:pantry/views/shopping/shopping_review_view.dart';
+import 'package:pantry/widgets/app_bar_back_leading.dart';
+import 'package:pantry/widgets/member_avatar.dart';
+
+/// Read-only list of closed trips (Phase 3). A Mine/House scope toggle selects
+/// which trips are shown; tapping a row opens its read-only per-store summary.
+class ShoppingHistoryView extends StatefulWidget {
+  final int houseId;
+
+  const ShoppingHistoryView({super.key, required this.houseId});
+
+  @override
+  State<ShoppingHistoryView> createState() => _ShoppingHistoryViewState();
+}
+
+class _ShoppingHistoryViewState extends State<ShoppingHistoryView> {
+  static const _pageSize = 30;
+  ShoppingService get _service => ShoppingService.instance;
+
+  ShoppingHistoryScope _scope = ShoppingHistoryScope.mine;
+  final List<ShoppingHistoryRow> _rows = [];
+  Map<int, Store> _stores = {};
+  Map<String, String> _memberNames = {};
+
+  bool _loading = true;
+  bool _loadingMore = false;
+  bool _hasMore = true;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    _stores = {
+      for (final s
+          in StoreService.instance.getCached(widget.houseId) ?? const [])
+        s.id: s,
+    };
+    _memberNames = {
+      for (final mm
+          in HouseService.instance.getCachedMembers(widget.houseId) ?? const [])
+        mm.userId: mm.displayName,
+    };
+    _reload();
+  }
+
+  Future<void> _reload() async {
+    setState(() {
+      _loading = true;
+      _error = null;
+      _rows.clear();
+      _hasMore = true;
+    });
+    // Refresh reference data best-effort (names/store labels on the cards).
+    unawaited(_loadReferenceData());
+    await _fetch(reset: true);
+  }
+
+  Future<void> _loadReferenceData() async {
+    try {
+      final stores = await StoreService.instance.getStores(widget.houseId);
+      final members = await HouseService.instance.getMembers(widget.houseId);
+      if (!mounted) return;
+      setState(() {
+        _stores = {for (final s in stores) s.id: s};
+        _memberNames = {for (final mm in members) mm.userId: mm.displayName};
+      });
+    } catch (_) {
+      /* keep cached */
+    }
+  }
+
+  Future<void> _fetch({bool reset = false}) async {
+    try {
+      final rows = await _service.getHistory(
+        widget.houseId,
+        scope: _scope,
+        limit: _pageSize,
+        offset: reset ? 0 : _rows.length,
+      );
+      if (!mounted) return;
+      setState(() {
+        _rows.addAll(rows);
+        _hasMore = rows.length == _pageSize;
+        _loading = false;
+        _loadingMore = false;
+      });
+    } catch (_) {
+      if (!mounted) return;
+      setState(() {
+        _loading = false;
+        _loadingMore = false;
+        if (_rows.isEmpty) _error = m.shopping.loadFailed;
+      });
+    }
+  }
+
+  Future<void> _loadMore() async {
+    if (_loadingMore || !_hasMore) return;
+    setState(() => _loadingMore = true);
+    await _fetch();
+  }
+
+  void _setScope(ShoppingHistoryScope scope) {
+    if (scope == _scope) return;
+    setState(() => _scope = scope);
+    _reload();
+  }
+
+  Future<void> _openSummary(ShoppingHistoryRow row) async {
+    await Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => ShoppingReviewView(
+          houseId: widget.houseId,
+          sessionId: row.id,
+          mode: ShoppingReviewMode.history,
+          stores: _stores,
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        leading: appBarBackLeading(context),
+        title: Text(m.shopping.historyTitle),
+      ),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(12),
+            child: SegmentedButton<ShoppingHistoryScope>(
+              segments: [
+                ButtonSegment(
+                  value: ShoppingHistoryScope.mine,
+                  label: Text(m.shopping.scopeMine),
+                ),
+                ButtonSegment(
+                  value: ShoppingHistoryScope.house,
+                  label: Text(m.shopping.scopeHouse),
+                ),
+              ],
+              selected: {_scope},
+              onSelectionChanged: (s) => _setScope(s.first),
+            ),
+          ),
+          Expanded(child: _buildBody()),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildBody() {
+    if (_loading) return const Center(child: CircularProgressIndicator());
+    if (_error != null) {
+      return _ErrorRetry(message: _error!, onRetry: _reload);
+    }
+    if (_rows.isEmpty) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(32),
+          child: Text(
+            _scope == ShoppingHistoryScope.mine
+                ? m.shopping.noTripsYet
+                : m.shopping.noHouseTripsYet,
+            textAlign: TextAlign.center,
+            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+            ),
+          ),
+        ),
+      );
+    }
+    return RefreshIndicator(
+      onRefresh: _reload,
+      child: ListView.builder(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+        itemCount: _rows.length + (_hasMore ? 1 : 0),
+        itemBuilder: (context, index) {
+          if (index >= _rows.length) {
+            return Padding(
+              padding: const EdgeInsets.all(12),
+              child: Center(
+                child: _loadingMore
+                    ? const CircularProgressIndicator()
+                    : OutlinedButton(
+                        onPressed: _loadMore,
+                        child: Text(m.shopping.loadMore),
+                      ),
+              ),
+            );
+          }
+          return _HistoryCard(
+            row: _rows[index],
+            memberName: _memberNames[_rows[index].userId],
+            onTap: () => _openSummary(_rows[index]),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _HistoryCard extends StatelessWidget {
+  final ShoppingHistoryRow row;
+  final String? memberName;
+  final VoidCallback onTap;
+
+  const _HistoryCard({
+    required this.row,
+    required this.memberName,
+    required this.onTap,
+  });
+
+  /// Human trip duration (createdAt → closedAt), or null when still open.
+  String? get _duration {
+    final closed = row.closedAt;
+    if (closed == null) return null;
+    final secs = closed - row.createdAt;
+    if (secs < 60) return '${secs < 0 ? 0 : secs}s';
+    final mins = (secs / 60).round();
+    if (mins < 60) return '${mins}m';
+    final h = mins ~/ 60;
+    final rem = mins % 60;
+    return rem == 0 ? '${h}h' : '${h}h ${rem}m';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final total = formatCurrencyAmounts(row.grandTotal);
+    final when = row.closedAt ?? row.createdAt;
+    final duration = _duration;
+    final timeLabel = duration == null
+        ? formatDate(when)
+        : '${formatDate(when)} · $duration';
+
+    return Card(
+      margin: const EdgeInsets.symmetric(vertical: 4),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(12),
+        child: Padding(
+          padding: const EdgeInsets.all(12),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              MemberAvatar(
+                userId: row.userId,
+                displayName: memberName ?? row.userId,
+                size: 32,
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    _StorePath(stores: row.stores),
+                    const SizedBox(height: 4),
+                    Wrap(
+                      spacing: 8,
+                      runSpacing: 4,
+                      crossAxisAlignment: WrapCrossAlignment.center,
+                      children: [
+                        _Chip(icon: Icons.schedule, label: timeLabel),
+                        _Chip(
+                          icon: Icons.check_circle_outline,
+                          label: m.shopping.itemsCount(row.itemCount),
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(width: 8),
+              Container(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 10,
+                  vertical: 6,
+                ),
+                decoration: BoxDecoration(
+                  color: theme.colorScheme.secondaryContainer,
+                  borderRadius: BorderRadius.circular(16),
+                ),
+                child: Text(
+                  total ?? '—',
+                  style: theme.textTheme.labelLarge?.copyWith(
+                    color: theme.colorScheme.onSecondaryContainer,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// The store visit path ("A → B → C") rendered with Material arrow icons
+/// between store names, or the "no store" label when the trip was storeless.
+class _StorePath extends StatelessWidget {
+  final List<String> stores;
+
+  const _StorePath({required this.stores});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    if (stores.isEmpty) {
+      return Text(m.shopping.noStorePath, style: theme.textTheme.titleSmall);
+    }
+    return Wrap(
+      spacing: 4,
+      runSpacing: 2,
+      crossAxisAlignment: WrapCrossAlignment.center,
+      children: [
+        for (var i = 0; i < stores.length; i++) ...[
+          if (i > 0)
+            Icon(
+              Icons.arrow_right_alt,
+              size: 16,
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          Text(
+            stores[i],
+            textDirection: detectTextDirection(stores[i]),
+            style: theme.textTheme.titleSmall,
+          ),
+        ],
+      ],
+    );
+  }
+}
+
+class _Chip extends StatelessWidget {
+  final IconData icon;
+  final String label;
+
+  const _Chip({required this.icon, required this.label});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final cs = theme.colorScheme;
+    return Container(
+      padding: const EdgeInsetsDirectional.symmetric(
+        horizontal: 8,
+        vertical: 4,
+      ),
+      decoration: BoxDecoration(
+        color: cs.surfaceContainerHighest,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 14, color: cs.onSurfaceVariant),
+          const SizedBox(width: 4),
+          Text(
+            label,
+            style: theme.textTheme.labelSmall?.copyWith(
+              color: cs.onSurfaceVariant,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ErrorRetry extends StatelessWidget {
+  final String message;
+  final VoidCallback onRetry;
+
+  const _ErrorRetry({required this.message, required this.onRetry});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(message, textAlign: TextAlign.center),
+            const SizedBox(height: 16),
+            FilledButton(onPressed: onRetry, child: Text(m.common.retry)),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/views/shopping/shopping_reminder_block.dart
+++ b/lib/views/shopping/shopping_reminder_block.dart
@@ -1,0 +1,123 @@
+import 'package:flutter/material.dart';
+
+import 'package:pantry/i18n.dart';
+import 'package:pantry/models/shopping_reminder.dart';
+import 'package:pantry/utils/text_direction.dart';
+
+/// A non-blocking, inline block that surfaces the enabled reminders for one
+/// moment (start / advance / close). Acknowledgement is **client-local only** —
+/// ticking a reminder strikes it through for this render and never persists.
+///
+/// [reminders] must already be filtered to `enabled` and ordered by position;
+/// the caller owns the filtering. [onManage] opens the reminders manager.
+class ShoppingReminderBlock extends StatefulWidget {
+  final List<ShoppingReminder> reminders;
+  final VoidCallback? onManage;
+
+  const ShoppingReminderBlock({
+    super.key,
+    required this.reminders,
+    this.onManage,
+  });
+
+  @override
+  State<ShoppingReminderBlock> createState() => _ShoppingReminderBlockState();
+}
+
+class _ShoppingReminderBlockState extends State<ShoppingReminderBlock> {
+  final Set<int> _acked = {};
+
+  @override
+  Widget build(BuildContext context) {
+    if (widget.reminders.isEmpty) return const SizedBox.shrink();
+    final theme = Theme.of(context);
+    final cs = theme.colorScheme;
+
+    return Card(
+      margin: EdgeInsets.zero,
+      color: cs.surfaceContainerHighest,
+      elevation: 0,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(Icons.notifications_none, size: 20, color: cs.primary),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    m.shopping.remindersTitle,
+                    style: theme.textTheme.titleSmall,
+                  ),
+                ),
+                if (widget.onManage != null)
+                  IconButton(
+                    visualDensity: VisualDensity.compact,
+                    icon: const Icon(Icons.edit_outlined, size: 18),
+                    tooltip: m.shopping.manageReminders,
+                    onPressed: widget.onManage,
+                  ),
+              ],
+            ),
+            for (final r in widget.reminders)
+              _ReminderRow(
+                text: r.text,
+                acked: _acked.contains(r.id),
+                onToggle: () => setState(() {
+                  if (!_acked.remove(r.id)) _acked.add(r.id);
+                }),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ReminderRow extends StatelessWidget {
+  final String text;
+  final bool acked;
+  final VoidCallback onToggle;
+
+  const _ReminderRow({
+    required this.text,
+    required this.acked,
+    required this.onToggle,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return InkWell(
+      onTap: onToggle,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 4),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Icon(
+              acked ? Icons.check_circle : Icons.circle_outlined,
+              size: 20,
+              color: acked
+                  ? theme.colorScheme.primary
+                  : theme.colorScheme.onSurfaceVariant,
+            ),
+            const SizedBox(width: 8),
+            Expanded(
+              child: Text(
+                text,
+                textDirection: detectTextDirection(text),
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  decoration: acked ? TextDecoration.lineThrough : null,
+                  color: acked ? theme.colorScheme.onSurfaceVariant : null,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/views/shopping/shopping_reminders_view.dart
+++ b/lib/views/shopping/shopping_reminders_view.dart
@@ -1,0 +1,459 @@
+import 'package:flutter/material.dart';
+
+import 'package:pantry/i18n.dart';
+import 'package:pantry/models/shopping_reminder.dart';
+import 'package:pantry/services/shopping_service.dart';
+import 'package:pantry/utils/text_direction.dart';
+import 'package:pantry/widgets/app_bar_back_leading.dart';
+
+/// Full-screen manager for a house's shopping reminders. Three fixed-order
+/// groups by moment (start / between shops / end); each reminder row can be
+/// toggled, edited inline, moved to another moment, deleted, and reordered
+/// within its group. An add form sits at the bottom of each group.
+class ShoppingRemindersView extends StatefulWidget {
+  final int houseId;
+
+  const ShoppingRemindersView({super.key, required this.houseId});
+
+  @override
+  State<ShoppingRemindersView> createState() => _ShoppingRemindersViewState();
+}
+
+class _ShoppingRemindersViewState extends State<ShoppingRemindersView> {
+  ShoppingService get _service => ShoppingService.instance;
+
+  List<ShoppingReminder> _reminders = [];
+  bool _loading = true;
+  String? _error;
+
+  // One text controller per reminder id, so inline edits keep their cursor.
+  final Map<int, TextEditingController> _textControllers = {};
+
+  @override
+  void initState() {
+    super.initState();
+    final cached = _service.getCachedReminders(widget.houseId);
+    if (cached != null) {
+      _reminders = cached;
+      _loading = false;
+    }
+    _load();
+  }
+
+  @override
+  void dispose() {
+    for (final c in _textControllers.values) {
+      c.dispose();
+    }
+    super.dispose();
+  }
+
+  Future<void> _load() async {
+    try {
+      final reminders = await _service.getReminders(widget.houseId);
+      if (!mounted) return;
+      setState(() {
+        _reminders = reminders;
+        _loading = false;
+        _error = null;
+      });
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _loading = false;
+        if (_reminders.isEmpty) _error = m.shopping.loadFailed;
+      });
+    }
+  }
+
+  List<ShoppingReminder> _group(ShoppingReminderMoment moment) =>
+      (_reminders.where((r) => r.showOn == moment).toList()
+        ..sort((a, b) => a.position.compareTo(b.position)));
+
+  TextEditingController _controllerFor(ShoppingReminder r) {
+    final existing = _textControllers[r.id];
+    if (existing != null) {
+      if (existing.text != r.text &&
+          !existing.selection.isValid &&
+          FocusManager.instance.primaryFocus?.hasFocus != true) {
+        existing.text = r.text;
+      }
+      return existing;
+    }
+    return _textControllers[r.id] = TextEditingController(text: r.text);
+  }
+
+  void _replace(ShoppingReminder updated) {
+    setState(() {
+      _reminders = [
+        for (final r in _reminders) r.id == updated.id ? updated : r,
+      ];
+    });
+  }
+
+  Future<void> _persistUpdate(
+    ShoppingReminder r, {
+    String? text,
+    ShoppingReminderMoment? showOn,
+    bool? enabled,
+  }) async {
+    // Optimistic; revert to a reload on failure.
+    _replace(r.copyWith(text: text, showOn: showOn, enabled: enabled));
+    try {
+      final updated = await _service.updateReminder(
+        widget.houseId,
+        r.id,
+        text: text,
+        showOn: showOn,
+        enabled: enabled,
+      );
+      _replace(updated);
+    } catch (_) {
+      _showError(m.shopping.reminderSaveFailed);
+      await _load();
+    }
+  }
+
+  Future<void> _delete(ShoppingReminder r) async {
+    setState(() => _reminders = _reminders.where((x) => x.id != r.id).toList());
+    _textControllers.remove(r.id)?.dispose();
+    try {
+      await _service.deleteReminder(widget.houseId, r.id);
+    } catch (_) {
+      _showError(m.shopping.reminderDeleteFailed);
+      await _load();
+    }
+  }
+
+  Future<void> _add(String text, ShoppingReminderMoment moment) async {
+    final trimmed = text.trim();
+    if (trimmed.isEmpty) return;
+    try {
+      final created = await _service.createReminder(
+        widget.houseId,
+        text: trimmed,
+        showOn: moment,
+      );
+      if (!mounted) return;
+      setState(() => _reminders = [..._reminders, created]);
+    } catch (_) {
+      _showError(m.shopping.reminderSaveFailed);
+    }
+  }
+
+  Future<void> _reorderWithin(
+    ShoppingReminderMoment moment,
+    int oldIndex,
+    int newIndex,
+  ) async {
+    final group = _group(moment);
+    if (newIndex > oldIndex) newIndex--;
+    if (oldIndex == newIndex) return;
+    final moved = group.removeAt(oldIndex);
+    group.insert(newIndex, moved);
+
+    // Rebuild the full ordered id list across all groups (fixed group order)
+    // so positions come out consistent, then persist in one call.
+    final ordered = <ShoppingReminder>[];
+    for (final mm in ShoppingReminderMoment.values) {
+      ordered.addAll(mm == moment ? group : _group(mm));
+    }
+    setState(() {
+      _reminders = [
+        for (var i = 0; i < ordered.length; i++)
+          ordered[i].copyWith(position: i),
+      ];
+    });
+    try {
+      final result = await _service.reorderReminders(
+        widget.houseId,
+        ordered.map((r) => r.id).toList(),
+      );
+      if (!mounted) return;
+      setState(() => _reminders = result);
+    } catch (_) {
+      _showError(m.shopping.reminderSaveFailed);
+      await _load();
+    }
+  }
+
+  void _showError(String message) {
+    if (!mounted) return;
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(SnackBar(content: Text(message)));
+  }
+
+  String _momentLabel(ShoppingReminderMoment moment) => switch (moment) {
+    ShoppingReminderMoment.onStart => m.shopping.reminderGroupStart,
+    ShoppingReminderMoment.onStoreAdvance => m.shopping.reminderGroupAdvance,
+    ShoppingReminderMoment.onClose => m.shopping.reminderGroupEnd,
+  };
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        leading: appBarBackLeading(context),
+        title: Text(m.shopping.remindersTitle),
+      ),
+      body: _loading && _reminders.isEmpty
+          ? const Center(child: CircularProgressIndicator())
+          : _error != null && _reminders.isEmpty
+          ? _ErrorRetry(message: _error!, onRetry: _load)
+          : ListView(
+              padding: const EdgeInsets.symmetric(vertical: 8),
+              children: [
+                for (final moment in ShoppingReminderMoment.values)
+                  _MomentGroup(
+                    label: _momentLabel(moment),
+                    reminders: _group(moment),
+                    controllerFor: _controllerFor,
+                    momentLabelFor: _momentLabel,
+                    onReorder: (o, n) => _reorderWithin(moment, o, n),
+                    onToggle: (r, v) => _persistUpdate(r, enabled: v),
+                    onEditText: (r, t) {
+                      if (t.trim().isNotEmpty && t.trim() != r.text) {
+                        _persistUpdate(r, text: t.trim());
+                      }
+                    },
+                    onChangeMoment: (r, mm) => _persistUpdate(r, showOn: mm),
+                    onDelete: _delete,
+                    onAdd: (t) => _add(t, moment),
+                  ),
+              ],
+            ),
+    );
+  }
+}
+
+class _MomentGroup extends StatefulWidget {
+  final String label;
+  final List<ShoppingReminder> reminders;
+  final TextEditingController Function(ShoppingReminder) controllerFor;
+  final String Function(ShoppingReminderMoment) momentLabelFor;
+  final void Function(int oldIndex, int newIndex) onReorder;
+  final void Function(ShoppingReminder, bool) onToggle;
+  final void Function(ShoppingReminder, String) onEditText;
+  final void Function(ShoppingReminder, ShoppingReminderMoment) onChangeMoment;
+  final void Function(ShoppingReminder) onDelete;
+  final void Function(String) onAdd;
+
+  const _MomentGroup({
+    required this.label,
+    required this.reminders,
+    required this.controllerFor,
+    required this.momentLabelFor,
+    required this.onReorder,
+    required this.onToggle,
+    required this.onEditText,
+    required this.onChangeMoment,
+    required this.onDelete,
+    required this.onAdd,
+  });
+
+  @override
+  State<_MomentGroup> createState() => _MomentGroupState();
+}
+
+class _MomentGroupState extends State<_MomentGroup> {
+  final _addCtrl = TextEditingController();
+
+  @override
+  void dispose() {
+    _addCtrl.dispose();
+    super.dispose();
+  }
+
+  void _submitAdd() {
+    final text = _addCtrl.text;
+    if (text.trim().isEmpty) return;
+    widget.onAdd(text);
+    _addCtrl.clear();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsetsDirectional.only(
+            start: 16,
+            end: 16,
+            top: 16,
+            bottom: 4,
+          ),
+          child: Text(
+            widget.label,
+            style: theme.textTheme.titleSmall?.copyWith(
+              color: theme.colorScheme.primary,
+            ),
+          ),
+        ),
+        if (widget.reminders.isEmpty)
+          Padding(
+            padding: const EdgeInsetsDirectional.only(
+              start: 16,
+              end: 16,
+              bottom: 4,
+            ),
+            child: Text(
+              m.shopping.noRemindersHere,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+          )
+        else
+          ReorderableListView.builder(
+            shrinkWrap: true,
+            physics: const NeverScrollableScrollPhysics(),
+            buildDefaultDragHandles: false,
+            itemCount: widget.reminders.length,
+            onReorder: widget.onReorder,
+            itemBuilder: (context, index) {
+              final r = widget.reminders[index];
+              return _ReminderEditRow(
+                key: ValueKey(r.id),
+                index: index,
+                reminder: r,
+                controller: widget.controllerFor(r),
+                momentLabelFor: widget.momentLabelFor,
+                onToggle: (v) => widget.onToggle(r, v),
+                onEditText: (t) => widget.onEditText(r, t),
+                onChangeMoment: (mm) => widget.onChangeMoment(r, mm),
+                onDelete: () => widget.onDelete(r),
+              );
+            },
+          ),
+        Padding(
+          padding: const EdgeInsetsDirectional.only(
+            start: 16,
+            end: 8,
+            top: 4,
+            bottom: 8,
+          ),
+          child: Row(
+            children: [
+              Expanded(
+                child: TextField(
+                  controller: _addCtrl,
+                  textDirection: detectTextDirection(_addCtrl.text),
+                  decoration: InputDecoration(
+                    isDense: true,
+                    hintText: m.shopping.addReminderHint,
+                    border: const OutlineInputBorder(),
+                  ),
+                  onSubmitted: (_) => _submitAdd(),
+                ),
+              ),
+              const SizedBox(width: 8),
+              FilledButton.tonal(
+                onPressed: _submitAdd,
+                child: Text(m.shopping.add),
+              ),
+            ],
+          ),
+        ),
+        const Divider(height: 1),
+      ],
+    );
+  }
+}
+
+class _ReminderEditRow extends StatelessWidget {
+  final int index;
+  final ShoppingReminder reminder;
+  final TextEditingController controller;
+  final String Function(ShoppingReminderMoment) momentLabelFor;
+  final ValueChanged<bool> onToggle;
+  final ValueChanged<String> onEditText;
+  final ValueChanged<ShoppingReminderMoment> onChangeMoment;
+  final VoidCallback onDelete;
+
+  const _ReminderEditRow({
+    super.key,
+    required this.index,
+    required this.reminder,
+    required this.controller,
+    required this.momentLabelFor,
+    required this.onToggle,
+    required this.onEditText,
+    required this.onChangeMoment,
+    required this.onDelete,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsetsDirectional.only(start: 4, end: 8, top: 2),
+      child: Row(
+        children: [
+          ReorderableDragStartListener(
+            index: index,
+            child: const Padding(
+              padding: EdgeInsets.all(8),
+              child: Icon(Icons.drag_handle, size: 20),
+            ),
+          ),
+          Switch(value: reminder.enabled, onChanged: onToggle),
+          const SizedBox(width: 4),
+          Expanded(
+            child: TextField(
+              controller: controller,
+              textDirection: detectTextDirection(controller.text),
+              style: Theme.of(context).textTheme.bodyMedium,
+              decoration: const InputDecoration(
+                isDense: true,
+                border: InputBorder.none,
+              ),
+              onTapOutside: (_) => onEditText(controller.text),
+              onEditingComplete: () => onEditText(controller.text),
+            ),
+          ),
+          PopupMenuButton<ShoppingReminderMoment>(
+            icon: const Icon(Icons.schedule, size: 20),
+            tooltip: m.shopping.reminderWhen,
+            initialValue: reminder.showOn,
+            onSelected: onChangeMoment,
+            itemBuilder: (context) => [
+              for (final mm in ShoppingReminderMoment.values)
+                PopupMenuItem(value: mm, child: Text(momentLabelFor(mm))),
+            ],
+          ),
+          IconButton(
+            visualDensity: VisualDensity.compact,
+            icon: const Icon(Icons.delete_outline, size: 20),
+            onPressed: onDelete,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ErrorRetry extends StatelessWidget {
+  final String message;
+  final VoidCallback onRetry;
+
+  const _ErrorRetry({required this.message, required this.onRetry});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(message, textAlign: TextAlign.center),
+            const SizedBox(height: 16),
+            FilledButton(onPressed: onRetry, child: Text(m.common.retry)),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/views/shopping/shopping_review_view.dart
+++ b/lib/views/shopping/shopping_review_view.dart
@@ -1,0 +1,519 @@
+import 'package:flutter/material.dart';
+
+import 'package:pantry/i18n.dart';
+import 'package:pantry/models/checklist.dart';
+import 'package:pantry/models/shopping_estimate.dart';
+import 'package:pantry/models/shopping_reminder.dart';
+import 'package:pantry/models/shopping_review.dart';
+import 'package:pantry/models/store.dart';
+import 'package:pantry/services/shopping_service.dart';
+import 'package:pantry/utils/color.dart';
+import 'package:pantry/utils/currencies.dart';
+import 'package:pantry/utils/price.dart';
+import 'package:pantry/utils/store_icons.dart';
+import 'package:pantry/utils/text_direction.dart';
+import 'package:pantry/views/shopping/shopping_reminder_block.dart';
+import 'package:pantry/widgets/app_bar_back_leading.dart';
+
+/// Which review the screen renders. [advance] shows only the store being left
+/// (a till summary before moving on); [close] shows the whole trip with
+/// editable totals and a confirm to finish; [history] is a read-only past trip.
+enum ShoppingReviewMode { advance, close, history }
+
+/// Full-screen review of a trip. Loads `…/review` (live) or `…/summary`
+/// (history). Pops `true` when the user confirms the transition (advance /
+/// finish); billed-total edits are persisted independently as they happen.
+class ShoppingReviewView extends StatefulWidget {
+  final int houseId;
+  final int sessionId;
+  final ShoppingReviewMode mode;
+
+  /// The active store being left, for [ShoppingReviewMode.advance] narrowing.
+  final int? activeStoreId;
+  final Map<int, Store> stores;
+
+  /// Reminders for the moment surfaced at the top (advance → on_store_advance,
+  /// close → on_close). Already filtered to enabled and ordered.
+  final List<ShoppingReminder> reminders;
+  final VoidCallback? onManageReminders;
+
+  const ShoppingReviewView({
+    super.key,
+    required this.houseId,
+    required this.sessionId,
+    required this.mode,
+    required this.stores,
+    this.activeStoreId,
+    this.reminders = const [],
+    this.onManageReminders,
+  });
+
+  @override
+  State<ShoppingReviewView> createState() => _ShoppingReviewViewState();
+}
+
+class _ShoppingReviewViewState extends State<ShoppingReviewView> {
+  ShoppingService get _service => ShoppingService.instance;
+  bool get _readOnly => widget.mode == ShoppingReviewMode.history;
+
+  ShoppingReview? _review;
+  bool _loading = true;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
+    try {
+      final review = widget.mode == ShoppingReviewMode.history
+          ? await _service.getSummary(widget.houseId, widget.sessionId)
+          : await _service.getReview(widget.houseId, widget.sessionId);
+      if (!mounted) return;
+      setState(() {
+        _review = review;
+        _loading = false;
+      });
+    } catch (_) {
+      if (!mounted) return;
+      setState(() {
+        _loading = false;
+        _error = m.shopping.loadFailed;
+      });
+    }
+  }
+
+  /// The store groups to render. In advance mode, only the store being left.
+  List<ShoppingReviewStore> get _visibleStores {
+    final all = _review?.stores ?? const [];
+    if (widget.mode != ShoppingReviewMode.advance) return all;
+    return all.where((s) => s.storeId == widget.activeStoreId).toList();
+  }
+
+  Future<void> _saveBilled(
+    ShoppingReviewStore store,
+    double? total,
+    String currency,
+  ) async {
+    try {
+      if (store.storeId == null) {
+        await _service.setSessionBilled(
+          widget.houseId,
+          widget.sessionId,
+          billedTotal: total,
+          billedCurrency: total == null ? null : currency,
+        );
+      } else {
+        await _service.setStoreBilled(
+          widget.houseId,
+          widget.sessionId,
+          store.storeId!,
+          billedTotal: total,
+          billedCurrency: total == null ? null : currency,
+        );
+      }
+    } catch (_) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text(m.shopping.saveTotalFailed)));
+    }
+  }
+
+  String get _title => switch (widget.mode) {
+    ShoppingReviewMode.advance => m.shopping.advanceTitle,
+    ShoppingReviewMode.close => m.shopping.reviewTitle,
+    ShoppingReviewMode.history => m.shopping.reviewTitle,
+  };
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Scaffold(
+      appBar: AppBar(leading: appBarBackLeading(context), title: Text(_title)),
+      body: _loading
+          ? const Center(child: CircularProgressIndicator())
+          : _error != null
+          ? _ErrorRetry(message: _error!, onRetry: _load)
+          : ListView(
+              padding: const EdgeInsets.all(16),
+              children: [
+                if (widget.reminders.isNotEmpty) ...[
+                  ShoppingReminderBlock(
+                    reminders: widget.reminders,
+                    onManage: widget.onManageReminders,
+                  ),
+                  const SizedBox(height: 16),
+                ],
+                for (final store in _visibleStores) ...[
+                  _StoreSection(
+                    store: store,
+                    storeName: _storeName(store.storeId),
+                    storeColor: _storeColor(store.storeId),
+                    storeIconData: _storeIcon(store.storeId),
+                    readOnly: _readOnly,
+                    onSaveBilled: (total, currency) =>
+                        _saveBilled(store, total, currency),
+                  ),
+                  const SizedBox(height: 16),
+                ],
+                if (widget.mode != ShoppingReviewMode.advance)
+                  _GrandTotal(review: _review!),
+              ],
+            ),
+      bottomNavigationBar: _readOnly
+          ? null
+          : SafeArea(
+              child: Padding(
+                padding: const EdgeInsets.all(12),
+                child: Row(
+                  children: [
+                    Expanded(
+                      child: OutlinedButton(
+                        onPressed: () => Navigator.of(context).pop(false),
+                        child: Text(m.common.cancel),
+                      ),
+                    ),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: FilledButton.icon(
+                        onPressed: _loading
+                            ? null
+                            : () => Navigator.of(context).pop(true),
+                        icon: Icon(
+                          widget.mode == ShoppingReviewMode.advance
+                              ? Icons.arrow_forward
+                              : Icons.flag,
+                        ),
+                        label: Text(
+                          widget.mode == ShoppingReviewMode.advance
+                              ? m.shopping.nextStore
+                              : m.shopping.finishTrip,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+      backgroundColor: theme.colorScheme.surface,
+    );
+  }
+
+  String _storeName(int? storeId) {
+    if (storeId == null) return m.shopping.anyStore;
+    return widget.stores[storeId]?.name ?? m.shopping.anyStore;
+  }
+
+  Color? _storeColor(int? storeId) =>
+      storeId == null ? null : parseHexColor(widget.stores[storeId]?.color);
+
+  IconData _storeIcon(int? storeId) =>
+      storeIcon(storeId == null ? null : widget.stores[storeId]?.icon);
+}
+
+class _StoreSection extends StatefulWidget {
+  final ShoppingReviewStore store;
+  final String storeName;
+  final Color? storeColor;
+  final IconData storeIconData;
+  final bool readOnly;
+  final void Function(double? total, String currency) onSaveBilled;
+
+  const _StoreSection({
+    required this.store,
+    required this.storeName,
+    required this.storeColor,
+    required this.storeIconData,
+    required this.readOnly,
+    required this.onSaveBilled,
+  });
+
+  @override
+  State<_StoreSection> createState() => _StoreSectionState();
+}
+
+class _StoreSectionState extends State<_StoreSection> {
+  late final TextEditingController _billedCtrl;
+  late String _currency;
+
+  @override
+  void initState() {
+    super.initState();
+    final billed = widget.store.billedTotal;
+    _billedCtrl = TextEditingController(
+      text: billed == null ? '' : _trim(billed),
+    );
+    _currency =
+        widget.store.billedCurrency ??
+        (widget.store.estimate.isNotEmpty
+            ? widget.store.estimate.first.currency
+            : defaultCurrency);
+  }
+
+  static String _trim(double v) {
+    if (v == v.truncateToDouble()) return v.toInt().toString();
+    return v.toString();
+  }
+
+  @override
+  void dispose() {
+    _billedCtrl.dispose();
+    super.dispose();
+  }
+
+  void _persist() {
+    final raw = _billedCtrl.text.trim().replaceAll(',', '.');
+    final parsed = raw.isEmpty ? null : double.tryParse(raw);
+    widget.onSaveBilled(parsed, _currency);
+  }
+
+  /// The bare estimate figure(s) used as the billed field's placeholder.
+  String get _estimateHint {
+    final est = widget.store.estimate;
+    if (est.isEmpty) return '';
+    final r = est.first;
+    return r.min == r.max ? _trim(r.min) : '${_trim(r.min)}–${_trim(r.max)}';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final cs = theme.colorScheme;
+    final store = widget.store;
+    final estimateLabel = formatShoppingEstimate(store.estimate);
+
+    return Card(
+      margin: EdgeInsets.zero,
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(
+                  widget.storeIconData,
+                  color: widget.storeColor ?? cs.primary,
+                  size: 22,
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    widget.storeName,
+                    textDirection: detectTextDirection(widget.storeName),
+                    style: theme.textTheme.titleMedium,
+                  ),
+                ),
+                if (estimateLabel != null)
+                  Text(
+                    estimateLabel,
+                    style: theme.textTheme.titleSmall?.copyWith(
+                      color: cs.onSurfaceVariant,
+                    ),
+                  ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            for (final item in store.items) _ReviewItemRow(item: item),
+            if (store.noPriceCount > 0)
+              Padding(
+                padding: const EdgeInsets.only(top: 4),
+                child: Text(
+                  m.shopping.itemsWithoutPrice(store.noPriceCount),
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: cs.onSurfaceVariant,
+                  ),
+                ),
+              ),
+            if (!widget.readOnly) ...[
+              const SizedBox(height: 12),
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.end,
+                children: [
+                  Expanded(
+                    flex: 2,
+                    child: TextField(
+                      controller: _billedCtrl,
+                      keyboardType: const TextInputType.numberWithOptions(
+                        decimal: true,
+                      ),
+                      decoration: InputDecoration(
+                        isDense: true,
+                        labelText: m.shopping.actualPaid,
+                        hintText: _estimateHint,
+                        border: const OutlineInputBorder(),
+                      ),
+                      onTapOutside: (_) => _persist(),
+                      onEditingComplete: _persist,
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: DropdownButtonFormField<String>(
+                      initialValue: _currency,
+                      isExpanded: true,
+                      decoration: const InputDecoration(
+                        isDense: true,
+                        border: OutlineInputBorder(),
+                      ),
+                      items: [
+                        // Keep an unknown server-supplied code selectable so
+                        // the dropdown's value always matches exactly one item.
+                        if (currencyByCode(_currency) == null)
+                          DropdownMenuItem(
+                            value: _currency,
+                            child: Text(
+                              _currency,
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                          ),
+                        for (final c in currencies)
+                          DropdownMenuItem(
+                            value: c.code,
+                            child: Text(
+                              '${c.code} ${c.symbol}',
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                          ),
+                      ],
+                      onChanged: (v) {
+                        if (v == null) return;
+                        setState(() => _currency = v);
+                        _persist();
+                      },
+                    ),
+                  ),
+                ],
+              ),
+            ] else if (store.billedTotal != null)
+              Padding(
+                padding: const EdgeInsets.only(top: 8),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Text(
+                      m.shopping.actualPaid,
+                      style: theme.textTheme.bodyMedium?.copyWith(
+                        color: cs.onSurfaceVariant,
+                      ),
+                    ),
+                    Text(
+                      CurrencyAmount(
+                        currency: store.billedCurrency ?? defaultCurrency,
+                        amount: store.billedTotal!,
+                      ).label,
+                      style: theme.textTheme.titleSmall,
+                    ),
+                  ],
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ReviewItemRow extends StatelessWidget {
+  final ListItem item;
+
+  const _ReviewItemRow({required this.item});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final price = item.formattedPrice;
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 3),
+      child: Row(
+        children: [
+          Expanded(
+            child: Text(
+              item.name,
+              textDirection: detectTextDirection(item.name),
+              style: theme.textTheme.bodyMedium,
+            ),
+          ),
+          if (price != null)
+            Text(
+              price,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                fontFeatures: const [],
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _GrandTotal extends StatelessWidget {
+  final ShoppingReview review;
+
+  const _GrandTotal({required this.review});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final total = formatShoppingEstimate(review.grandTotal);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text(m.shopping.grandTotal, style: theme.textTheme.titleMedium),
+            Text(
+              total ?? '—',
+              style: theme.textTheme.titleMedium?.copyWith(
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+          ],
+        ),
+        if (review.uncheckedCount > 0)
+          Padding(
+            padding: const EdgeInsets.only(top: 4),
+            child: Text(
+              m.shopping.itemsStillUnchecked(review.uncheckedCount),
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+class _ErrorRetry extends StatelessWidget {
+  final String message;
+  final VoidCallback onRetry;
+
+  const _ErrorRetry({required this.message, required this.onRetry});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(message, textAlign: TextAlign.center),
+            const SizedBox(height: 16),
+            FilledButton(onPressed: onRetry, child: Text(m.common.retry)),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/views/shopping/shopping_session_controller.dart
+++ b/lib/views/shopping/shopping_session_controller.dart
@@ -1,0 +1,324 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+
+import 'package:pantry/i18n.dart';
+import 'package:pantry/models/category.dart' as models;
+import 'package:pantry/models/checklist.dart';
+import 'package:pantry/models/member.dart';
+import 'package:pantry/models/shopping_presence_entry.dart';
+import 'package:pantry/models/shopping_reminder.dart';
+import 'package:pantry/models/shopping_review.dart';
+import 'package:pantry/models/shopping_session.dart';
+import 'package:pantry/models/store.dart';
+import 'package:pantry/services/auth_service.dart';
+import 'package:pantry/services/category_service.dart';
+import 'package:pantry/services/house_service.dart';
+import 'package:pantry/services/shopping_service.dart';
+import 'package:pantry/services/store_service.dart';
+
+/// A contiguous run of items under one category, for the grouped dense view.
+/// [category] is null for the Uncategorized run (always rendered last, matching
+/// the server's ordering).
+class ShoppingItemGroup {
+  final models.Category? category;
+  final List<ListItem> items;
+
+  const ShoppingItemGroup({required this.category, required this.items});
+}
+
+/// Drives the live dense shopping screen: the store-narrowed to-buy list, the
+/// done-today tally, and house presence. Polls items + heartbeat + done-today
+/// together; checking an item is optimistic and reconciled on the next poll.
+class ShoppingSessionController extends ChangeNotifier {
+  ShoppingSessionController({required ShoppingSession session})
+    : _session = session,
+      houseId = session.houseId;
+
+  final int houseId;
+  ShoppingService get _service => ShoppingService.instance;
+
+  ShoppingSession _session;
+  ShoppingSession get session => _session;
+  int get sessionId => _session.id;
+
+  List<ListItem> _items = [];
+  List<ListItem> get items => _items;
+
+  ShoppingDoneToday? _doneToday;
+  ShoppingDoneToday? get doneToday => _doneToday;
+  int get inCartCount => _doneToday?.count ?? 0;
+
+  List<ShoppingPresenceEntry> _presence = [];
+  List<ShoppingPresenceEntry> get presence => _presence;
+
+  Map<int, models.Category> _categories = {};
+  Map<int, Store> _stores = {};
+  Map<int, Store> get stores => _stores;
+
+  Map<String, Member> _members = {};
+  Map<String, Member> get members => _members;
+
+  List<ShoppingReminder> _reminders = [];
+
+  /// Enabled reminders for a moment, in position order — surfaced on advance /
+  /// close. Empty until reminders load.
+  List<ShoppingReminder> remindersFor(ShoppingReminderMoment moment) =>
+      (_reminders.where((r) => r.enabled && r.showOn == moment).toList()
+        ..sort((a, b) => a.position.compareTo(b.position)));
+
+  final String? currentUserId = AuthService.instance.credentials?.loginName;
+
+  bool _loading = true;
+  bool get isLoading => _loading;
+  String? _error;
+  String? get error => _error;
+
+  bool _disposed = false;
+
+  @override
+  void dispose() {
+    _disposed = true;
+    super.dispose();
+  }
+
+  @override
+  void notifyListeners() {
+    if (_disposed) return;
+    super.notifyListeners();
+  }
+
+  /// Progress across the trip: checked (in cart) vs the sum of checked plus
+  /// what's still to buy at the active store. Approximated from done-today
+  /// (single-trip-per-day is the common case) to avoid a heavy review poll.
+  double get progress {
+    final total = inCartCount + _items.length;
+    if (total == 0) return 0;
+    return inCartCount / total;
+  }
+
+  /// The store legs in position order — backs the sticky store bar.
+  List<ShoppingSessionStore> get orderedStores {
+    final list = [..._session.stores]
+      ..sort((a, b) => a.position.compareTo(b.position));
+    return list;
+  }
+
+  /// Position of the active store, or -1 when none is chosen. Store pills at a
+  /// lower position render as "past".
+  int get activePosition {
+    final active = _session.activeStoreId;
+    if (active == null) return -1;
+    return _session.stores
+            .cast<ShoppingSessionStore?>()
+            .firstWhere((s) => s!.storeId == active, orElse: () => null)
+            ?.position ??
+        -1;
+  }
+
+  /// Other shoppers attributed to [storeId] (self excluded) — the avatar stack
+  /// on each store pill.
+  List<ShoppingPresenceEntry> presenceAt(int storeId) => [
+    for (final p in _presence)
+      if (p.activeStoreId == storeId && p.userId != currentUserId) p,
+  ];
+
+  /// Items grouped into contiguous category runs, preserving the server order
+  /// (category.sortOrder, item.sortOrder; Uncategorized last).
+  List<ShoppingItemGroup> get groupedItems {
+    final groups = <ShoppingItemGroup>[];
+    int? runCategoryId;
+    var run = <ListItem>[];
+    void flush() {
+      if (run.isEmpty) return;
+      groups.add(
+        ShoppingItemGroup(category: _categories[runCategoryId], items: run),
+      );
+      run = [];
+    }
+
+    for (final item in _items) {
+      if (groups.isEmpty && run.isEmpty) {
+        runCategoryId = item.categoryId;
+      } else if (item.categoryId != runCategoryId) {
+        flush();
+        runCategoryId = item.categoryId;
+      }
+      run.add(item);
+    }
+    flush();
+    return groups;
+  }
+
+  Future<void> load() async {
+    _loading = _items.isEmpty;
+    notifyListeners();
+
+    // Reference data (cache-first, best-effort) — never fatal.
+    _categories = {
+      for (final c in CategoryService.instance.getCached(houseId) ?? const [])
+        c.id: c,
+    };
+    _stores = {
+      for (final s in StoreService.instance.getCached(houseId) ?? const [])
+        s.id: s,
+    };
+    _members = {
+      for (final mm
+          in HouseService.instance.getCachedMembers(houseId) ?? const [])
+        mm.userId: mm,
+    };
+    _reminders = _service.getCachedReminders(houseId) ?? _reminders;
+
+    unawaited(_loadReferenceData());
+
+    try {
+      // A session with stores but no active store yet: land on the first so
+      // the item list is narrowed to somewhere sensible.
+      if (_session.stores.isNotEmpty && _session.activeStoreId == null) {
+        try {
+          _session = await _service.advance(
+            houseId,
+            sessionId,
+            storeId: orderedStores.first.storeId,
+          );
+        } catch (e) {
+          debugPrint('[ShoppingSessionController] auto-advance failed: $e');
+        }
+      }
+      await _refreshLiveData(includeHeartbeat: true);
+      _error = null;
+    } catch (_) {
+      if (_items.isEmpty) _error = m.shopping.loadItemsFailed;
+    } finally {
+      _loading = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> _loadReferenceData() async {
+    try {
+      final results = await Future.wait([
+        CategoryService.instance.getCategories(houseId),
+        StoreService.instance.getStores(houseId),
+        HouseService.instance.getMembers(houseId),
+        _service.getReminders(houseId).catchError((_) => <ShoppingReminder>[]),
+      ]);
+      _categories = {
+        for (final c in results[0] as List<models.Category>) c.id: c,
+      };
+      _stores = {for (final s in results[1] as List<Store>) s.id: s};
+      _members = {for (final mm in results[2] as List<Member>) mm.userId: mm};
+      _reminders = results[3] as List<ShoppingReminder>;
+      notifyListeners();
+    } catch (e) {
+      debugPrint('[ShoppingSessionController] reference load failed: $e');
+    }
+  }
+
+  /// Poll: refresh the item list, stamp a heartbeat (returns presence), and
+  /// refresh the done-today tally. Called ~1 min while focused.
+  Future<void> poll() async {
+    try {
+      await _refreshLiveData(includeHeartbeat: true);
+    } catch (e) {
+      debugPrint('[ShoppingSessionController] poll failed: $e');
+    }
+  }
+
+  Future<void> _refreshLiveData({required bool includeHeartbeat}) async {
+    final results = await Future.wait([
+      _service.getItems(houseId, sessionId),
+      _service.getDoneToday(houseId),
+      if (includeHeartbeat)
+        _service.heartbeat(houseId)
+      else
+        _service.getPresence(houseId),
+    ]);
+    _items = results[0] as List<ListItem>;
+    _doneToday = results[1] as ShoppingDoneToday;
+    _presence = results[2] as List<ShoppingPresenceEntry>;
+    notifyListeners();
+  }
+
+  /// Optimistically remove [item] and record the check; reconcile on the next
+  /// fetch. On failure, re-fetch to restore.
+  Future<void> checkItem(ListItem item) async {
+    _items = _items.where((i) => i.id != item.id).toList();
+    notifyListeners();
+    try {
+      await _service.checkItem(houseId, sessionId, item.id);
+      await _refreshLiveData(includeHeartbeat: false);
+    } catch (e) {
+      debugPrint('[ShoppingSessionController] check failed: $e');
+      await _refreshLiveData(includeHeartbeat: false).catchError((_) {});
+      rethrow;
+    }
+  }
+
+  /// Move to [storeId] and adopt the returned session (new active store, so the
+  /// next item fetch is narrowed differently).
+  Future<void> advance(int storeId) async {
+    _session = await _service.advance(houseId, sessionId, storeId: storeId);
+    notifyListeners();
+    await _refreshLiveData(includeHeartbeat: false);
+  }
+
+  Future<void> setPrivacy(bool isPrivate) async {
+    final previous = _session;
+    _session = ShoppingSessionPrivacy.withPrivacy(_session, isPrivate);
+    notifyListeners();
+    try {
+      _session = await _service.setPrivacy(
+        houseId,
+        sessionId,
+        isPrivate: isPrivate,
+      );
+      notifyListeners();
+    } catch (e) {
+      debugPrint('[ShoppingSessionController] privacy toggle failed: $e');
+      _session = previous;
+      notifyListeners();
+      rethrow;
+    }
+  }
+
+  Future<ShoppingSession> close() async {
+    _session = await _service.close(houseId, sessionId);
+    notifyListeners();
+    return _session;
+  }
+
+  /// Refresh the session DTO from the server (e.g. after billed edits on the
+  /// review screen) so the store bar reflects any changes.
+  Future<void> refreshSession() async {
+    final current = await _service.getCurrentSession();
+    if (current != null && current.id == sessionId) {
+      _session = current;
+      notifyListeners();
+    }
+  }
+}
+
+/// Copy a session with a new privacy flag without a full [ShoppingSession]
+/// copyWith (the DTO is otherwise immutable-by-construction here).
+extension ShoppingSessionPrivacy on ShoppingSession {
+  static ShoppingSession withPrivacy(ShoppingSession s, bool isPrivate) =>
+      ShoppingSession(
+        id: s.id,
+        houseId: s.houseId,
+        userId: s.userId,
+        listIds: s.listIds,
+        stores: s.stores,
+        activeStoreId: s.activeStoreId,
+        includeUnassigned: s.includeUnassigned,
+        isPrivate: isPrivate,
+        billedTotal: s.billedTotal,
+        billedCurrency: s.billedCurrency,
+        lastSeenAt: s.lastSeenAt,
+        live: s.live,
+        closedAt: s.closedAt,
+        createdAt: s.createdAt,
+        updatedAt: s.updatedAt,
+      );
+}

--- a/lib/views/shopping/shopping_session_controller.dart
+++ b/lib/views/shopping/shopping_session_controller.dart
@@ -16,6 +16,9 @@ import 'package:pantry/services/category_service.dart';
 import 'package:pantry/services/house_service.dart';
 import 'package:pantry/services/shopping_service.dart';
 import 'package:pantry/services/store_service.dart';
+import 'package:pantry/sync/sync_ids.dart';
+import 'package:pantry/sync/sync_manager.dart';
+import 'package:pantry/sync/sync_op.dart';
 
 /// A contiguous run of items under one category, for the grouped dense view.
 /// [category] is null for the Uncategorized run (always rendered last, matching
@@ -75,11 +78,39 @@ class ShoppingSessionController extends ChangeNotifier {
   String? get error => _error;
 
   bool _disposed = false;
+  StreamSubscription<SyncOpApplied>? _appliedSub;
+  StreamSubscription<SyncOpSkipped>? _skippedSub;
 
   @override
   void dispose() {
     _disposed = true;
+    _appliedSub?.cancel();
+    _skippedSub?.cancel();
     super.dispose();
+  }
+
+  bool _isOwnCheckOp(SyncOp op) =>
+      op.entity == SyncEntity.shoppingCheck &&
+      op.houseId == houseId &&
+      op.parentId == sessionId;
+
+  /// Watch the sync queue so a check that flushes (or gets dropped) reconciles
+  /// this view promptly instead of waiting for the next ~1-min poll.
+  void _bindSync() {
+    _appliedSub ??= SyncManager.instance.onApplied.listen((e) {
+      // A check landed on the server — refresh the done-today tally so the
+      // in-cart count / drawer catch up. The item list is already optimistic.
+      if (_isOwnCheckOp(e.op)) unawaited(_refreshDoneToday());
+    });
+    _skippedSub ??= SyncManager.instance.onSkipped.listen((e) {
+      // A check was dropped (e.g. the session closed, or a 4xx) — un-hide the
+      // item so it returns to the list on the next fetch.
+      if (_isOwnCheckOp(e.op) && e.op.op == SyncOpKind.create) {
+        final id = e.op.entityId;
+        if (id != null) _checkedPending.remove(id);
+        unawaited(_refreshLiveData(includeHeartbeat: false).catchError((_) {}));
+      }
+    });
   }
 
   @override
@@ -151,6 +182,7 @@ class ShoppingSessionController extends ChangeNotifier {
   }
 
   Future<void> load() async {
+    _bindSync();
     _loading = _items.isEmpty;
     notifyListeners();
 
@@ -226,6 +258,13 @@ class ShoppingSessionController extends ChangeNotifier {
     }
   }
 
+  /// Items checked locally whose removal the server hasn't caught up to yet.
+  /// The check endpoint and the item query are eventually consistent, so an
+  /// immediate re-fetch can still return a just-checked item as unchecked —
+  /// which would make it flicker back onto the list. We hide these ids from any
+  /// fetch result until a fetch stops returning them (server confirmed).
+  final Set<int> _checkedPending = {};
+
   Future<void> _refreshLiveData({required bool includeHeartbeat}) async {
     final results = await Future.wait([
       _service.getItems(houseId, sessionId),
@@ -235,25 +274,54 @@ class ShoppingSessionController extends ChangeNotifier {
       else
         _service.getPresence(houseId),
     ]);
-    _items = results[0] as List<ListItem>;
+    final fetched = results[0] as List<ListItem>;
+    // Hide any item with a pending check op (offline / still flushing) plus any
+    // we optimistically checked that the server still returns (eventual
+    // consistency). Drop an id from the hidden set only once it is neither
+    // queue-pending nor still listed by the server — i.e. fully confirmed gone.
+    final queuePending = SyncManager.instance.pendingShoppingCheckedIds(
+      houseId,
+      sessionId,
+    );
+    _checkedPending.removeWhere(
+      (id) => !queuePending.contains(id) && !fetched.any((i) => i.id == id),
+    );
+    _checkedPending.addAll(queuePending);
+    _items = fetched.where((i) => !_checkedPending.contains(i.id)).toList();
     _doneToday = results[1] as ShoppingDoneToday;
     _presence = results[2] as List<ShoppingPresenceEntry>;
     notifyListeners();
   }
 
-  /// Optimistically remove [item] and record the check; reconcile on the next
-  /// fetch. On failure, re-fetch to restore.
+  Future<void> _refreshDoneToday() async {
+    try {
+      _doneToday = await _service.getDoneToday(houseId);
+      notifyListeners();
+    } catch (e) {
+      debugPrint('[ShoppingSessionController] done-today refresh failed: $e');
+    }
+  }
+
+  /// Optimistically remove [item] and enqueue the check on the sync queue, so
+  /// it survives offline / spotty in-store connectivity and flushes when
+  /// possible. The id is held in [_checkedPending] (and reflected in the queue)
+  /// so an eventually-consistent re-fetch can't flicker it back; the sync
+  /// subscriptions reconcile once the op lands or is dropped.
   Future<void> checkItem(ListItem item) async {
+    _checkedPending.add(item.id);
     _items = _items.where((i) => i.id != item.id).toList();
     notifyListeners();
-    try {
-      await _service.checkItem(houseId, sessionId, item.id);
-      await _refreshLiveData(includeHeartbeat: false);
-    } catch (e) {
-      debugPrint('[ShoppingSessionController] check failed: $e');
-      await _refreshLiveData(includeHeartbeat: false).catchError((_) {});
-      rethrow;
-    }
+    SyncManager.instance.enqueue(
+      SyncOp(
+        uuid: SyncIds.newOpUuid(),
+        entity: SyncEntity.shoppingCheck,
+        op: SyncOpKind.create,
+        houseId: houseId,
+        entityId: item.id,
+        parentId: sessionId,
+        createdAt: DateTime.now().millisecondsSinceEpoch,
+      ),
+    );
   }
 
   /// Move to [storeId] and adopt the returned session (new active store, so the

--- a/lib/views/shopping/shopping_session_controller.dart
+++ b/lib/views/shopping/shopping_session_controller.dart
@@ -6,6 +6,7 @@ import 'package:pantry/i18n.dart';
 import 'package:pantry/models/category.dart' as models;
 import 'package:pantry/models/checklist.dart';
 import 'package:pantry/models/member.dart';
+import 'package:pantry/models/shopping_estimate.dart';
 import 'package:pantry/models/shopping_presence_entry.dart';
 import 'package:pantry/models/shopping_reminder.dart';
 import 'package:pantry/models/shopping_review.dart';
@@ -30,8 +31,8 @@ class ShoppingItemGroup {
   const ShoppingItemGroup({required this.category, required this.items});
 }
 
-/// Drives the live dense shopping screen: the store-narrowed to-buy list, the
-/// done-today tally, and house presence. Polls items + heartbeat + done-today
+/// Drives the live dense shopping screen: the store-narrowed to-buy list, this
+/// session's checked log, and house presence. Polls items + review + heartbeat
 /// together; checking an item is optimistic and reconciled on the next poll.
 class ShoppingSessionController extends ChangeNotifier {
   ShoppingSessionController({required ShoppingSession session})
@@ -48,9 +49,22 @@ class ShoppingSessionController extends ChangeNotifier {
   List<ListItem> _items = [];
   List<ListItem> get items => _items;
 
-  ShoppingDoneToday? _doneToday;
-  ShoppingDoneToday? get doneToday => _doneToday;
-  int get inCartCount => _doneToday?.count ?? 0;
+  /// This session's checked log (server-computed, grouped by store). Drives the
+  /// Done drawer and the in-cart count. Deliberately session-scoped via
+  /// [ShoppingService.getReview] rather than the house/day `done-today` tally,
+  /// which would fold in items checked on earlier trips today.
+  ShoppingReview? _review;
+
+  /// Flat list of everything checked off on this trip, for the Done drawer.
+  List<ListItem> get doneItems => [
+    for (final s in _review?.stores ?? const <ShoppingReviewStore>[])
+      ...s.items,
+  ];
+
+  /// Per-currency estimate of this trip's checked items — the Done drawer total.
+  ShoppingEstimate get doneEstimate => _review?.grandTotal ?? const [];
+
+  int get inCartCount => doneItems.length;
 
   List<ShoppingPresenceEntry> _presence = [];
   List<ShoppingPresenceEntry> get presence => _presence;
@@ -98,9 +112,9 @@ class ShoppingSessionController extends ChangeNotifier {
   /// this view promptly instead of waiting for the next ~1-min poll.
   void _bindSync() {
     _appliedSub ??= SyncManager.instance.onApplied.listen((e) {
-      // A check landed on the server — refresh the done-today tally so the
-      // in-cart count / drawer catch up. The item list is already optimistic.
-      if (_isOwnCheckOp(e.op)) unawaited(_refreshDoneToday());
+      // A check landed on the server — refresh the session review so the Done
+      // drawer / in-cart count catch up. The item list is already optimistic.
+      if (_isOwnCheckOp(e.op)) unawaited(_refreshReview());
     });
     _skippedSub ??= SyncManager.instance.onSkipped.listen((e) {
       // A check was dropped (e.g. the session closed, or a 4xx) — un-hide the
@@ -120,8 +134,8 @@ class ShoppingSessionController extends ChangeNotifier {
   }
 
   /// Progress across the trip: checked (in cart) vs the sum of checked plus
-  /// what's still to buy at the active store. Approximated from done-today
-  /// (single-trip-per-day is the common case) to avoid a heavy review poll.
+  /// what's still to buy at the active store. Both come from this session only
+  /// (the review), so a second trip on the same day starts back at zero.
   double get progress {
     final total = inCartCount + _items.length;
     if (total == 0) return 0;
@@ -268,7 +282,7 @@ class ShoppingSessionController extends ChangeNotifier {
   Future<void> _refreshLiveData({required bool includeHeartbeat}) async {
     final results = await Future.wait([
       _service.getItems(houseId, sessionId),
-      _service.getDoneToday(houseId),
+      _service.getReview(houseId, sessionId),
       if (includeHeartbeat)
         _service.heartbeat(houseId)
       else
@@ -288,17 +302,19 @@ class ShoppingSessionController extends ChangeNotifier {
     );
     _checkedPending.addAll(queuePending);
     _items = fetched.where((i) => !_checkedPending.contains(i.id)).toList();
-    _doneToday = results[1] as ShoppingDoneToday;
+    _review = results[1] as ShoppingReview;
     _presence = results[2] as List<ShoppingPresenceEntry>;
     notifyListeners();
   }
 
-  Future<void> _refreshDoneToday() async {
+  /// Refresh just this session's checked log (the Done drawer / in-cart count)
+  /// — used after a check lands so the tally catches up without a full poll.
+  Future<void> _refreshReview() async {
     try {
-      _doneToday = await _service.getDoneToday(houseId);
+      _review = await _service.getReview(houseId, sessionId);
       notifyListeners();
     } catch (e) {
-      debugPrint('[ShoppingSessionController] done-today refresh failed: $e');
+      debugPrint('[ShoppingSessionController] review refresh failed: $e');
     }
   }
 

--- a/lib/views/shopping/shopping_session_view.dart
+++ b/lib/views/shopping/shopping_session_view.dart
@@ -626,11 +626,9 @@ class _BottomBar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final done = controller.doneToday;
-    final doneCount = done?.count ?? 0;
-    final estimate = done != null
-        ? formatShoppingEstimate(done.estimate)
-        : null;
+    final doneItems = controller.doneItems;
+    final doneCount = doneItems.length;
+    final estimate = formatShoppingEstimate(controller.doneEstimate);
 
     return SafeArea(
       top: false,
@@ -671,13 +669,13 @@ class _BottomBar extends StatelessWidget {
                 ),
               ),
             ),
-            if (doneExpanded && done != null)
+            if (doneExpanded)
               ConstrainedBox(
                 constraints: const BoxConstraints(maxHeight: 220),
                 child: ListView(
                   shrinkWrap: true,
                   children: [
-                    for (final item in done.items)
+                    for (final item in doneItems)
                       ListTile(
                         dense: true,
                         leading: Icon(

--- a/lib/views/shopping/shopping_session_view.dart
+++ b/lib/views/shopping/shopping_session_view.dart
@@ -1,0 +1,721 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import 'package:pantry/i18n.dart';
+import 'package:pantry/models/category.dart';
+import 'package:pantry/models/checklist.dart';
+import 'package:pantry/models/shopping_estimate.dart';
+import 'package:pantry/models/shopping_presence_entry.dart';
+import 'package:pantry/models/shopping_reminder.dart';
+import 'package:pantry/models/shopping_session.dart';
+import 'package:pantry/utils/category_icons.dart';
+import 'package:pantry/utils/color.dart';
+import 'package:pantry/utils/price.dart';
+import 'package:pantry/utils/store_icons.dart';
+import 'package:pantry/utils/text_direction.dart';
+import 'package:pantry/views/shopping/shopping_reminders_view.dart';
+import 'package:pantry/views/shopping/shopping_review_view.dart';
+import 'package:pantry/views/shopping/shopping_session_controller.dart';
+import 'package:pantry/widgets/app_bar_back_leading.dart';
+import 'package:pantry/widgets/member_avatar.dart';
+
+/// The live, dense shopping screen. Owns the ~1-min poll (items + heartbeat +
+/// done-today), paused while the app is backgrounded and fired on resume.
+class ShoppingSessionView extends StatefulWidget {
+  final ShoppingSession session;
+
+  const ShoppingSessionView({super.key, required this.session});
+
+  @override
+  State<ShoppingSessionView> createState() => _ShoppingSessionViewState();
+}
+
+class _ShoppingSessionViewState extends State<ShoppingSessionView> {
+  late final _controller = ShoppingSessionController(session: widget.session);
+
+  @override
+  void initState() {
+    super.initState();
+    _controller.load();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ChangeNotifierProvider.value(
+      value: _controller,
+      child: const _SessionBody(),
+    );
+  }
+}
+
+class _SessionBody extends StatefulWidget {
+  const _SessionBody();
+
+  @override
+  State<_SessionBody> createState() => _SessionBodyState();
+}
+
+class _SessionBodyState extends State<_SessionBody>
+    with WidgetsBindingObserver {
+  static const _pollInterval = Duration(seconds: 60);
+  Timer? _timer;
+  bool _doneExpanded = false;
+  bool _busy = false;
+
+  ShoppingSessionController get _c => context.read<ShoppingSessionController>();
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+    _startTimer();
+  }
+
+  @override
+  void dispose() {
+    _stopTimer();
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  void _startTimer() {
+    _timer?.cancel();
+    _timer = Timer.periodic(_pollInterval, (_) => _c.poll());
+  }
+
+  void _stopTimer() {
+    _timer?.cancel();
+    _timer = null;
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    switch (state) {
+      case AppLifecycleState.resumed:
+        _c.poll();
+        _startTimer();
+      case AppLifecycleState.hidden:
+      case AppLifecycleState.paused:
+      case AppLifecycleState.detached:
+        _stopTimer();
+      case AppLifecycleState.inactive:
+        break;
+    }
+  }
+
+  Future<void> _check(ListItem item) async {
+    try {
+      await _c.checkItem(item);
+    } catch (_) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text(m.shopping.checkFailed)));
+    }
+  }
+
+  Future<void> _jumpToStore(int storeId) async {
+    if (storeId == _c.session.activeStoreId) return;
+    try {
+      await _c.advance(storeId);
+    } catch (_) {
+      /* poll will reconcile */
+    }
+  }
+
+  Future<void> _togglePrivacy() async {
+    try {
+      await _c.setPrivacy(!_c.session.isPrivate);
+    } catch (_) {
+      /* reverted in controller */
+    }
+  }
+
+  Future<void> _openReminders() async {
+    await Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => ShoppingRemindersView(houseId: _c.houseId),
+      ),
+    );
+  }
+
+  /// FAB action: review the current store, then advance to the next store or
+  /// finish the trip.
+  Future<void> _reviewAndProceed() async {
+    if (_busy) return;
+    final controller = _c;
+    final session = controller.session;
+    final nextStoreId = session.nextStoreId;
+    final isAdvance = nextStoreId != null;
+    final mode = isAdvance
+        ? ShoppingReviewMode.advance
+        : ShoppingReviewMode.close;
+    final moment = isAdvance
+        ? ShoppingReminderMoment.onStoreAdvance
+        : ShoppingReminderMoment.onClose;
+
+    final confirmed = await Navigator.of(context).push<bool>(
+      MaterialPageRoute(
+        builder: (_) => ShoppingReviewView(
+          houseId: controller.houseId,
+          sessionId: controller.sessionId,
+          mode: mode,
+          activeStoreId: session.activeStoreId,
+          stores: controller.stores,
+          reminders: controller.remindersFor(moment),
+          onManageReminders: _openReminders,
+        ),
+      ),
+    );
+
+    if (!mounted) return;
+    if (confirmed != true) {
+      // Billed edits may have landed — refresh the session DTO.
+      await controller.refreshSession();
+      return;
+    }
+
+    setState(() => _busy = true);
+    try {
+      if (isAdvance) {
+        await controller.advance(nextStoreId);
+      } else {
+        await controller.close();
+        if (mounted) Navigator.of(context).pop();
+        return;
+      }
+    } catch (_) {
+      if (mounted) {
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text(m.shopping.loadFailed)));
+      }
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final controller = context.watch<ShoppingSessionController>();
+    final session = controller.session;
+    final activeStore = session.activeStoreId != null
+        ? controller.stores[session.activeStoreId]
+        : null;
+    final hasNext = session.nextStoreId != null;
+
+    return Scaffold(
+      appBar: AppBar(
+        leading: appBarBackLeading(context),
+        title: Text(activeStore?.name ?? m.shopping.startTitle),
+        actions: [
+          IconButton(
+            icon: Icon(
+              session.isPrivate ? Icons.visibility_off : Icons.visibility,
+            ),
+            tooltip: session.isPrivate
+                ? m.shopping.makePublic
+                : m.shopping.makePrivate,
+            onPressed: _togglePrivacy,
+          ),
+        ],
+      ),
+      body: controller.isLoading
+          ? const Center(child: CircularProgressIndicator())
+          : Column(
+              children: [
+                if (session.stores.isNotEmpty)
+                  _StoreBar(controller: controller),
+                _ProgressRow(controller: controller),
+                Expanded(
+                  child: _ItemArea(controller: controller, onCheck: _check),
+                ),
+              ],
+            ),
+      bottomNavigationBar: controller.isLoading
+          ? null
+          : _BottomBar(
+              controller: controller,
+              doneExpanded: _doneExpanded,
+              onToggleDone: () =>
+                  setState(() => _doneExpanded = !_doneExpanded),
+              busy: _busy,
+              hasNext: hasNext,
+              onProceed: _reviewAndProceed,
+            ),
+    );
+  }
+}
+
+/// Horizontal, scrollable row of store pills. The active pill is filled; past
+/// pills (lower position) are dimmed. Each pill carries the avatars of other
+/// shoppers currently at that store.
+class _StoreBar extends StatelessWidget {
+  final ShoppingSessionController controller;
+
+  const _StoreBar({required this.controller});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final cs = theme.colorScheme;
+    final activePos = controller.activePosition;
+
+    return SizedBox(
+      height: 56,
+      child: ListView(
+        scrollDirection: Axis.horizontal,
+        padding: const EdgeInsetsDirectional.symmetric(horizontal: 12),
+        children: [
+          for (final leg in controller.orderedStores)
+            Builder(
+              builder: (context) {
+                final store = controller.stores[leg.storeId];
+                final isActive =
+                    leg.storeId == controller.session.activeStoreId;
+                final isPast = activePos >= 0 && leg.position < activePos;
+                final others = controller.presenceAt(leg.storeId);
+                return Padding(
+                  padding: const EdgeInsetsDirectional.only(end: 8),
+                  child: Opacity(
+                    opacity: isPast ? 0.5 : 1,
+                    child: Material(
+                      color: isActive
+                          ? cs.primaryContainer
+                          : cs.surfaceContainerHighest,
+                      borderRadius: BorderRadius.circular(24),
+                      child: InkWell(
+                        borderRadius: BorderRadius.circular(24),
+                        onTap: () =>
+                            (context
+                                    .findAncestorStateOfType<
+                                      _SessionBodyState
+                                    >())
+                                ?._jumpToStore(leg.storeId),
+                        child: Padding(
+                          padding: const EdgeInsetsDirectional.symmetric(
+                            horizontal: 14,
+                            vertical: 8,
+                          ),
+                          child: Row(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              Icon(
+                                storeIcon(store?.icon),
+                                size: 18,
+                                color:
+                                    parseHexColor(store?.color) ??
+                                    (isActive
+                                        ? cs.onPrimaryContainer
+                                        : cs.onSurfaceVariant),
+                              ),
+                              const SizedBox(width: 6),
+                              Text(
+                                store?.name ?? '',
+                                textDirection: detectTextDirection(store?.name),
+                                style: theme.textTheme.labelLarge?.copyWith(
+                                  color: isActive
+                                      ? cs.onPrimaryContainer
+                                      : cs.onSurface,
+                                ),
+                              ),
+                              if (others.isNotEmpty) ...[
+                                const SizedBox(width: 8),
+                                _AvatarStack(
+                                  controller: controller,
+                                  entries: others,
+                                ),
+                              ],
+                            ],
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                );
+              },
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _AvatarStack extends StatelessWidget {
+  final ShoppingSessionController controller;
+  final List<ShoppingPresenceEntry> entries;
+
+  const _AvatarStack({required this.controller, required this.entries});
+
+  @override
+  Widget build(BuildContext context) {
+    const size = 20.0;
+    const overlap = 12.0;
+    final shown = entries.take(3).toList();
+    return SizedBox(
+      width: size + (shown.length - 1) * overlap,
+      height: size,
+      child: Stack(
+        children: [
+          for (var i = 0; i < shown.length; i++)
+            PositionedDirectional(
+              start: i * overlap,
+              child: Builder(
+                builder: (context) {
+                  final userId = shown[i].userId;
+                  final member = controller.members[userId];
+                  return Container(
+                    decoration: BoxDecoration(
+                      shape: BoxShape.circle,
+                      border: Border.all(
+                        color: Theme.of(context).colorScheme.surface,
+                        width: 1.5,
+                      ),
+                    ),
+                    child: MemberAvatar(
+                      userId: userId,
+                      displayName: member?.displayName ?? userId,
+                      size: size,
+                    ),
+                  );
+                },
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ProgressRow extends StatelessWidget {
+  final ShoppingSessionController controller;
+
+  const _ProgressRow({required this.controller});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsetsDirectional.symmetric(
+        horizontal: 16,
+        vertical: 8,
+      ),
+      child: Row(
+        children: [
+          Text(
+            m.shopping.inCart(controller.inCartCount),
+            style: theme.textTheme.labelLarge,
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(4),
+              child: LinearProgressIndicator(
+                value: controller.progress,
+                minHeight: 6,
+                backgroundColor: theme.colorScheme.surfaceContainerHighest,
+                color: Colors.green,
+              ),
+            ),
+          ),
+          if (controller.session.isPrivate)
+            Padding(
+              padding: const EdgeInsetsDirectional.only(start: 8),
+              child: Icon(
+                Icons.visibility_off,
+                size: 18,
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ItemArea extends StatelessWidget {
+  final ShoppingSessionController controller;
+  final Future<void> Function(ListItem) onCheck;
+
+  const _ItemArea({required this.controller, required this.onCheck});
+
+  @override
+  Widget build(BuildContext context) {
+    final groups = controller.groupedItems;
+    if (groups.isEmpty) return _EmptyState(controller: controller);
+
+    return ListView(
+      padding: const EdgeInsets.only(bottom: 8),
+      children: [
+        for (final group in groups) ...[
+          _CategoryHeader(category: group.category, count: group.items.length),
+          for (final item in group.items)
+            _ShoppingItemRow(item: item, onCheck: () => onCheck(item)),
+        ],
+      ],
+    );
+  }
+}
+
+class _CategoryHeader extends StatelessWidget {
+  final Category? category;
+  final int count;
+
+  const _CategoryHeader({required this.category, required this.count});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final color = parseHexColor(category?.color) ?? theme.colorScheme.primary;
+    final name = category?.name ?? m.shopping.uncategorized;
+    return Container(
+      color: theme.colorScheme.surfaceContainerHighest,
+      padding: const EdgeInsetsDirectional.symmetric(
+        horizontal: 16,
+        vertical: 6,
+      ),
+      child: Row(
+        children: [
+          Icon(categoryIcon(category?.icon), size: 18, color: color),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              name,
+              textDirection: detectTextDirection(name),
+              style: theme.textTheme.labelLarge?.copyWith(color: color),
+            ),
+          ),
+          Text('$count', style: theme.textTheme.labelMedium),
+        ],
+      ),
+    );
+  }
+}
+
+/// A single to-buy row. Tapping anywhere on the row checks the item off.
+class _ShoppingItemRow extends StatelessWidget {
+  final ListItem item;
+  final VoidCallback onCheck;
+
+  const _ShoppingItemRow({required this.item, required this.onCheck});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final price = item.formattedPrice;
+    return InkWell(
+      onTap: onCheck,
+      child: Padding(
+        padding: const EdgeInsetsDirectional.symmetric(
+          horizontal: 16,
+          vertical: 12,
+        ),
+        child: Row(
+          children: [
+            Icon(
+              Icons.circle_outlined,
+              size: 22,
+              color: theme.colorScheme.outline,
+            ),
+            const SizedBox(width: 14),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    item.name,
+                    textDirection: detectTextDirection(item.name),
+                    style: theme.textTheme.bodyLarge,
+                  ),
+                  if (item.quantity != null && item.quantity!.trim().isNotEmpty)
+                    Text(
+                      item.quantity!,
+                      textDirection: detectTextDirection(item.quantity),
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                ],
+              ),
+            ),
+            if (price != null)
+              Padding(
+                padding: const EdgeInsetsDirectional.only(start: 8),
+                child: Text(
+                  price,
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _EmptyState extends StatelessWidget {
+  final ShoppingSessionController controller;
+
+  const _EmptyState({required this.controller});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final hasNext = controller.session.nextStoreId != null;
+    final title = hasNext ? m.shopping.allCheckedHere : m.shopping.allDone;
+    final subtitle = hasNext
+        ? m.shopping.moveOnToNext
+        : m.shopping.everythingInCart;
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              hasNext ? Icons.check_circle_outline : Icons.done_all,
+              size: 48,
+              color: theme.colorScheme.primary,
+            ),
+            const SizedBox(height: 16),
+            Text(title, style: theme.textTheme.titleMedium),
+            const SizedBox(height: 4),
+            Text(
+              subtitle,
+              textAlign: TextAlign.center,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// The Done-today drawer (collapsible) stacked above the Next-store / Finish
+/// action button.
+class _BottomBar extends StatelessWidget {
+  final ShoppingSessionController controller;
+  final bool doneExpanded;
+  final VoidCallback onToggleDone;
+  final bool busy;
+  final bool hasNext;
+  final VoidCallback onProceed;
+
+  const _BottomBar({
+    required this.controller,
+    required this.doneExpanded,
+    required this.onToggleDone,
+    required this.busy,
+    required this.hasNext,
+    required this.onProceed,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final done = controller.doneToday;
+    final doneCount = done?.count ?? 0;
+    final estimate = done != null
+        ? formatShoppingEstimate(done.estimate)
+        : null;
+
+    return SafeArea(
+      top: false,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (doneCount > 0) ...[
+            const Divider(height: 1),
+            InkWell(
+              onTap: onToggleDone,
+              child: Padding(
+                padding: const EdgeInsetsDirectional.symmetric(
+                  horizontal: 16,
+                  vertical: 10,
+                ),
+                child: Row(
+                  children: [
+                    Icon(
+                      doneExpanded
+                          ? Icons.keyboard_arrow_down
+                          : Icons.keyboard_arrow_up,
+                    ),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: Text(
+                        m.shopping.doneToday(doneCount),
+                        style: theme.textTheme.titleSmall,
+                      ),
+                    ),
+                    if (estimate != null)
+                      Text(
+                        estimate,
+                        style: theme.textTheme.bodyMedium?.copyWith(
+                          color: theme.colorScheme.onSurfaceVariant,
+                        ),
+                      ),
+                  ],
+                ),
+              ),
+            ),
+            if (doneExpanded && done != null)
+              ConstrainedBox(
+                constraints: const BoxConstraints(maxHeight: 220),
+                child: ListView(
+                  shrinkWrap: true,
+                  children: [
+                    for (final item in done.items)
+                      ListTile(
+                        dense: true,
+                        leading: Icon(
+                          Icons.check_circle,
+                          color: Colors.green,
+                          size: 20,
+                        ),
+                        title: Text(
+                          item.name,
+                          textDirection: detectTextDirection(item.name),
+                        ),
+                        trailing: item.formattedPrice != null
+                            ? Text(item.formattedPrice!)
+                            : null,
+                      ),
+                  ],
+                ),
+              ),
+          ],
+          Padding(
+            padding: const EdgeInsets.all(12),
+            child: SizedBox(
+              width: double.infinity,
+              child: FilledButton.icon(
+                onPressed: busy ? null : onProceed,
+                icon: busy
+                    ? const SizedBox(
+                        width: 18,
+                        height: 18,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : Icon(hasNext ? Icons.arrow_forward : Icons.flag),
+                label: Text(hasNext ? m.shopping.nextStore : m.shopping.finish),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/views/shopping/shopping_start_view.dart
+++ b/lib/views/shopping/shopping_start_view.dart
@@ -1,0 +1,578 @@
+import 'package:flutter/material.dart';
+
+import 'package:pantry/i18n.dart';
+import 'package:pantry/models/checklist.dart';
+import 'package:pantry/models/house.dart';
+import 'package:pantry/models/shopping_reminder.dart';
+import 'package:pantry/models/shopping_session.dart';
+import 'package:pantry/models/store.dart';
+import 'package:pantry/services/checklist_service.dart';
+import 'package:pantry/services/house_service.dart';
+import 'package:pantry/services/shopping_service.dart';
+import 'package:pantry/services/store_service.dart';
+import 'package:pantry/utils/checklist_icons.dart';
+import 'package:pantry/utils/color.dart';
+import 'package:pantry/utils/store_icons.dart';
+import 'package:pantry/utils/text_direction.dart';
+import 'package:pantry/views/shopping/shopping_reminder_block.dart';
+import 'package:pantry/views/shopping/shopping_reminders_view.dart';
+import 'package:pantry/widgets/app_bar_back_leading.dart';
+
+/// The start screen: pick lists to shop, toggle & order the stores you'll
+/// visit, choose whether to include unassigned items, then start. Guards the
+/// one-live-session-per-user rule — if a trip is already in progress it offers
+/// Resume / End previous instead of the picker.
+///
+/// Pops a [ShoppingSession] when the caller should navigate into a live session
+/// (freshly created, or resumed); pops null / nothing otherwise.
+class ShoppingStartView extends StatefulWidget {
+  final int houseId;
+
+  /// Optional list to preselect (e.g. the list the user was viewing). When
+  /// null, all lists start selected.
+  final int? preselectListId;
+
+  const ShoppingStartView({
+    super.key,
+    required this.houseId,
+    this.preselectListId,
+  });
+
+  @override
+  State<ShoppingStartView> createState() => _ShoppingStartViewState();
+}
+
+class _ShoppingStartViewState extends State<ShoppingStartView> {
+  ShoppingService get _shopping => ShoppingService.instance;
+
+  bool _loading = true;
+  String? _error;
+  bool _submitting = false;
+
+  List<ChecklistList> _lists = [];
+  final Set<int> _selectedListIds = {};
+  final Map<int, List<ListItem>> _itemsByList = {};
+  Map<int, Store> _stores = {};
+
+  /// Available stores in display/drag order (those referenced by un-done items
+  /// on the selected lists). Enabled ones, in this order, are sent on start.
+  List<int> _orderedStoreIds = [];
+  final Set<int> _enabledStoreIds = {};
+
+  bool _includeUnassigned = true;
+  List<ShoppingReminder> _startReminders = [];
+
+  /// A live session found on mount — shows the Resume / End guard instead.
+  ShoppingSession? _guardSession;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
+    try {
+      // Guard first — a live session (any house) blocks starting a new one.
+      final current = await _shopping.getCurrentSession();
+      if (!mounted) return;
+      if (current != null && current.live) {
+        setState(() {
+          _guardSession = current;
+          _loading = false;
+        });
+        return;
+      }
+
+      final results = await Future.wait([
+        ChecklistService.instance.getLists(widget.houseId),
+        StoreService.instance.getStores(widget.houseId),
+        _shopping
+            .getReminders(widget.houseId)
+            .catchError((_) => <ShoppingReminder>[]),
+      ]);
+      if (!mounted) return;
+      final lists = (results[0] as List<ChecklistList>)
+          .where((l) => l.id > 0)
+          .toList();
+      _stores = {for (final s in results[1] as List<Store>) s.id: s};
+      _startReminders =
+          (results[2] as List<ShoppingReminder>)
+              .where(
+                (r) => r.enabled && r.showOn == ShoppingReminderMoment.onStart,
+              )
+              .toList()
+            ..sort((a, b) => a.position.compareTo(b.position));
+
+      _lists = lists;
+      _selectedListIds
+        ..clear()
+        ..addAll(
+          widget.preselectListId != null &&
+                  lists.any((l) => l.id == widget.preselectListId)
+              ? {widget.preselectListId!}
+              : lists.map((l) => l.id),
+        );
+
+      // Load each list's items (cache-first) to derive the store set.
+      await Future.wait(
+        lists.map((l) async {
+          final cached = ChecklistService.instance.getCachedItems(l.id);
+          if (cached != null) {
+            _itemsByList[l.id] = cached;
+            return;
+          }
+          try {
+            _itemsByList[l.id] = await ChecklistService.instance.getItems(
+              widget.houseId,
+              l.id,
+            );
+          } catch (_) {
+            _itemsByList[l.id] = const [];
+          }
+        }),
+      );
+      if (!mounted) return;
+      _recomputeStores();
+      setState(() => _loading = false);
+    } catch (_) {
+      if (!mounted) return;
+      setState(() {
+        _loading = false;
+        _error = m.shopping.loadFailed;
+      });
+    }
+  }
+
+  /// Recompute which stores are offered from the selected lists' un-done items.
+  /// Preserves the order & enabled state of stores that remain available;
+  /// newly-available stores are appended and default to enabled.
+  void _recomputeStores() {
+    final available = <int>{};
+    for (final listId in _selectedListIds) {
+      for (final item in _itemsByList[listId] ?? const <ListItem>[]) {
+        if (item.done || item.deletedAt != null || item.archivedAt != null) {
+          continue;
+        }
+        available.addAll(item.storeIds.where(_stores.containsKey));
+      }
+    }
+    final kept = [
+      for (final id in _orderedStoreIds)
+        if (available.contains(id)) id,
+    ];
+    final added =
+        [
+          for (final id in available)
+            if (!kept.contains(id)) id,
+        ]..sort(
+          (a, b) => (_stores[a]?.name ?? '').toLowerCase().compareTo(
+            (_stores[b]?.name ?? '').toLowerCase(),
+          ),
+        );
+    _orderedStoreIds = [...kept, ...added];
+    _enabledStoreIds
+      ..removeWhere((id) => !available.contains(id))
+      ..addAll(added);
+  }
+
+  void _toggleList(int id, bool selected) {
+    setState(() {
+      if (selected) {
+        _selectedListIds.add(id);
+      } else {
+        _selectedListIds.remove(id);
+      }
+      _recomputeStores();
+    });
+  }
+
+  void _selectAllLists(bool all) {
+    setState(() {
+      _selectedListIds.clear();
+      if (all) _selectedListIds.addAll(_lists.map((l) => l.id));
+      _recomputeStores();
+    });
+  }
+
+  void _reorderStores(int oldIndex, int newIndex) {
+    setState(() {
+      if (newIndex > oldIndex) newIndex--;
+      final moved = _orderedStoreIds.removeAt(oldIndex);
+      _orderedStoreIds.insert(newIndex, moved);
+    });
+  }
+
+  Future<void> _start() async {
+    if (_selectedListIds.isEmpty || _submitting) return;
+    setState(() => _submitting = true);
+    final storeIds = [
+      for (final id in _orderedStoreIds)
+        if (_enabledStoreIds.contains(id)) id,
+    ];
+    try {
+      final session = await _shopping.createSession(
+        widget.houseId,
+        listIds: _selectedListIds.toList(),
+        storeIds: storeIds,
+        includeUnassigned: _includeUnassigned,
+      );
+      if (!mounted) return;
+      Navigator.of(context).pop(session);
+    } on ShoppingSessionConflict catch (conflict) {
+      if (!mounted) return;
+      setState(() {
+        _guardSession = conflict.session;
+        _submitting = false;
+      });
+    } catch (_) {
+      if (!mounted) return;
+      setState(() => _submitting = false);
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text(m.shopping.startFailed)));
+    }
+  }
+
+  Future<void> _resumeGuard() async {
+    Navigator.of(context).pop(_guardSession);
+  }
+
+  Future<void> _endPrevious() async {
+    final session = _guardSession;
+    if (session == null) return;
+    setState(() => _submitting = true);
+    try {
+      await _shopping.close(session.houseId, session.id);
+    } on ShoppingSessionConflict {
+      // Already closed — fine, proceed to the picker.
+    } catch (_) {
+      if (!mounted) return;
+      setState(() => _submitting = false);
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text(m.shopping.endPreviousFailed)));
+      return;
+    }
+    if (!mounted) return;
+    setState(() {
+      _guardSession = null;
+      _submitting = false;
+    });
+    await _load();
+  }
+
+  Future<void> _openReminders() async {
+    await Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => ShoppingRemindersView(houseId: widget.houseId),
+      ),
+    );
+    // Refresh the on_start block in case reminders changed.
+    try {
+      final reminders = await _shopping.getReminders(widget.houseId);
+      if (!mounted) return;
+      setState(() {
+        _startReminders =
+            reminders
+                .where(
+                  (r) =>
+                      r.enabled && r.showOn == ShoppingReminderMoment.onStart,
+                )
+                .toList()
+              ..sort((a, b) => a.position.compareTo(b.position));
+      });
+    } catch (_) {
+      /* keep what we have */
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        leading: appBarBackLeading(context),
+        title: Text(m.shopping.startTitle),
+      ),
+      body: _loading
+          ? const Center(child: CircularProgressIndicator())
+          : _error != null
+          ? _ErrorRetry(message: _error!, onRetry: _load)
+          : _guardSession != null
+          ? _buildGuard()
+          : _buildPicker(),
+    );
+  }
+
+  Widget _buildGuard() {
+    final theme = Theme.of(context);
+    final session = _guardSession!;
+    final sameHouse = session.houseId == widget.houseId;
+    final houseName = HouseService.instance
+        .getCached()
+        ?.cast<House?>()
+        .firstWhere((h) => h!.id == session.houseId, orElse: () => null)
+        ?.name;
+    return Center(
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 480),
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Card(
+            child: Padding(
+              padding: const EdgeInsets.all(20),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  Icon(
+                    Icons.shopping_cart_outlined,
+                    size: 40,
+                    color: theme.colorScheme.primary,
+                  ),
+                  const SizedBox(height: 16),
+                  Text(
+                    sameHouse || houseName == null
+                        ? m.shopping.tripInProgress
+                        : m.shopping.tripInProgressElsewhere(houseName),
+                    textAlign: TextAlign.center,
+                    style: theme.textTheme.bodyLarge,
+                  ),
+                  const SizedBox(height: 20),
+                  FilledButton.icon(
+                    onPressed: _submitting ? null : _resumeGuard,
+                    icon: const Icon(Icons.play_arrow),
+                    label: Text(m.shopping.resume),
+                  ),
+                  const SizedBox(height: 8),
+                  OutlinedButton(
+                    onPressed: _submitting ? null : _endPrevious,
+                    child: Text(m.shopping.endPreviousTrip),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildPicker() {
+    final theme = Theme.of(context);
+    final allSelected = _selectedListIds.length == _lists.length;
+    return Column(
+      children: [
+        Expanded(
+          child: ListView(
+            padding: const EdgeInsets.all(16),
+            children: [
+              if (_startReminders.isNotEmpty) ...[
+                ShoppingReminderBlock(
+                  reminders: _startReminders,
+                  onManage: _openReminders,
+                ),
+                const SizedBox(height: 16),
+              ],
+              // Lists section.
+              Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      m.shopping.listsToShop,
+                      style: theme.textTheme.titleMedium,
+                    ),
+                  ),
+                  if (_lists.isNotEmpty)
+                    TextButton(
+                      onPressed: () => _selectAllLists(!allSelected),
+                      child: Text(
+                        allSelected
+                            ? m.shopping.selectNone
+                            : m.shopping.selectAll,
+                      ),
+                    ),
+                ],
+              ),
+              if (_lists.isEmpty)
+                Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 8),
+                  child: Text(
+                    m.shopping.noListsToShop,
+                    style: theme.textTheme.bodyMedium?.copyWith(
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                )
+              else
+                for (final list in _lists)
+                  CheckboxListTile(
+                    contentPadding: EdgeInsets.zero,
+                    controlAffinity: ListTileControlAffinity.leading,
+                    value: _selectedListIds.contains(list.id),
+                    onChanged: (v) => _toggleList(list.id, v ?? false),
+                    secondary: Icon(checklistIcon(list.icon)),
+                    title: Text(
+                      list.name,
+                      textDirection: detectTextDirection(list.name),
+                    ),
+                  ),
+              const SizedBox(height: 16),
+              // Stores section.
+              Text(m.shopping.storesTitle, style: theme.textTheme.titleMedium),
+              const SizedBox(height: 4),
+              Text(
+                m.shopping.storesHint,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+              const SizedBox(height: 8),
+              if (_orderedStoreIds.isEmpty)
+                Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 8),
+                  child: Text(
+                    m.shopping.noStoresWithItems,
+                    style: theme.textTheme.bodyMedium?.copyWith(
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                )
+              else
+                ReorderableListView.builder(
+                  shrinkWrap: true,
+                  physics: const NeverScrollableScrollPhysics(),
+                  buildDefaultDragHandles: false,
+                  itemCount: _orderedStoreIds.length,
+                  onReorder: _reorderStores,
+                  itemBuilder: (context, index) {
+                    final id = _orderedStoreIds[index];
+                    final store = _stores[id];
+                    return _StoreToggleRow(
+                      key: ValueKey(id),
+                      index: index,
+                      name: store?.name ?? '',
+                      icon: storeIcon(store?.icon),
+                      color: parseHexColor(store?.color),
+                      enabled: _enabledStoreIds.contains(id),
+                      onToggle: (v) => setState(() {
+                        if (v) {
+                          _enabledStoreIds.add(id);
+                        } else {
+                          _enabledStoreIds.remove(id);
+                        }
+                      }),
+                    );
+                  },
+                ),
+              const SizedBox(height: 8),
+              SwitchListTile(
+                contentPadding: EdgeInsets.zero,
+                value: _includeUnassigned,
+                onChanged: (v) => setState(() => _includeUnassigned = v),
+                title: Text(m.shopping.includeUnassigned),
+              ),
+            ],
+          ),
+        ),
+        SafeArea(
+          child: Padding(
+            padding: const EdgeInsets.all(12),
+            child: SizedBox(
+              width: double.infinity,
+              child: FilledButton.icon(
+                onPressed: (_selectedListIds.isEmpty || _submitting)
+                    ? null
+                    : _start,
+                icon: _submitting
+                    ? const SizedBox(
+                        width: 18,
+                        height: 18,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Icon(Icons.shopping_cart_checkout),
+                label: Text(m.shopping.start),
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _StoreToggleRow extends StatelessWidget {
+  final int index;
+  final String name;
+  final IconData icon;
+  final Color? color;
+  final bool enabled;
+  final ValueChanged<bool> onToggle;
+
+  const _StoreToggleRow({
+    super.key,
+    required this.index,
+    required this.name,
+    required this.icon,
+    required this.color,
+    required this.enabled,
+    required this.onToggle,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 2),
+      child: Row(
+        children: [
+          ReorderableDragStartListener(
+            index: index,
+            child: const Padding(
+              padding: EdgeInsets.all(8),
+              child: Icon(Icons.drag_handle, size: 20),
+            ),
+          ),
+          Icon(icon, color: color ?? cs.primary, size: 22),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Text(
+              name,
+              textDirection: detectTextDirection(name),
+              style: Theme.of(context).textTheme.bodyLarge,
+            ),
+          ),
+          Switch(value: enabled, onChanged: onToggle),
+        ],
+      ),
+    );
+  }
+}
+
+class _ErrorRetry extends StatelessWidget {
+  final String message;
+  final VoidCallback onRetry;
+
+  const _ErrorRetry({required this.message, required this.onRetry});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(message, textAlign: TextAlign.center),
+            const SizedBox(height: 16),
+            FilledButton(onPressed: onRetry, child: Text(m.common.retry)),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Shopping Mode (Flutter client)

Implements the pantry-flutter side of Shopping Mode — a live, per-shopper shopping trip over one or more checklists and an ordered sequence of stores. Matches the `feat/shopping-mode` server contract (`openapi.json`).

### What's included
- **Models** — `ShoppingSession` (+ nested store legs), `ShoppingReview`/`ShoppingReviewStore`, `ShoppingDoneToday`, `ShoppingPresenceEntry`, `ShoppingReminder`, `ShoppingHistoryRow`, and a shared `ShoppingEstimate` (per-currency ranges) with formatting helpers. Reuses the existing `ListItem`.
- **Service** — `ShoppingService` singleton wrapping all 21 endpoints, incl. the global `GET /current` (null-safe), 409-conflict handling (`ShoppingSessionConflict`), and reminder caching.
- **Screens** (`lib/views/shopping/`)
  - **Start** — pick lists (select all/none), toggle & drag-order the stores derived from the selected lists' items, include-unassigned switch, `on_start` reminders, and a one-live-session guard (Resume / End previous).
  - **Dense session** — sticky store bar with per-store presence avatars, `%n in cart` progress, whole-row tap-to-check (optimistic), category-grouped list, Done-today drawer, and Next-store / Finish action. ~60s polling (items + heartbeat + done-today), paused on blur, fired on focus.
  - **Review** — advance / close / history modes with per-store estimates, billed-total entry + currency picker, grand total and unchecked count.
  - **Reminders manager** — CRUD across the three moments with inline edit and drag-reorder.
  - **History** — Mine/House scope, paginated trip cards, tap → read-only summary.
- **Entry points** — Start/Resume FAB + resume banner on the checklists screen, and "Shopping history" in the overflow menu. All gated on the `shopping` capability.
- **i18n** — full `shopping` section translated across all six locales (en/de/es/fr/he/nn).

### Notes
- Full-screen pages for advance/close/history (mobile-friendly over the web's dialog).
- Progress/“in cart” is approximated from done-today to avoid a heavy review poll during the live loop.

Related issue chenasraf/nextcloud-pantry#189
Related PR chenasraf/nextcloud-pantry#204
