### PR TITLE
feat(checklists): per-store item prices

### DIFF
--- a/lib/i18n/messages.i18n.dart
+++ b/lib/i18n/messages.i18n.dart
@@ -3179,6 +3179,26 @@ class PriceChecklistsMessages {
   /// "Clear price"
   /// ```
   String get clear => """Clear price""";
+
+  /// ```dart
+  /// "Any store"
+  /// ```
+  String get anyStore => """Any store""";
+
+  /// ```dart
+  /// "Store"
+  /// ```
+  String get store => """Store""";
+
+  /// ```dart
+  /// "Add price"
+  /// ```
+  String get addPrice => """Add price""";
+
+  /// ```dart
+  /// "Remove price"
+  /// ```
+  String get removePrice => """Remove price""";
 }
 
 class ReuseChecklistsMessages {
@@ -5076,6 +5096,10 @@ Password: pantry-rocks""",
   """checklists.price.max""": """Max""",
   """checklists.price.currency""": """Currency""",
   """checklists.price.clear""": """Clear price""",
+  """checklists.price.anyStore""": """Any store""",
+  """checklists.price.store""": """Store""",
+  """checklists.price.addPrice""": """Add price""",
+  """checklists.price.removePrice""": """Remove price""",
   """checklists.reuse.dialogTitle""": """Item already exists""",
   """checklists.reuse.reuseExisting""": """Reuse existing""",
   """checklists.reuse.addAnyway""": """Add anyway""",

--- a/lib/i18n/messages.i18n.yaml
+++ b/lib/i18n/messages.i18n.yaml
@@ -601,6 +601,10 @@ checklists:
     max: Max
     currency: Currency
     clear: Clear price
+    anyStore: Any store
+    store: Store
+    addPrice: Add price
+    removePrice: Remove price
   reuse:
     dialogTitle: Item already exists
     dialogBody(String name): 'An item named "$name" already exists in this list. Reuse it instead of adding a new one?'

--- a/lib/i18n/messages_de.i18n.dart
+++ b/lib/i18n/messages_de.i18n.dart
@@ -3212,6 +3212,26 @@ class PriceChecklistsMessagesDe extends PriceChecklistsMessages {
   /// "Preis entfernen"
   /// ```
   String get clear => """Preis entfernen""";
+
+  /// ```dart
+  /// "Beliebiger Laden"
+  /// ```
+  String get anyStore => """Beliebiger Laden""";
+
+  /// ```dart
+  /// "Laden"
+  /// ```
+  String get store => """Laden""";
+
+  /// ```dart
+  /// "Preis hinzufügen"
+  /// ```
+  String get addPrice => """Preis hinzufügen""";
+
+  /// ```dart
+  /// "Preis entfernen"
+  /// ```
+  String get removePrice => """Preis entfernen""";
 }
 
 class ReuseChecklistsMessagesDe extends ReuseChecklistsMessages {
@@ -5153,6 +5173,10 @@ Passwort: pantry-rocks""",
   """checklists.price.max""": """Max""",
   """checklists.price.currency""": """Währung""",
   """checklists.price.clear""": """Preis entfernen""",
+  """checklists.price.anyStore""": """Beliebiger Laden""",
+  """checklists.price.store""": """Laden""",
+  """checklists.price.addPrice""": """Preis hinzufügen""",
+  """checklists.price.removePrice""": """Preis entfernen""",
   """checklists.reuse.dialogTitle""": """Eintrag existiert bereits""",
   """checklists.reuse.reuseExisting""": """Vorhandenen wiederverwenden""",
   """checklists.reuse.addAnyway""": """Trotzdem hinzufügen""",

--- a/lib/i18n/messages_de.i18n.yaml
+++ b/lib/i18n/messages_de.i18n.yaml
@@ -601,6 +601,10 @@ checklists:
     max: Max
     currency: Währung
     clear: Preis entfernen
+    anyStore: Beliebiger Laden
+    store: Laden
+    addPrice: Preis hinzufügen
+    removePrice: Preis entfernen
   reuse:
     dialogTitle: Eintrag existiert bereits
     dialogBody(String name): 'Ein Eintrag namens "$name" existiert bereits in dieser Liste. Wiederverwenden, statt einen neuen hinzuzufügen?'

--- a/lib/i18n/messages_es.i18n.dart
+++ b/lib/i18n/messages_es.i18n.dart
@@ -3205,6 +3205,26 @@ class PriceChecklistsMessagesEs extends PriceChecklistsMessages {
   /// "Borrar precio"
   /// ```
   String get clear => """Borrar precio""";
+
+  /// ```dart
+  /// "Cualquier tienda"
+  /// ```
+  String get anyStore => """Cualquier tienda""";
+
+  /// ```dart
+  /// "Tienda"
+  /// ```
+  String get store => """Tienda""";
+
+  /// ```dart
+  /// "Añadir precio"
+  /// ```
+  String get addPrice => """Añadir precio""";
+
+  /// ```dart
+  /// "Quitar precio"
+  /// ```
+  String get removePrice => """Quitar precio""";
 }
 
 class ReuseChecklistsMessagesEs extends ReuseChecklistsMessages {
@@ -5129,6 +5149,10 @@ Contraseña: pantry-rocks""",
   """checklists.price.max""": """Máx""",
   """checklists.price.currency""": """Moneda""",
   """checklists.price.clear""": """Borrar precio""",
+  """checklists.price.anyStore""": """Cualquier tienda""",
+  """checklists.price.store""": """Tienda""",
+  """checklists.price.addPrice""": """Añadir precio""",
+  """checklists.price.removePrice""": """Quitar precio""",
   """checklists.reuse.dialogTitle""": """El artículo ya existe""",
   """checklists.reuse.reuseExisting""": """Reutilizar existente""",
   """checklists.reuse.addAnyway""": """Añadir de todos modos""",

--- a/lib/i18n/messages_es.i18n.yaml
+++ b/lib/i18n/messages_es.i18n.yaml
@@ -601,6 +601,10 @@ checklists:
     max: Máx
     currency: Moneda
     clear: Borrar precio
+    anyStore: Cualquier tienda
+    store: Tienda
+    addPrice: Añadir precio
+    removePrice: Quitar precio
   reuse:
     dialogTitle: El artículo ya existe
     dialogBody(String name): 'Ya existe un artículo llamado "$name" en esta lista. ¿Reutilizarlo en lugar de añadir uno nuevo?'

--- a/lib/i18n/messages_fr.i18n.dart
+++ b/lib/i18n/messages_fr.i18n.dart
@@ -3212,6 +3212,26 @@ class PriceChecklistsMessagesFr extends PriceChecklistsMessages {
   /// "Effacer le prix"
   /// ```
   String get clear => """Effacer le prix""";
+
+  /// ```dart
+  /// "N'importe quel magasin"
+  /// ```
+  String get anyStore => """N'importe quel magasin""";
+
+  /// ```dart
+  /// "Magasin"
+  /// ```
+  String get store => """Magasin""";
+
+  /// ```dart
+  /// "Ajouter un prix"
+  /// ```
+  String get addPrice => """Ajouter un prix""";
+
+  /// ```dart
+  /// "Supprimer le prix"
+  /// ```
+  String get removePrice => """Supprimer le prix""";
 }
 
 class ReuseChecklistsMessagesFr extends ReuseChecklistsMessages {
@@ -5150,6 +5170,10 @@ Mot de passe : pantry-rocks""",
   """checklists.price.max""": """Max""",
   """checklists.price.currency""": """Devise""",
   """checklists.price.clear""": """Effacer le prix""",
+  """checklists.price.anyStore""": """N'importe quel magasin""",
+  """checklists.price.store""": """Magasin""",
+  """checklists.price.addPrice""": """Ajouter un prix""",
+  """checklists.price.removePrice""": """Supprimer le prix""",
   """checklists.reuse.dialogTitle""": """L'article existe déjà""",
   """checklists.reuse.reuseExisting""": """Réutiliser l'existant""",
   """checklists.reuse.addAnyway""": """Ajouter quand même""",

--- a/lib/i18n/messages_fr.i18n.yaml
+++ b/lib/i18n/messages_fr.i18n.yaml
@@ -601,6 +601,10 @@ checklists:
     max: Max
     currency: Devise
     clear: Effacer le prix
+    anyStore: N'importe quel magasin
+    store: Magasin
+    addPrice: Ajouter un prix
+    removePrice: Supprimer le prix
   reuse:
     dialogTitle: "L'article existe déjà"
     dialogBody(String name): 'Un article nommé "$name" existe déjà dans cette liste. Le réutiliser au lieu d''en ajouter un nouveau ?'

--- a/lib/i18n/messages_he.i18n.dart
+++ b/lib/i18n/messages_he.i18n.dart
@@ -3187,6 +3187,26 @@ class PriceChecklistsMessagesHe extends PriceChecklistsMessages {
   /// "נקה מחיר"
   /// ```
   String get clear => """נקה מחיר""";
+
+  /// ```dart
+  /// "כל חנות"
+  /// ```
+  String get anyStore => """כל חנות""";
+
+  /// ```dart
+  /// "חנות"
+  /// ```
+  String get store => """חנות""";
+
+  /// ```dart
+  /// "הוספת מחיר"
+  /// ```
+  String get addPrice => """הוספת מחיר""";
+
+  /// ```dart
+  /// "הסרת מחיר"
+  /// ```
+  String get removePrice => """הסרת מחיר""";
 }
 
 class ReuseChecklistsMessagesHe extends ReuseChecklistsMessages {
@@ -5074,6 +5094,10 @@ Map<String, String> get messagesHeMap => {
   """checklists.price.max""": """מקס׳""",
   """checklists.price.currency""": """מטבע""",
   """checklists.price.clear""": """נקה מחיר""",
+  """checklists.price.anyStore""": """כל חנות""",
+  """checklists.price.store""": """חנות""",
+  """checklists.price.addPrice""": """הוספת מחיר""",
+  """checklists.price.removePrice""": """הסרת מחיר""",
   """checklists.reuse.dialogTitle""": """הפריט כבר קיים""",
   """checklists.reuse.reuseExisting""": """השתמש בקיים""",
   """checklists.reuse.addAnyway""": """הוסף בכל זאת""",

--- a/lib/i18n/messages_he.i18n.yaml
+++ b/lib/i18n/messages_he.i18n.yaml
@@ -601,6 +601,10 @@ checklists:
     max: מקס׳
     currency: מטבע
     clear: נקה מחיר
+    anyStore: כל חנות
+    store: חנות
+    addPrice: הוספת מחיר
+    removePrice: הסרת מחיר
   reuse:
     dialogTitle: הפריט כבר קיים
     dialogBody(String name): 'פריט בשם "$name" כבר קיים ברשימה. להשתמש בו במקום להוסיף פריט חדש?'

--- a/lib/i18n/messages_nn.i18n.dart
+++ b/lib/i18n/messages_nn.i18n.dart
@@ -3200,6 +3200,26 @@ class PriceChecklistsMessagesNn extends PriceChecklistsMessages {
   /// "Fjern pris"
   /// ```
   String get clear => """Fjern pris""";
+
+  /// ```dart
+  /// "Kva som helst butikk"
+  /// ```
+  String get anyStore => """Kva som helst butikk""";
+
+  /// ```dart
+  /// "Butikk"
+  /// ```
+  String get store => """Butikk""";
+
+  /// ```dart
+  /// "Legg til pris"
+  /// ```
+  String get addPrice => """Legg til pris""";
+
+  /// ```dart
+  /// "Fjern pris"
+  /// ```
+  String get removePrice => """Fjern pris""";
 }
 
 class ReuseChecklistsMessagesNn extends ReuseChecklistsMessages {
@@ -5114,6 +5134,10 @@ Passord: pantry""",
   """checklists.price.max""": """Maks""",
   """checklists.price.currency""": """Valuta""",
   """checklists.price.clear""": """Fjern pris""",
+  """checklists.price.anyStore""": """Kva som helst butikk""",
+  """checklists.price.store""": """Butikk""",
+  """checklists.price.addPrice""": """Legg til pris""",
+  """checklists.price.removePrice""": """Fjern pris""",
   """checklists.reuse.dialogTitle""": """Oppføringa finst allereie""",
   """checklists.reuse.reuseExisting""": """Gjenbruk""",
   """checklists.reuse.addAnyway""": """Legg til likevel""",

--- a/lib/i18n/messages_nn.i18n.yaml
+++ b/lib/i18n/messages_nn.i18n.yaml
@@ -715,6 +715,10 @@ checklists:
     max: Maks
     currency: Valuta
     clear: Fjern pris
+    anyStore: Kva som helst butikk
+    store: Butikk
+    addPrice: Legg til pris
+    removePrice: Fjern pris
   reuse:
     dialogTitle: Oppføringa finst allereie
     dialogBody(String name):

--- a/lib/models/checklist.dart
+++ b/lib/models/checklist.dart
@@ -117,6 +117,44 @@ extension ChecklistSharing on ChecklistList {
       hasFeature('share-users') ? (canEdit ?? houseCanEdit) : houseCanEdit;
 }
 
+/// A single price entry for an item. [storeId] `null` is the store-less
+/// (default) price — at most one per item; a non-null [storeId] scopes the
+/// price to that store, at most one per store. [priceType] is `'set'` (single
+/// amount in [priceMin]), `'range'` ([priceMin]–[priceMax]), or null for no
+/// price. [priceCurrency] is an ISO 4217 code. Gated behind the `item-price`
+/// capability.
+class ItemPrice {
+  final int? storeId;
+  final String? priceType;
+  final double? priceMin;
+  final double? priceMax;
+  final String? priceCurrency;
+
+  const ItemPrice({
+    this.storeId,
+    this.priceType,
+    this.priceMin,
+    this.priceMax,
+    this.priceCurrency,
+  });
+
+  factory ItemPrice.fromJson(Map<String, dynamic> json) => ItemPrice(
+    storeId: json['storeId'] as int?,
+    priceType: json['priceType'] as String?,
+    priceMin: (json['priceMin'] as num?)?.toDouble(),
+    priceMax: (json['priceMax'] as num?)?.toDouble(),
+    priceCurrency: json['priceCurrency'] as String?,
+  );
+
+  Map<String, dynamic> toJson() => {
+    'storeId': storeId,
+    'priceType': priceType,
+    'priceMin': priceMin,
+    'priceMax': priceMax,
+    'priceCurrency': priceCurrency,
+  };
+}
+
 class ListItem {
   final int id;
   final int listId;
@@ -137,13 +175,10 @@ class ListItem {
   final String? addedBy;
   final String? barcode;
 
-  /// Optional price. [priceType] is `'set'` (single amount in [priceMin]),
-  /// `'range'` ([priceMin]–[priceMax]), or null for no price. [priceCurrency]
-  /// is an ISO 4217 code. Gated behind the `item-price` capability.
-  final String? priceType;
-  final double? priceMin;
-  final double? priceMax;
-  final String? priceCurrency;
+  /// Prices for this item, one per store plus an optional store-less default.
+  /// Empty when the item carries no price. See [ItemPrice] and the resolution
+  /// helpers in `utils/price.dart`. Gated behind the `item-price` capability.
+  final List<ItemPrice> prices;
   final int sortOrder;
   final int createdAt;
   final int updatedAt;
@@ -169,10 +204,7 @@ class ListItem {
     this.imageUploadedBy,
     this.addedBy,
     this.barcode,
-    this.priceType,
-    this.priceMin,
-    this.priceMax,
-    this.priceCurrency,
+    this.prices = const [],
     required this.sortOrder,
     required this.createdAt,
     required this.updatedAt,
@@ -201,16 +233,39 @@ class ListItem {
     imageUploadedBy: json['imageUploadedBy'] as String?,
     addedBy: json['addedBy'] as String?,
     barcode: json['barcode'] as String?,
-    priceType: json['priceType'] as String?,
-    priceMin: (json['priceMin'] as num?)?.toDouble(),
-    priceMax: (json['priceMax'] as num?)?.toDouble(),
-    priceCurrency: json['priceCurrency'] as String?,
+    prices: _pricesFromJson(json),
     sortOrder: json['sortOrder'] as int,
     createdAt: json['createdAt'] as int,
     updatedAt: json['updatedAt'] as int,
     deletedAt: json['deletedAt'] as int?,
     archivedAt: json['archivedAt'] as int?,
   );
+
+  /// Read prices from either shape: the new `prices` array (servers advertising
+  /// `item-price-per-store`, and our own cache) or the legacy flat
+  /// `priceType/priceMin/priceMax/priceCurrency` fields (older servers), which
+  /// collapse to a single store-less [ItemPrice].
+  static List<ItemPrice> _pricesFromJson(Map<String, dynamic> json) {
+    final raw = json['prices'];
+    if (raw is List) {
+      return raw
+          .map((e) => ItemPrice.fromJson(e as Map<String, dynamic>))
+          .toList();
+    }
+    final type = json['priceType'] as String?;
+    final min = (json['priceMin'] as num?)?.toDouble();
+    if ((type == 'set' || type == 'range') && min != null) {
+      return [
+        ItemPrice(
+          priceType: type,
+          priceMin: min,
+          priceMax: (json['priceMax'] as num?)?.toDouble(),
+          priceCurrency: json['priceCurrency'] as String?,
+        ),
+      ];
+    }
+    return const [];
+  }
 
   Map<String, dynamic> toJson() => {
     'id': id,
@@ -231,10 +286,7 @@ class ListItem {
     'imageUploadedBy': imageUploadedBy,
     'addedBy': addedBy,
     'barcode': barcode,
-    'priceType': priceType,
-    'priceMin': priceMin,
-    'priceMax': priceMax,
-    'priceCurrency': priceCurrency,
+    'prices': prices.map((p) => p.toJson()).toList(),
     'sortOrder': sortOrder,
     'createdAt': createdAt,
     'updatedAt': updatedAt,
@@ -261,11 +313,7 @@ class ListItem {
     bool clearImage = false,
     String? imageUploadedBy,
     String? barcode,
-    String? priceType,
-    double? priceMin,
-    double? priceMax,
-    String? priceCurrency,
-    bool clearPrice = false,
+    List<ItemPrice>? prices,
     int? sortOrder,
     int? updatedAt,
     int? deletedAt,
@@ -293,10 +341,7 @@ class ListItem {
         : (imageUploadedBy ?? this.imageUploadedBy),
     addedBy: addedBy,
     barcode: barcode ?? this.barcode,
-    priceType: clearPrice ? null : (priceType ?? this.priceType),
-    priceMin: clearPrice ? null : (priceMin ?? this.priceMin),
-    priceMax: clearPrice ? null : (priceMax ?? this.priceMax),
-    priceCurrency: clearPrice ? null : (priceCurrency ?? this.priceCurrency),
+    prices: prices ?? this.prices,
     sortOrder: sortOrder ?? this.sortOrder,
     createdAt: createdAt,
     updatedAt: updatedAt ?? this.updatedAt,

--- a/lib/services/checklist_service.dart
+++ b/lib/services/checklist_service.dart
@@ -2,6 +2,47 @@ import 'package:pantry/models/checklist.dart';
 import 'package:pantry/services/api_client.dart';
 import 'package:pantry/services/auth_service.dart';
 import 'package:pantry/services/cache_store.dart';
+import 'package:pantry/services/server_version_service.dart';
+
+/// Capability advertised by servers that store a price per store (the `prices`
+/// array). Absent on older servers, which keep the flat single-price fields.
+const kItemPricePerStoreFeature = 'item-price-per-store';
+
+/// Serialize a [prices] value for the item create/update body, adapting to what
+/// the server supports. `null` omits the field entirely (prices unchanged).
+///
+/// On `item-price-per-store` servers the full array is sent. On older servers
+/// the prices collapse to the store-less (default) entry sent as the legacy
+/// flat fields; when there's no usable store-less price an update clears it via
+/// the `priceType: ''` sentinel and a create sends nothing.
+Map<String, dynamic> itemPriceBody(
+  List<ItemPrice>? prices, {
+  required bool isUpdate,
+}) {
+  if (prices == null) return const {};
+  if (hasFeature(kItemPricePerStoreFeature)) {
+    return {'prices': prices.map((p) => p.toJson()).toList()};
+  }
+  ItemPrice? storeless;
+  for (final p in prices) {
+    if (p.storeId == null) {
+      storeless = p;
+      break;
+    }
+  }
+  final usable =
+      storeless != null &&
+      (storeless.priceType == 'set' || storeless.priceType == 'range') &&
+      storeless.priceMin != null;
+  if (!usable) return isUpdate ? {'priceType': ''} : const {};
+  return {
+    'priceType': storeless.priceType,
+    'priceMin': storeless.priceMin,
+    if (storeless.priceMax != null) 'priceMax': storeless.priceMax,
+    if (storeless.priceCurrency != null)
+      'priceCurrency': storeless.priceCurrency,
+  };
+}
 
 class ChecklistService {
   ChecklistService._();
@@ -453,10 +494,7 @@ class ChecklistService {
     bool? repeatFromCompletion,
     bool? deleteOnDone,
     String? barcode,
-    String? priceType,
-    double? priceMin,
-    double? priceMax,
-    String? priceCurrency,
+    List<ItemPrice>? prices,
   }) async {
     final loginName = AuthService.instance.credentials?.loginName;
     return ApiClient.instance.post<Map<String, dynamic>, ListItem>(
@@ -473,10 +511,9 @@ class ChecklistService {
         'deleteOnDone': ?deleteOnDone,
         'addedBy': ?loginName,
         'barcode': ?barcode,
-        'priceType': ?priceType,
-        'priceMin': ?priceMin,
-        'priceMax': ?priceMax,
-        'priceCurrency': ?priceCurrency,
+        // Adapts to the server: `prices` array on item-price-per-store servers,
+        // legacy flat fields otherwise. null omits (no prices).
+        ...itemPriceBody(prices, isUpdate: false),
       },
       fromJson: (data) => ListItem.fromJson(data),
     );
@@ -496,10 +533,7 @@ class ChecklistService {
     bool? repeatFromCompletion,
     bool? deleteOnDone,
     String? barcode,
-    String? priceType,
-    double? priceMin,
-    double? priceMax,
-    String? priceCurrency,
+    List<ItemPrice>? prices,
   }) async {
     return ApiClient.instance.patch<Map<String, dynamic>, ListItem>(
       '/houses/$houseId/lists/$listId/items/$itemId',
@@ -515,13 +549,10 @@ class ChecklistService {
         'repeatFromCompletion': ?repeatFromCompletion,
         'deleteOnDone': ?deleteOnDone,
         'barcode': ?barcode,
-        // priceType '' clears the price; 'set'/'range' sets it; null omits
-        // (unchanged). The `?` drops the key only on null, so a '' clear still
-        // reaches the server.
-        'priceType': ?priceType,
-        'priceMin': ?priceMin,
-        'priceMax': ?priceMax,
-        'priceCurrency': ?priceCurrency,
+        // Prices mirror stores: null omits (unchanged), an empty list clears
+        // all prices, otherwise the full set replaces the item's prices. On
+        // legacy servers this collapses to the store-less flat fields.
+        ...itemPriceBody(prices, isUpdate: true),
       },
       fromJson: (data) => ListItem.fromJson(data),
     );

--- a/lib/sync/sync_executor.dart
+++ b/lib/sync/sync_executor.dart
@@ -164,10 +164,7 @@ class SyncExecutor {
           repeatFromCompletion: op.body['repeatFromCompletion'] as bool?,
           deleteOnDone: op.body['deleteOnDone'] as bool?,
           barcode: op.body['barcode'] as String?,
-          priceType: op.body['priceType'] as String?,
-          priceMin: (op.body['priceMin'] as num?)?.toDouble(),
-          priceMax: (op.body['priceMax'] as num?)?.toDouble(),
-          priceCurrency: op.body['priceCurrency'] as String?,
+          prices: _pricesFromBody(op.body['prices']),
         );
         return SyncResult(item);
       case SyncOpKind.update:
@@ -186,10 +183,7 @@ class SyncExecutor {
           repeatFromCompletion: op.body['repeatFromCompletion'] as bool?,
           deleteOnDone: op.body['deleteOnDone'] as bool?,
           barcode: op.body['barcode'] as String?,
-          priceType: op.body['priceType'] as String?,
-          priceMin: (op.body['priceMin'] as num?)?.toDouble(),
-          priceMax: (op.body['priceMax'] as num?)?.toDouble(),
-          priceCurrency: op.body['priceCurrency'] as String?,
+          prices: _pricesFromBody(op.body['prices']),
         );
         return SyncResult(item);
       case SyncOpKind.delete:
@@ -464,6 +458,16 @@ class SyncExecutor {
         return SyncResult.empty;
     }
   }
+}
+
+/// Decode a queued `prices` payload back into [ItemPrice]s. Null (the key was
+/// omitted) leaves prices unchanged, so it stays null; a list — even empty —
+/// is passed through so an empty array can clear all prices on update.
+List<ItemPrice>? _pricesFromBody(Object? raw) {
+  if (raw == null) return null;
+  return (raw as List)
+      .map((e) => ItemPrice.fromJson(e as Map<String, dynamic>))
+      .toList();
 }
 
 /// Helpers to extract the server id from a result, used by the manager to

--- a/lib/utils/price.dart
+++ b/lib/utils/price.dart
@@ -41,17 +41,57 @@ String? formatPrice({
       : '$body${currency.symbol}';
 }
 
-extension ListItemPrice on ListItem {
-  /// Whether this item carries a usable price.
-  bool get hasPrice => hasPriceValue(priceType, priceMin);
+/// The item's store-less (default) price, or null when it has none. Mirrors
+/// the web app's `storelessPrice`.
+ItemPrice? storelessPrice(List<ItemPrice> prices) {
+  for (final p in prices) {
+    if (p.storeId == null) return p;
+  }
+  return null;
+}
 
-  /// Formatted price label for this item, or null when it has no price.
-  String? get formattedPrice => formatPrice(
+/// The price to show for a given store context: the store's own price when set,
+/// otherwise the store-less price. Passing null (non-store views) resolves the
+/// store-less price directly. Returns null when neither exists. Mirrors the web
+/// app's `resolveItemPrice`.
+ItemPrice? resolveItemPrice(List<ItemPrice> prices, int? storeId) {
+  if (storeId != null) {
+    for (final p in prices) {
+      if (p.storeId == storeId) return p;
+    }
+  }
+  return storelessPrice(prices);
+}
+
+extension ItemPriceX on ItemPrice {
+  /// Whether this entry carries a usable price.
+  bool get hasValue => hasPriceValue(priceType, priceMin);
+
+  /// Formatted price label for this entry, or null when it has no price.
+  String? get formatted => formatPrice(
     priceType: priceType,
     priceMin: priceMin,
     priceMax: priceMax,
     priceCurrency: priceCurrency,
   );
+}
+
+extension ListItemPrice on ListItem {
+  /// Whether this item's store-less (default) price is usable.
+  bool get hasPrice => storelessPrice(prices)?.hasValue ?? false;
+
+  /// Store-less (default) price label, or null when there is none.
+  String? get formattedPrice => storelessPrice(prices)?.formatted;
+
+  /// Whether the item has a usable price in [storeId]'s context (the store's
+  /// own price, else the store-less fallback).
+  bool hasPriceFor(int? storeId) =>
+      resolveItemPrice(prices, storeId)?.hasValue ?? false;
+
+  /// Price label resolved for [storeId] (store price, else store-less), or null
+  /// when neither exists.
+  String? formattedPriceFor(int? storeId) =>
+      resolveItemPrice(prices, storeId)?.formatted;
 }
 
 /// An active price-range filter. [currency] `null` means "any currency" —
@@ -82,19 +122,27 @@ class PriceFilter {
   );
 }
 
-/// Whether [item] passes [filter]. An item passes when its price overlaps
-/// `[min, max]`; a `set` price is treated as a zero-width range. When a
-/// currency is chosen, only items in that currency match. Items with no price
-/// never match an active filter. Mirrors the web app's `matchesPriceFilter`.
+/// Whether [item] passes [filter]. An item passes when **any** of its prices
+/// overlaps `[min, max]`; a `set` price is treated as a zero-width range. When a
+/// currency is chosen, only prices in that currency are considered. Items with
+/// no price never match an active filter. Mirrors the web app's
+/// `matchesPriceFilter`.
 bool matchesPriceFilter(ListItem item, PriceFilter filter) {
-  if (!item.hasPrice) return false;
+  for (final price in item.prices) {
+    if (_priceEntryMatches(price, filter)) return true;
+  }
+  return false;
+}
+
+bool _priceEntryMatches(ItemPrice price, PriceFilter filter) {
+  if (!price.hasValue) return false;
   if (filter.currency != null &&
-      (item.priceCurrency ?? '').toUpperCase() != filter.currency) {
+      (price.priceCurrency ?? '').toUpperCase() != filter.currency) {
     return false;
   }
-  final lo = item.priceMin!;
-  final hi = item.priceType == 'range' && item.priceMax != null
-      ? item.priceMax!
+  final lo = price.priceMin!;
+  final hi = price.priceType == 'range' && price.priceMax != null
+      ? price.priceMax!
       : lo;
   if (filter.min != null && hi < filter.min!) return false;
   if (filter.max != null && lo > filter.max!) return false;

--- a/lib/views/checklists/checklist_item_tile.dart
+++ b/lib/views/checklists/checklist_item_tile.dart
@@ -94,6 +94,12 @@ class ChecklistItemTile extends StatefulWidget {
   /// the header above it.
   final bool hideCategory;
 
+  /// Store context for the price chip. When non-null (store-grouped views), the
+  /// chip resolves this store's price, falling back to the store-less price;
+  /// null (flat/category views) shows the store-less price. See
+  /// `resolveItemPrice`.
+  final int? priceStoreContext;
+
   /// Multi-select state. When true, tapping the row toggles [selected] via
   /// [onSelectToggle], swipe actions are suppressed, and the leading control
   /// becomes a selection circle. When false, a non-null [onLongPressSelect]
@@ -133,6 +139,7 @@ class ChecklistItemTile extends StatefulWidget {
     this.addedByDisplayName,
     this.listBadge,
     this.hideCategory = false,
+    this.priceStoreContext,
     this.selectionMode = false,
     this.selected = false,
     this.onSelectToggle,
@@ -168,6 +175,7 @@ class ChecklistItemTile extends StatefulWidget {
        addedByDisplayName = null,
        listBadge = null,
        hideCategory = false,
+       priceStoreContext = null,
        selectionMode = false,
        selected = false,
        onSelectToggle = null,
@@ -409,6 +417,7 @@ class _ChecklistItemTileState extends State<ChecklistItemTile> {
       addedByDisplayName: widget.addedByDisplayName,
       listBadge: widget.listBadge,
       hideCategory: widget.hideCategory,
+      priceStoreContext: widget.priceStoreContext,
       onCheckboxTap: widget.canCheck ? _toggleAndCloseSwipe : null,
       onRowTap: rowTap,
       onRowLongPress: rowLongPress,
@@ -530,6 +539,7 @@ class _RowContent extends StatelessWidget {
   final String? addedByDisplayName;
   final ItemListBadge? listBadge;
   final bool hideCategory;
+  final int? priceStoreContext;
   final VoidCallback? onCheckboxTap;
   final VoidCallback? onRowTap;
   final VoidCallback? onRowLongPress;
@@ -554,6 +564,7 @@ class _RowContent extends StatelessWidget {
     required this.addedByDisplayName,
     required this.listBadge,
     required this.hideCategory,
+    this.priceStoreContext,
     required this.onCheckboxTap,
     required this.onRowTap,
     required this.onRowLongPress,
@@ -665,6 +676,7 @@ class _RowContent extends StatelessWidget {
                             stores: stores,
                             catColor: catColor,
                             listBadge: listBadge,
+                            priceStoreContext: priceStoreContext,
                           ),
                         ],
                       ],
@@ -700,7 +712,7 @@ class _RowContent extends StatelessWidget {
         item.quantity!.trim().isNotEmpty &&
         prefs.isItemChipVisible(ItemChipKind.quantity.key);
     final hasPrice =
-        item.hasPrice &&
+        item.hasPriceFor(priceStoreContext) &&
         hasFeature('item-price') &&
         prefs.isItemChipVisible(ItemChipKind.price.key);
     final hasDesc =
@@ -803,6 +815,7 @@ class _MetaRow extends StatelessWidget {
   final List<models.Store> stores;
   final Color catColor;
   final ItemListBadge? listBadge;
+  final int? priceStoreContext;
 
   const _MetaRow({
     required this.item,
@@ -810,6 +823,7 @@ class _MetaRow extends StatelessWidget {
     required this.stores,
     required this.catColor,
     required this.listBadge,
+    this.priceStoreContext,
   });
 
   @override
@@ -876,11 +890,11 @@ class _MetaRow extends StatelessWidget {
             textColor: cs.onSurfaceVariant,
             background: cs.onSurface.withValues(alpha: 0.06),
           ),
-        if (item.hasPrice &&
+        if (item.hasPriceFor(priceStoreContext) &&
             hasFeature('item-price') &&
             prefs.isItemChipVisible(ItemChipKind.price.key))
           _Chip(
-            label: item.formattedPrice!,
+            label: item.formattedPriceFor(priceStoreContext)!,
             textColor: cs.onSurfaceVariant,
             background: cs.onSurface.withValues(alpha: 0.06),
           ),

--- a/lib/views/checklists/checklists_controller.dart
+++ b/lib/views/checklists/checklists_controller.dart
@@ -1945,10 +1945,7 @@ class ChecklistsController extends ChangeNotifier {
     bool? repeatFromCompletion,
     bool? deleteOnDone,
     String? barcode,
-    String? priceType,
-    double? priceMin,
-    double? priceMax,
-    String? priceCurrency,
+    List<ItemPrice>? prices,
   }) async {
     final list = _currentList;
     if (list == null || list.id == kAllListsId) {
@@ -1969,10 +1966,7 @@ class ChecklistsController extends ChangeNotifier {
       repeatFromCompletion: repeatFromCompletion,
       deleteOnDone: deleteOnDone,
       barcode: barcode,
-      priceType: priceType,
-      priceMin: priceMin,
-      priceMax: priceMax,
-      priceCurrency: priceCurrency,
+      prices: prices,
     );
   }
 
@@ -1991,10 +1985,7 @@ class ChecklistsController extends ChangeNotifier {
     bool? repeatFromCompletion,
     bool? deleteOnDone,
     String? barcode,
-    String? priceType,
-    double? priceMin,
-    double? priceMax,
-    String? priceCurrency,
+    List<ItemPrice>? prices,
   }) async {
     final listId = targetListId;
     final tempId = _sync.newTempId();
@@ -2013,10 +2004,7 @@ class ChecklistsController extends ChangeNotifier {
       deleteOnDone: deleteOnDone ?? false,
       addedBy: loginName,
       barcode: barcode,
-      priceType: priceType,
-      priceMin: priceMin,
-      priceMax: priceMax,
-      priceCurrency: priceCurrency,
+      prices: prices ?? const [],
       sortOrder: 0,
       createdAt: _now(),
       updatedAt: _now(),
@@ -2045,10 +2033,7 @@ class ChecklistsController extends ChangeNotifier {
           'repeatFromCompletion': ?repeatFromCompletion,
           'deleteOnDone': ?deleteOnDone,
           'barcode': ?barcode,
-          'priceType': ?priceType,
-          'priceMin': ?priceMin,
-          'priceMax': ?priceMax,
-          'priceCurrency': ?priceCurrency,
+          if (prices != null) 'prices': prices.map((p) => p.toJson()).toList(),
         },
         createdAt: _now(),
       ),
@@ -2090,14 +2075,8 @@ class ChecklistsController extends ChangeNotifier {
     bool? repeatFromCompletion,
     bool? deleteOnDone,
     String? barcode,
-    String? priceType,
-    double? priceMin,
-    double? priceMax,
-    String? priceCurrency,
+    List<ItemPrice>? prices,
   }) async {
-    // An empty-string priceType is the "clear the price" sentinel on PATCH;
-    // reflect that optimistically by nulling the whole group locally.
-    final clearingPrice = priceType == '';
     final updated = item.copyWith(
       name: name,
       description: description,
@@ -2109,11 +2088,8 @@ class ChecklistsController extends ChangeNotifier {
       repeatFromCompletion: repeatFromCompletion,
       deleteOnDone: deleteOnDone,
       barcode: barcode,
-      clearPrice: clearingPrice,
-      priceType: clearingPrice ? null : priceType,
-      priceMin: priceMin,
-      priceMax: priceMax,
-      priceCurrency: priceCurrency,
+      // null leaves prices unchanged; a list (even empty) replaces them.
+      prices: prices,
       updatedAt: _now(),
     );
     final index = _items.indexWhere((i) => i.id == item.id);
@@ -2142,10 +2118,7 @@ class ChecklistsController extends ChangeNotifier {
           'repeatFromCompletion': ?repeatFromCompletion,
           'deleteOnDone': ?deleteOnDone,
           'barcode': ?barcode,
-          'priceType': ?priceType,
-          'priceMin': ?priceMin,
-          'priceMax': ?priceMax,
-          'priceCurrency': ?priceCurrency,
+          if (prices != null) 'prices': prices.map((p) => p.toJson()).toList(),
         },
         createdAt: _now(),
       ),

--- a/lib/views/checklists/checklists_view.dart
+++ b/lib/views/checklists/checklists_view.dart
@@ -888,6 +888,9 @@ class _BodyState extends State<_Body> with WidgetsBindingObserver {
                             ? controller.sortedStores
                             : const [],
                         priceEnabled: hasFeature('item-price'),
+                        perStorePriceEnabled: hasFeature(
+                          kItemPricePerStoreFeature,
+                        ),
                         lastCurrency: controller.lastCurrency,
                         initiallyFocused: false,
                         targetLists: realLists,
@@ -1111,10 +1114,7 @@ class _BodyState extends State<_Body> with WidgetsBindingObserver {
           repeatFromCompletion: s.repeatFromCompletion,
           deleteOnDone: s.deleteOnDone,
           barcode: s.barcode,
-          priceType: s.priceType,
-          priceMin: s.priceMin,
-          priceMax: s.priceMax,
-          priceCurrency: s.priceCurrency,
+          prices: s.prices,
         );
       } else {
         created = await controller.addItem(
@@ -1127,15 +1127,15 @@ class _BodyState extends State<_Body> with WidgetsBindingObserver {
           repeatFromCompletion: s.repeatFromCompletion,
           deleteOnDone: s.deleteOnDone,
           barcode: s.barcode,
-          priceType: s.priceType,
-          priceMin: s.priceMin,
-          priceMax: s.priceMax,
-          priceCurrency: s.priceCurrency,
+          prices: s.prices,
         );
       }
-      // Remember the chosen currency when the new item actually has a price.
-      if (s.priceType != null && s.priceCurrency != null) {
-        await controller.setLastCurrency(s.priceCurrency!);
+      // Remember the chosen currency when the new item actually has a price:
+      // the store-less price's currency, else the first per-store price's.
+      final prices = s.prices;
+      if (prices != null && prices.isNotEmpty) {
+        final currency = (storelessPrice(prices) ?? prices.first).priceCurrency;
+        if (currency != null) await controller.setLastCurrency(currency);
       }
       if (s.imageBytes != null) {
         await controller.uploadItemImage(
@@ -3278,6 +3278,7 @@ class _ItemListState extends State<_ItemList> {
                     keyOverride: ValueKey(
                       'store-tile-${group.storeId}-${item.id}',
                     ),
+                    priceStoreContext: group.storeId,
                   ),
                 );
               },
@@ -3291,6 +3292,7 @@ class _ItemListState extends State<_ItemList> {
                   context,
                   item,
                   keyOverride: ValueKey('store-${group.storeId}-${item.id}'),
+                  priceStoreContext: group.storeId,
                 );
               },
             ),
@@ -3304,7 +3306,12 @@ class _ItemListState extends State<_ItemList> {
   /// mounted twice (a duplicate-key crash), so those rows key off a unique
   /// (store, item) [ValueKey] instead. Toggles/edits still target `item.id`, so
   /// checking one copy updates every copy on the next rebuild.
-  Widget _buildTile(BuildContext context, ListItem item, {Key? keyOverride}) {
+  Widget _buildTile(
+    BuildContext context,
+    ListItem item, {
+    Key? keyOverride,
+    int? priceStoreContext,
+  }) {
     final controller = widget.controller;
     // A view-only shared list disables every item write; the granular house
     // caps still apply on top. Resolved per-item so the All-lists view (whose
@@ -3356,6 +3363,7 @@ class _ItemListState extends State<_ItemList> {
       addedByDisplayName: addedByDisplayName,
       listBadge: listBadge,
       hideCategory: widget.groupByCategory,
+      priceStoreContext: priceStoreContext,
       onToggle: (i) => _onToggle(context, controller, i),
       canCheck: writable && controller.permissions.canCheckItems,
       onView: (i) => _openView(context, controller, i),

--- a/lib/views/checklists/item_compose_bar.dart
+++ b/lib/views/checklists/item_compose_bar.dart
@@ -17,6 +17,7 @@ import 'package:pantry/widgets/avif_image.dart';
 import 'package:pantry/widgets/markdown_editor.dart';
 import 'package:pantry/utils/category_icons.dart';
 import 'package:pantry/utils/checklist_icons.dart';
+import 'package:pantry/utils/currencies.dart';
 import 'package:pantry/utils/price.dart';
 import 'package:pantry/utils/rrule.dart';
 import 'package:pantry/utils/store_icons.dart';
@@ -43,9 +44,9 @@ class ItemDraft {
   /// scan flow; null for hand-typed items.
   String? barcode;
 
-  /// Optional price for the composed item. Currency is preserved across
+  /// Optional prices for the composed item. Currency is preserved across
   /// [reset] so the last-picked currency sticks for rapid same-currency adds.
-  PriceDraft price = PriceDraft();
+  PricesDraft price = PricesDraft.empty(defaultCurrency);
 
   void reset(ItemLifecycle defaultLifecycle) {
     name = '';
@@ -58,7 +59,7 @@ class ItemDraft {
     imageFile = null;
     imageBytes = null;
     barcode = null;
-    price = PriceDraft(currency: price.currency);
+    price = PricesDraft.empty(price.storeless.currency);
   }
 
   bool get repeatFromCompletion => recurrence.repeatFromCompletion;
@@ -86,12 +87,9 @@ class ComposeSubmission {
   final String? imageMime;
   final String? barcode;
 
-  /// Price group for the created item. [priceType] is null when there's no
-  /// price (create semantics — omit the group).
-  final String? priceType;
-  final double? priceMin;
-  final double? priceMax;
-  final String? priceCurrency;
+  /// Prices for the created item, or null when there's no price (create
+  /// semantics — omit the field).
+  final List<ItemPrice>? prices;
 
   const ComposeSubmission({
     required this.name,
@@ -106,10 +104,7 @@ class ComposeSubmission {
     this.imageName,
     this.imageMime,
     this.barcode,
-    this.priceType,
-    this.priceMin,
-    this.priceMax,
-    this.priceCurrency,
+    this.prices,
   });
 }
 
@@ -128,6 +123,10 @@ class ItemComposeBar extends StatefulWidget {
   /// Whether the server advertises `item-price`. Hides the price chip + tray
   /// entirely when false.
   final bool priceEnabled;
+
+  /// Whether the server advertises `item-price-per-store`. When false the price
+  /// tray shows only the single store-less price (legacy single-price UI).
+  final bool perStorePriceEnabled;
 
   /// House's last-used currency, preselected when the price tray first opens.
   final String lastCurrency;
@@ -192,6 +191,7 @@ class ItemComposeBar extends StatefulWidget {
     this.initiallyFocused = false,
     this.dimmedListBackground = false,
     this.priceEnabled = false,
+    this.perStorePriceEnabled = false,
     this.lastCurrency = 'USD',
     this.onActiveChanged,
     this.onRequestCreateCategory,
@@ -224,7 +224,7 @@ enum _Tray {
 class ItemComposeBarState extends State<ItemComposeBar> {
   late final ItemDraft _draft = ItemDraft()
     ..lifecycle = _defaultLifecycle()
-    ..price.currency = widget.lastCurrency;
+    ..price = PricesDraft.empty(widget.lastCurrency);
   final _nameCtrl = TextEditingController();
   final _qtyCtrl = TextEditingController();
   final _focusNode = FocusNode();
@@ -529,17 +529,8 @@ class ItemComposeBarState extends State<ItemComposeBar> {
       barcode: _multiple ? null : _draft.barcode,
       // Price is a single-item concern — omitted entirely in bulk mode or when
       // the server lacks the capability.
-      priceType: (!_multiple && widget.priceEnabled)
-          ? _draft.price.createPriceType
-          : null,
-      priceMin: (!_multiple && widget.priceEnabled)
-          ? _draft.price.priceMin
-          : null,
-      priceMax: (!_multiple && widget.priceEnabled)
-          ? _draft.price.priceMax
-          : null,
-      priceCurrency: (!_multiple && widget.priceEnabled)
-          ? _draft.price.priceCurrency
+      prices: (!_multiple && widget.priceEnabled && _draft.price.hasAnyPrice)
+          ? _draft.price.toItemPrices()
           : null,
     );
   }
@@ -646,6 +637,8 @@ class ItemComposeBarState extends State<ItemComposeBar> {
       case _Tray.price:
         trayChild = _PriceTray(
           draft: _draft.price,
+          stores: widget.stores,
+          perStoreEnabled: widget.perStorePriceEnabled,
           onChanged: () => setState(() {}),
         );
       case _Tray.description:
@@ -1077,13 +1070,16 @@ class _ChipRow extends StatelessWidget {
     final hasQty = draft.quantity.trim().isNotEmpty;
     final hasDesc = draft.description.trim().isNotEmpty;
     final hasType = draft.lifecycle != ItemLifecycle.staple;
-    final hasPrice = draft.price.hasPrice;
+    final hasPrice = draft.price.hasAnyPrice;
+    final storeless = draft.price.storeless;
+    // Chip previews the store-less price when set; otherwise it just reflects
+    // the "has any price" accent state with the plain label.
     final priceLabel = hasPrice
         ? (formatPrice(
-                priceType: draft.price.createPriceType,
-                priceMin: draft.price.priceMin,
-                priceMax: draft.price.priceMax,
-                priceCurrency: draft.price.priceCurrency,
+                priceType: storeless.priceType,
+                priceMin: storeless.priceMin,
+                priceMax: storeless.priceMax,
+                priceCurrency: storeless.priceCurrency,
               ) ??
               m.checklists.price.label)
         : m.checklists.price.label;
@@ -1731,16 +1727,28 @@ class _QuantityTray extends StatelessWidget {
 }
 
 class _PriceTray extends StatelessWidget {
-  final PriceDraft draft;
+  final PricesDraft draft;
+  final List<models.Store> stores;
+  final bool perStoreEnabled;
   final VoidCallback onChanged;
 
-  const _PriceTray({required this.draft, required this.onChanged});
+  const _PriceTray({
+    required this.draft,
+    required this.stores,
+    required this.perStoreEnabled,
+    required this.onChanged,
+  });
 
   @override
   Widget build(BuildContext context) {
     return _TrayShell(
       label: m.checklists.price.label,
-      child: PriceInput(draft: draft, onChanged: onChanged),
+      child: ItemPricesEditor(
+        draft: draft,
+        stores: stores,
+        perStoreEnabled: perStoreEnabled,
+        onChanged: onChanged,
+      ),
     );
   }
 }

--- a/lib/views/checklists/item_form_view.dart
+++ b/lib/views/checklists/item_form_view.dart
@@ -49,7 +49,7 @@ class _ItemFormViewState extends State<ItemFormView> {
   late ItemLifecycle _lifecycle;
   late RecurrenceState _recurrence;
   late final bool _priceEnabled;
-  late final PriceDraft _price;
+  late final PricesDraft _prices;
   bool _saving = false;
   bool _deleting = false;
   bool _catPickerOpen = false;
@@ -96,12 +96,12 @@ class _ItemFormViewState extends State<ItemFormView> {
           : ItemLifecycle.staple;
     }
     _priceEnabled = hasFeature('item-price');
-    _price = item != null
-        ? PriceDraft.fromItem(
+    _prices = item != null
+        ? PricesDraft.fromItem(
             item,
             fallbackCurrency: widget.controller.lastCurrency,
           )
-        : PriceDraft(currency: widget.controller.lastCurrency);
+        : PricesDraft.empty(widget.controller.lastCurrency);
     _nameDir = detectTextDirection(item?.name);
     _nameController.addListener(() {
       final dir = detectTextDirection(_nameController.text);
@@ -197,12 +197,9 @@ class _ItemFormViewState extends State<ItemFormView> {
           rrule: effectiveRrule,
           repeatFromCompletion: effectiveRepeatFromCompletion,
           deleteOnDone: isOnce,
-          // Always send the full price group on edit ('' clears). Omitted
-          // entirely when the server lacks the capability.
-          priceType: _priceEnabled ? _price.updatePriceType : null,
-          priceMin: _priceEnabled ? _price.priceMin : null,
-          priceMax: _priceEnabled ? _price.priceMax : null,
-          priceCurrency: _priceEnabled ? _price.priceCurrency : null,
+          // Always send the full price set on edit (an empty list clears).
+          // Omitted entirely when the server lacks the capability.
+          prices: _priceEnabled ? _prices.toItemPrices() : null,
         );
       } else {
         savedItem = await widget.controller.addItem(
@@ -215,15 +212,15 @@ class _ItemFormViewState extends State<ItemFormView> {
               : null,
           rrule: isRecurring ? effectiveRrule : null,
           deleteOnDone: isOnce,
-          priceType: _priceEnabled ? _price.createPriceType : null,
-          priceMin: _priceEnabled ? _price.priceMin : null,
-          priceMax: _priceEnabled ? _price.priceMax : null,
-          priceCurrency: _priceEnabled ? _price.priceCurrency : null,
+          prices: _priceEnabled && _prices.hasAnyPrice
+              ? _prices.toItemPrices()
+              : null,
         );
       }
       // Remember the currency only when the saved item actually has a price.
-      if (_priceEnabled && _price.hasPrice) {
-        await widget.controller.setLastCurrency(_price.currency);
+      if (_priceEnabled && _prices.hasAnyPrice) {
+        final currency = _prices.rememberCurrency;
+        if (currency != null) await widget.controller.setLastCurrency(currency);
       }
 
       if (_removeExistingImage && _pickedImage == null) {
@@ -418,7 +415,12 @@ class _ItemFormViewState extends State<ItemFormView> {
                 if (_priceEnabled) ...[
                   _SectionLabel(text: m.checklists.price.label),
                   const SizedBox(height: 10),
-                  PriceInput(draft: _price, onChanged: () => setState(() {})),
+                  ItemPricesEditor(
+                    draft: _prices,
+                    stores: _storesEnabled ? _stores : const [],
+                    perStoreEnabled: hasFeature(kItemPricePerStoreFeature),
+                    onChanged: () => setState(() {}),
+                  ),
                   const SizedBox(height: 16),
                 ],
                 _SectionLabel(text: f.category),

--- a/lib/views/checklists/price_input.dart
+++ b/lib/views/checklists/price_input.dart
@@ -3,7 +3,12 @@ import 'package:flutter/services.dart';
 
 import 'package:pantry/i18n.dart';
 import 'package:pantry/models/checklist.dart';
+import 'package:pantry/models/store.dart' as models;
 import 'package:pantry/utils/currencies.dart';
+import 'package:pantry/utils/price.dart';
+import 'package:pantry/utils/store_icons.dart';
+import 'package:pantry/views/checklists/checklist_switcher_sheet.dart'
+    show parseHexColor;
 
 /// Format a stored amount for seeding an input field: trim trailing zeros so a
 /// round number shows as "1" (not "1.00") and "9.99" stays "9.99".
@@ -34,22 +39,23 @@ class PriceDraft {
     this.currency = defaultCurrency,
   });
 
-  /// Seed from an existing item, falling back to [fallbackCurrency] (the
-  /// house's last-used currency) when the item carries none.
-  factory PriceDraft.fromItem(
-    ListItem item, {
+  /// Seed from a single [ItemPrice] entry (or null for an empty row), falling
+  /// back to [fallbackCurrency] (the house's last-used currency) when the entry
+  /// carries no currency.
+  factory PriceDraft.fromItemPrice(
+    ItemPrice? price, {
     required String fallbackCurrency,
   }) {
-    final type = item.priceType;
+    final type = price?.priceType;
     final hasPrice =
-        (type == 'set' || type == 'range') && item.priceMin != null;
+        (type == 'set' || type == 'range') && price?.priceMin != null;
     return PriceDraft(
       isRange: type == 'range',
-      minText: hasPrice ? _seedAmount(item.priceMin!) : '',
-      maxText: type == 'range' && item.priceMax != null
-          ? _seedAmount(item.priceMax!)
+      minText: hasPrice ? _seedAmount(price!.priceMin!) : '',
+      maxText: type == 'range' && price?.priceMax != null
+          ? _seedAmount(price!.priceMax!)
           : '',
-      currency: item.priceCurrency ?? fallbackCurrency,
+      currency: price?.priceCurrency ?? fallbackCurrency,
     );
   }
 
@@ -59,16 +65,25 @@ class PriceDraft {
   /// Whether the draft carries a usable price (a parseable min amount).
   bool get hasPrice => _min != null;
 
-  /// priceType to send on **create** — null when there's no price.
-  String? get createPriceType => hasPrice ? (isRange ? 'range' : 'set') : null;
-
-  /// priceType to send on **update** — `''` clears when there's no price,
-  /// otherwise `'set'`/`'range'`. Always send the full group on edit.
-  String get updatePriceType => hasPrice ? (isRange ? 'range' : 'set') : '';
+  /// priceType this draft represents, or null when there's no price.
+  String? get priceType => hasPrice ? (isRange ? 'range' : 'set') : null;
 
   double? get priceMin => hasPrice ? _min : null;
   double? get priceMax => hasPrice && isRange ? _max : null;
   String? get priceCurrency => hasPrice ? currency : null;
+
+  /// Compose this draft into an [ItemPrice] for [storeId], or null when the
+  /// draft carries no usable amount.
+  ItemPrice? toItemPrice(int? storeId) {
+    if (!hasPrice) return null;
+    return ItemPrice(
+      storeId: storeId,
+      priceType: priceType,
+      priceMin: priceMin,
+      priceMax: priceMax,
+      priceCurrency: priceCurrency,
+    );
+  }
 }
 
 /// A Set/Range segmented control, one or two amount fields, and a currency
@@ -324,6 +339,346 @@ class _CurrencyDropdown extends StatelessWidget {
           ],
           onChanged: (code) {
             if (code != null) onChanged(code);
+          },
+        ),
+      ),
+    );
+  }
+}
+
+/// One per-store price row within a [PricesDraft]. [key] is a stable identity so
+/// the row's [PriceInput] keeps its text controllers as rows are added/removed.
+class StorePriceRow {
+  static int _nextKey = 0;
+
+  final int key;
+  int storeId;
+  final PriceDraft draft;
+
+  StorePriceRow({required this.storeId, required this.draft})
+    : key = _nextKey++;
+}
+
+/// Mutable draft for an item's full set of prices: a store-less (default) price
+/// plus zero or more per-store rows. Mirrors the web app's `ItemPricesEditor`
+/// model. Compose into the wire shape with [toItemPrices].
+class PricesDraft {
+  final PriceDraft storeless;
+  final List<StorePriceRow> rows;
+  final String defaultCurrency;
+
+  PricesDraft({
+    required this.storeless,
+    required this.rows,
+    required this.defaultCurrency,
+  });
+
+  factory PricesDraft.empty(String currency) => PricesDraft(
+    storeless: PriceDraft(currency: currency),
+    rows: [],
+    defaultCurrency: currency,
+  );
+
+  /// Seed from an existing item, falling back to [fallbackCurrency] where an
+  /// entry carries no currency.
+  factory PricesDraft.fromItem(
+    ListItem item, {
+    required String fallbackCurrency,
+  }) {
+    final rows = [
+      for (final p in item.prices)
+        if (p.storeId != null)
+          StorePriceRow(
+            storeId: p.storeId!,
+            draft: PriceDraft.fromItemPrice(
+              p,
+              fallbackCurrency: fallbackCurrency,
+            ),
+          ),
+    ];
+    return PricesDraft(
+      storeless: PriceDraft.fromItemPrice(
+        storelessPrice(item.prices),
+        fallbackCurrency: fallbackCurrency,
+      ),
+      rows: rows,
+      defaultCurrency: fallbackCurrency,
+    );
+  }
+
+  /// Whether any price (store-less or per-store) carries a usable amount.
+  bool get hasAnyPrice =>
+      storeless.hasPrice || rows.any((r) => r.draft.hasPrice);
+
+  /// Currency worth remembering for the next new item: the store-less price's
+  /// currency when set, else the first priced row's, else null.
+  String? get rememberCurrency {
+    if (storeless.hasPrice) return storeless.currency;
+    for (final r in rows) {
+      if (r.draft.hasPrice) return r.draft.currency;
+    }
+    return null;
+  }
+
+  /// Compose into the wire list, dropping rows without a usable amount. Safe to
+  /// send as the `prices` param on create/update (empty clears all prices).
+  List<ItemPrice> toItemPrices() {
+    final out = <ItemPrice>[];
+    final s = storeless.toItemPrice(null);
+    if (s != null) out.add(s);
+    for (final r in rows) {
+      final p = r.draft.toItemPrice(r.storeId);
+      if (p != null) out.add(p);
+    }
+    return out;
+  }
+}
+
+/// Editor for an item's prices: a pinned "Any store" row plus an add-row per
+/// store. Mirrors the web app's `ItemPricesEditor`. Renders bare so callers can
+/// host it inside their own section (the item form and the compose bar tray).
+class ItemPricesEditor extends StatefulWidget {
+  final PricesDraft draft;
+
+  /// Stores offered for per-store rows. Empty (and the add button hidden) when
+  /// the server lacks the `stores` capability.
+  final List<models.Store> stores;
+
+  /// Whether the server advertises `item-price-per-store`. When false the editor
+  /// collapses to just the store-less price input (the legacy single-price UI):
+  /// no "Any store" label, per-store rows, or add button.
+  final bool perStoreEnabled;
+
+  /// Called on any change so the host can rebuild its live preview.
+  final VoidCallback onChanged;
+
+  const ItemPricesEditor({
+    super.key,
+    required this.draft,
+    required this.stores,
+    required this.perStoreEnabled,
+    required this.onChanged,
+  });
+
+  @override
+  State<ItemPricesEditor> createState() => _ItemPricesEditorState();
+}
+
+class _ItemPricesEditorState extends State<ItemPricesEditor> {
+  List<models.Store> get _stores => widget.stores;
+
+  /// Stores not already claimed by a per-store row.
+  List<models.Store> get _availableStores {
+    final used = widget.draft.rows.map((r) => r.storeId).toSet();
+    return [
+      for (final s in _stores)
+        if (!used.contains(s.id)) s,
+    ];
+  }
+
+  void _addRow() {
+    final next = _availableStores.isNotEmpty ? _availableStores.first : null;
+    if (next == null) return;
+    setState(() {
+      widget.draft.rows.add(
+        StorePriceRow(
+          storeId: next.id,
+          draft: PriceDraft(currency: widget.draft.defaultCurrency),
+        ),
+      );
+    });
+    widget.onChanged();
+  }
+
+  void _removeRow(int index) {
+    setState(() => widget.draft.rows.removeAt(index));
+    widget.onChanged();
+  }
+
+  void _selectStore(int index, int storeId) {
+    setState(() => widget.draft.rows[index].storeId = storeId);
+    widget.onChanged();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // Legacy single-price servers: just the store-less input, nothing else.
+    if (!widget.perStoreEnabled) {
+      return PriceInput(
+        draft: widget.draft.storeless,
+        onChanged: widget.onChanged,
+      );
+    }
+    final p = m.checklists.price;
+    final rows = widget.draft.rows;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        _StoreLabel(text: p.anyStore),
+        const SizedBox(height: 8),
+        PriceInput(draft: widget.draft.storeless, onChanged: widget.onChanged),
+        for (var i = 0; i < rows.length; i++) ...[
+          const SizedBox(height: 14),
+          _StoreRow(
+            row: rows[i],
+            stores: _stores,
+            // A row may keep its own store plus any not used elsewhere.
+            options: [
+              for (final s in _stores)
+                if (s.id == rows[i].storeId ||
+                    _availableStores.any((a) => a.id == s.id))
+                  s,
+            ],
+            onStoreSelected: (id) => _selectStore(i, id),
+            onRemove: () => _removeRow(i),
+            onChanged: widget.onChanged,
+          ),
+        ],
+        if (_stores.isNotEmpty) ...[
+          const SizedBox(height: 10),
+          Align(
+            alignment: AlignmentDirectional.centerStart,
+            child: TextButton.icon(
+              onPressed: _availableStores.isEmpty ? null : _addRow,
+              icon: const Icon(Icons.add, size: 18),
+              label: Text(p.addPrice),
+            ),
+          ),
+        ],
+      ],
+    );
+  }
+}
+
+class _StoreLabel extends StatelessWidget {
+  final String text;
+
+  const _StoreLabel({required this.text});
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return Padding(
+      padding: const EdgeInsetsDirectional.only(start: 2),
+      child: Text(
+        text.toUpperCase(),
+        style: TextStyle(
+          fontSize: 11,
+          fontWeight: FontWeight.w700,
+          letterSpacing: 0.6,
+          color: cs.onSurfaceVariant,
+        ),
+      ),
+    );
+  }
+}
+
+class _StoreRow extends StatelessWidget {
+  final StorePriceRow row;
+  final List<models.Store> stores;
+  final List<models.Store> options;
+  final ValueChanged<int> onStoreSelected;
+  final VoidCallback onRemove;
+  final VoidCallback onChanged;
+
+  const _StoreRow({
+    required this.row,
+    required this.stores,
+    required this.options,
+    required this.onStoreSelected,
+    required this.onRemove,
+    required this.onChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            Expanded(
+              child: _StoreSelect(
+                value: row.storeId,
+                options: options,
+                onChanged: onStoreSelected,
+              ),
+            ),
+            const SizedBox(width: 4),
+            IconButton(
+              onPressed: onRemove,
+              icon: const Icon(Icons.close, size: 18),
+              tooltip: m.checklists.price.removePrice,
+              visualDensity: VisualDensity.compact,
+            ),
+          ],
+        ),
+        const SizedBox(height: 8),
+        PriceInput(
+          key: ValueKey('price-row-${row.key}'),
+          draft: row.draft,
+          onChanged: onChanged,
+        ),
+      ],
+    );
+  }
+}
+
+class _StoreSelect extends StatelessWidget {
+  final int value;
+  final List<models.Store> options;
+  final ValueChanged<int> onChanged;
+
+  const _StoreSelect({
+    required this.value,
+    required this.options,
+    required this.onChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    final selectable = options.any((s) => s.id == value);
+    return InputDecorator(
+      decoration: InputDecoration(
+        labelText: m.checklists.price.store,
+        isDense: true,
+        contentPadding: const EdgeInsetsDirectional.fromSTEB(12, 12, 8, 12),
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(11),
+          borderSide: BorderSide(color: cs.outlineVariant),
+        ),
+        enabledBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(11),
+          borderSide: BorderSide(color: cs.outlineVariant),
+        ),
+      ),
+      child: DropdownButtonHideUnderline(
+        child: DropdownButton<int>(
+          value: selectable ? value : null,
+          isExpanded: true,
+          isDense: true,
+          items: [
+            for (final s in options)
+              DropdownMenuItem<int>(
+                value: s.id,
+                child: Row(
+                  children: [
+                    Icon(
+                      storeIcon(s.icon),
+                      size: 16,
+                      color: parseHexColor(s.color) ?? cs.primary,
+                    ),
+                    const SizedBox(width: 8),
+                    Flexible(
+                      child: Text(s.name, overflow: TextOverflow.ellipsis),
+                    ),
+                  ],
+                ),
+              ),
+          ],
+          onChanged: (id) {
+            if (id != null) onChanged(id);
           },
         ),
       ),

--- a/lib/views/shopping/shopping_review_view.dart
+++ b/lib/views/shopping/shopping_review_view.dart
@@ -387,7 +387,8 @@ class _StoreSectionState extends State<_StoreSection> {
               ],
             ),
             const SizedBox(height: 8),
-            for (final item in store.items) _ReviewItemRow(item: item),
+            for (final item in store.items)
+              _ReviewItemRow(item: item, storeContext: store.storeId),
             if (store.noPriceCount > 0)
               Padding(
                 padding: const EdgeInsets.only(top: 4),
@@ -490,12 +491,16 @@ class _StoreSectionState extends State<_StoreSection> {
 class _ReviewItemRow extends StatelessWidget {
   final ListItem item;
 
-  const _ReviewItemRow({required this.item});
+  /// Store this review row belongs to (null for the store-less "Any store"
+  /// group), so the price resolves for that store with the store-less fallback.
+  final int? storeContext;
+
+  const _ReviewItemRow({required this.item, required this.storeContext});
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final price = item.formattedPrice;
+    final price = item.formattedPriceFor(storeContext);
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 3),
       child: Row(

--- a/lib/views/shopping/shopping_session_view.dart
+++ b/lib/views/shopping/shopping_session_view.dart
@@ -487,6 +487,7 @@ class _ItemArea extends StatelessWidget {
                       // removed.
                       key: ValueKey(item.id),
                       item: item,
+                      storeContext: controller.session.activeStoreId,
                       onCheck: () => onCheck(item),
                       onSkip: () => onSkip(item),
                     ),
@@ -539,9 +540,14 @@ class _ShoppingItemRow extends StatelessWidget {
   final VoidCallback onCheck;
   final VoidCallback onSkip;
 
+  /// Active store leg, so the row shows this store's price (falling back to the
+  /// store-less price) rather than always the store-less default.
+  final int? storeContext;
+
   const _ShoppingItemRow({
     super.key,
     required this.item,
+    required this.storeContext,
     required this.onCheck,
     required this.onSkip,
   });
@@ -549,7 +555,7 @@ class _ShoppingItemRow extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final price = item.formattedPrice;
+    final price = item.formattedPriceFor(storeContext);
     return Dismissible(
       key: ValueKey('skip-${item.id}'),
       // End-to-start (trailing → leading) keeps the "swipe it away" gesture

--- a/test/models/checklist_item_test.dart
+++ b/test/models/checklist_item_test.dart
@@ -110,12 +110,7 @@ void main() {
   });
 
   group('ListItem price serialization', () {
-    ListItem base({
-      String? priceType,
-      double? priceMin,
-      double? priceMax,
-      String? priceCurrency,
-    }) => ListItem(
+    ListItem base(List<ItemPrice> prices) => ListItem(
       id: 1,
       listId: 2,
       name: 'Milk',
@@ -125,20 +120,35 @@ void main() {
       sortOrder: 0,
       createdAt: 100,
       updatedAt: 200,
-      priceType: priceType,
-      priceMin: priceMin,
-      priceMax: priceMax,
-      priceCurrency: priceCurrency,
+      prices: prices,
     );
 
-    test('round-trips a set price through toJson/fromJson', () {
+    test('round-trips prices through toJson/fromJson', () {
       final decoded = ListItem.fromJson(
-        base(priceType: 'set', priceMin: 9.99, priceCurrency: 'USD').toJson(),
+        base([
+          const ItemPrice(
+            priceType: 'set',
+            priceMin: 9.99,
+            priceCurrency: 'USD',
+          ),
+          const ItemPrice(
+            storeId: 12,
+            priceType: 'range',
+            priceMin: 4,
+            priceMax: 6,
+            priceCurrency: 'USD',
+          ),
+        ]).toJson(),
       );
-      expect(decoded.priceType, 'set');
-      expect(decoded.priceMin, 9.99);
-      expect(decoded.priceMax, isNull);
-      expect(decoded.priceCurrency, 'USD');
+      expect(decoded.prices.length, 2);
+      final storeless = decoded.prices.first;
+      expect(storeless.storeId, isNull);
+      expect(storeless.priceType, 'set');
+      expect(storeless.priceMin, 9.99);
+      expect(storeless.priceMax, isNull);
+      expect(storeless.priceCurrency, 'USD');
+      expect(decoded.prices[1].storeId, 12);
+      expect(decoded.prices[1].priceMax, 6);
     });
 
     test('coerces integer JSON amounts to double', () {
@@ -151,16 +161,61 @@ void main() {
         'sortOrder': 0,
         'createdAt': 100,
         'updatedAt': 200,
-        'priceType': 'range',
-        'priceMin': 1,
-        'priceMax': 10,
-        'priceCurrency': 'ILS',
+        'prices': [
+          {
+            'storeId': null,
+            'priceType': 'range',
+            'priceMin': 1,
+            'priceMax': 10,
+            'priceCurrency': 'ILS',
+          },
+        ],
       });
-      expect(decoded.priceMin, 1.0);
-      expect(decoded.priceMax, 10.0);
+      expect(decoded.prices.single.priceMin, 1.0);
+      expect(decoded.prices.single.priceMax, 10.0);
     });
 
-    test('treats missing price keys as no price', () {
+    test('reads the legacy flat single-price shape as a store-less entry', () {
+      final decoded = ListItem.fromJson({
+        'id': 1,
+        'listId': 2,
+        'name': 'Milk',
+        'done': false,
+        'repeatFromCompletion': false,
+        'sortOrder': 0,
+        'createdAt': 100,
+        'updatedAt': 200,
+        'priceType': 'set',
+        'priceMin': 9.99,
+        'priceCurrency': 'USD',
+      });
+      expect(decoded.prices.single.storeId, isNull);
+      expect(decoded.prices.single.priceType, 'set');
+      expect(decoded.prices.single.priceMin, 9.99);
+      expect(decoded.prices.single.priceCurrency, 'USD');
+    });
+
+    test('prefers the new prices array over legacy flat fields', () {
+      final decoded = ListItem.fromJson({
+        'id': 1,
+        'listId': 2,
+        'name': 'Milk',
+        'done': false,
+        'repeatFromCompletion': false,
+        'sortOrder': 0,
+        'createdAt': 100,
+        'updatedAt': 200,
+        'priceType': 'set',
+        'priceMin': 1,
+        'prices': [
+          {'storeId': 12, 'priceType': 'set', 'priceMin': 4, 'priceMax': null},
+        ],
+      });
+      expect(decoded.prices.single.storeId, 12);
+      expect(decoded.prices.single.priceMin, 4);
+    });
+
+    test('treats a missing prices key as no prices', () {
       final decoded = ListItem.fromJson({
         'id': 1,
         'listId': 2,
@@ -171,18 +226,17 @@ void main() {
         'createdAt': 100,
         'updatedAt': 200,
       });
-      expect(decoded.priceType, isNull);
-      expect(decoded.priceMin, isNull);
+      expect(decoded.prices, isEmpty);
     });
 
-    test('clearPrice nulls the whole group', () {
-      final priced = base(priceType: 'set', priceMin: 5, priceCurrency: 'USD');
-      final cleared = priced.copyWith(clearPrice: true);
-      expect(cleared.priceType, isNull);
-      expect(cleared.priceMin, isNull);
-      expect(cleared.priceCurrency, isNull);
-      // A plain copyWith preserves the price.
-      expect(priced.copyWith(name: 'Bread').priceMin, 5);
+    test('copyWith replaces prices, or leaves them unchanged when null', () {
+      final priced = base(const [
+        ItemPrice(priceType: 'set', priceMin: 5, priceCurrency: 'USD'),
+      ]);
+      // An empty list clears all prices.
+      expect(priced.copyWith(prices: const []).prices, isEmpty);
+      // A plain copyWith preserves the prices.
+      expect(priced.copyWith(name: 'Bread').prices.single.priceMin, 5);
     });
   });
 }

--- a/test/services/item_price_body_test.dart
+++ b/test/services/item_price_body_test.dart
@@ -1,0 +1,90 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pantry/models/checklist.dart';
+import 'package:pantry/services/checklist_service.dart';
+import 'package:pantry/services/server_version_service.dart';
+
+void main() {
+  tearDown(() => ServerVersionService.instance.debugSeed());
+
+  void seedPerStore(bool enabled) {
+    ServerVersionService.instance.debugSeed(
+      features: {if (enabled) kItemPricePerStoreFeature: true},
+      featuresAuthoritative: true,
+    );
+  }
+
+  const storeless = ItemPrice(
+    priceType: 'set',
+    priceMin: 5,
+    priceCurrency: 'USD',
+  );
+  const forStore = ItemPrice(
+    storeId: 12,
+    priceType: 'range',
+    priceMin: 4,
+    priceMax: 6,
+    priceCurrency: 'USD',
+  );
+
+  test('null prices omit the field in both modes', () {
+    seedPerStore(true);
+    expect(itemPriceBody(null, isUpdate: false), isEmpty);
+    expect(itemPriceBody(null, isUpdate: true), isEmpty);
+    seedPerStore(false);
+    expect(itemPriceBody(null, isUpdate: true), isEmpty);
+  });
+
+  group('item-price-per-store server', () {
+    setUp(() => seedPerStore(true));
+
+    test('sends the full prices array', () {
+      final body = itemPriceBody(const [storeless, forStore], isUpdate: false);
+      expect(body.keys, ['prices']);
+      final prices = body['prices'] as List;
+      expect(prices, hasLength(2));
+      expect(prices[1]['storeId'], 12);
+      expect(prices[1]['priceMax'], 6);
+    });
+
+    test('an empty list is sent as an empty array (clears all)', () {
+      expect(itemPriceBody(const [], isUpdate: true), {'prices': []});
+    });
+  });
+
+  group('legacy single-price server', () {
+    setUp(() => seedPerStore(false));
+
+    test('collapses to the store-less price as flat fields', () {
+      final body = itemPriceBody(const [storeless, forStore], isUpdate: false);
+      expect(body, {'priceType': 'set', 'priceMin': 5, 'priceCurrency': 'USD'});
+    });
+
+    test('a range store-less price includes the max', () {
+      final body = itemPriceBody(const [
+        ItemPrice(
+          priceType: 'range',
+          priceMin: 4,
+          priceMax: 6,
+          priceCurrency: 'USD',
+        ),
+      ], isUpdate: false);
+      expect(body['priceMax'], 6);
+    });
+
+    test('no usable store-less price clears via the sentinel on update', () {
+      // Only a per-store price exists — nothing the legacy server can store.
+      expect(itemPriceBody(const [forStore], isUpdate: true), {
+        'priceType': '',
+      });
+    });
+
+    test('no usable store-less price sends nothing on create', () {
+      expect(itemPriceBody(const [forStore], isUpdate: false), isEmpty);
+      expect(itemPriceBody(const [], isUpdate: false), isEmpty);
+    });
+
+    test('an empty list clears via the sentinel on update', () {
+      expect(itemPriceBody(const [], isUpdate: true), {'priceType': ''});
+    });
+  });
+}

--- a/test/utils/price_test.dart
+++ b/test/utils/price_test.dart
@@ -2,12 +2,21 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:pantry/models/checklist.dart';
 import 'package:pantry/utils/price.dart';
 
-ListItem priced({
+ItemPrice price({
+  int? storeId,
   String? priceType,
   double? priceMin,
   double? priceMax,
   String? priceCurrency,
-}) => ListItem(
+}) => ItemPrice(
+  storeId: storeId,
+  priceType: priceType,
+  priceMin: priceMin,
+  priceMax: priceMax,
+  priceCurrency: priceCurrency,
+);
+
+ListItem priced(List<ItemPrice> prices) => ListItem(
   id: 1,
   listId: 2,
   name: 'Milk',
@@ -17,10 +26,7 @@ ListItem priced({
   sortOrder: 0,
   createdAt: 100,
   updatedAt: 200,
-  priceType: priceType,
-  priceMin: priceMin,
-  priceMax: priceMax,
-  priceCurrency: priceCurrency,
+  prices: prices,
 );
 
 String? fmt({
@@ -92,13 +98,79 @@ void main() {
     });
   });
 
+  group('storelessPrice / resolveItemPrice', () {
+    final storeless = price(
+      priceType: 'set',
+      priceMin: 5,
+      priceCurrency: 'USD',
+    );
+    final forStore12 = price(
+      storeId: 12,
+      priceType: 'set',
+      priceMin: 4,
+      priceCurrency: 'USD',
+    );
+
+    test('storelessPrice returns the null-store entry, else null', () {
+      expect(storelessPrice([storeless, forStore12]), storeless);
+      expect(storelessPrice([forStore12]), isNull);
+    });
+
+    test(
+      'resolveItemPrice prefers the store price, falls back to store-less',
+      () {
+        expect(resolveItemPrice([storeless, forStore12], 12), forStore12);
+        // No entry for store 99 → store-less fallback.
+        expect(resolveItemPrice([storeless, forStore12], 99), storeless);
+        // Non-store context resolves the store-less price directly.
+        expect(resolveItemPrice([storeless, forStore12], null), storeless);
+        // Neither exists.
+        expect(resolveItemPrice([forStore12], 99), isNull);
+      },
+    );
+  });
+
+  group('ListItem price extension', () {
+    test('hasPrice / formattedPrice read the store-less price', () {
+      final item = priced([
+        price(priceType: 'set', priceMin: 5, priceCurrency: 'USD'),
+        price(storeId: 12, priceType: 'set', priceMin: 4, priceCurrency: 'USD'),
+      ]);
+      expect(item.hasPrice, isTrue);
+      expect(item.formattedPrice, r'$5');
+    });
+
+    test('store-only item has no store-less price', () {
+      final item = priced([
+        price(storeId: 12, priceType: 'set', priceMin: 4, priceCurrency: 'USD'),
+      ]);
+      expect(item.hasPrice, isFalse);
+      expect(item.formattedPrice, isNull);
+      // But it resolves for that store.
+      expect(item.hasPriceFor(12), isTrue);
+      expect(item.formattedPriceFor(12), r'$4');
+    });
+
+    test('formattedPriceFor falls back to the store-less price', () {
+      final item = priced([
+        price(priceType: 'set', priceMin: 5, priceCurrency: 'USD'),
+      ]);
+      expect(item.formattedPriceFor(99), r'$5');
+    });
+  });
+
   group('matchesPriceFilter', () {
     test('items with no price never match an active filter', () {
-      expect(matchesPriceFilter(priced(), const PriceFilter(min: 1)), isFalse);
+      expect(
+        matchesPriceFilter(priced(const []), const PriceFilter(min: 1)),
+        isFalse,
+      );
     });
 
     test('a set price is a zero-width range against min/max bounds', () {
-      final item = priced(priceType: 'set', priceMin: 5, priceCurrency: 'USD');
+      final item = priced([
+        price(priceType: 'set', priceMin: 5, priceCurrency: 'USD'),
+      ]);
       expect(matchesPriceFilter(item, const PriceFilter(min: 3)), isTrue);
       expect(matchesPriceFilter(item, const PriceFilter(min: 6)), isFalse);
       expect(matchesPriceFilter(item, const PriceFilter(max: 5)), isTrue);
@@ -106,12 +178,14 @@ void main() {
     });
 
     test('a range price passes when it overlaps the filter bounds', () {
-      final item = priced(
-        priceType: 'range',
-        priceMin: 5,
-        priceMax: 10,
-        priceCurrency: 'USD',
-      );
+      final item = priced([
+        price(
+          priceType: 'range',
+          priceMin: 5,
+          priceMax: 10,
+          priceCurrency: 'USD',
+        ),
+      ]);
       // Overlap on the low end.
       expect(matchesPriceFilter(item, const PriceFilter(max: 6)), isTrue);
       // Overlap on the high end.
@@ -122,9 +196,22 @@ void main() {
       expect(matchesPriceFilter(item, const PriceFilter(max: 4)), isFalse);
     });
 
-    test('a currency filter only matches items in that currency', () {
-      final usd = priced(priceType: 'set', priceMin: 5, priceCurrency: 'USD');
-      final ils = priced(priceType: 'set', priceMin: 5, priceCurrency: 'ILS');
+    test('matches when any of the item prices falls in range', () {
+      // Store-less price is out of range; a per-store price is in range.
+      final item = priced([
+        price(priceType: 'set', priceMin: 20, priceCurrency: 'USD'),
+        price(storeId: 12, priceType: 'set', priceMin: 4, priceCurrency: 'USD'),
+      ]);
+      expect(matchesPriceFilter(item, const PriceFilter(max: 5)), isTrue);
+    });
+
+    test('a currency filter only matches prices in that currency', () {
+      final usd = priced([
+        price(priceType: 'set', priceMin: 5, priceCurrency: 'USD'),
+      ]);
+      final ils = priced([
+        price(priceType: 'set', priceMin: 5, priceCurrency: 'ILS'),
+      ]);
       expect(
         matchesPriceFilter(usd, const PriceFilter(currency: 'USD')),
         isTrue,
@@ -133,8 +220,10 @@ void main() {
         matchesPriceFilter(ils, const PriceFilter(currency: 'USD')),
         isFalse,
       );
-      // Case-insensitive on the item's stored code.
-      final lower = priced(priceType: 'set', priceMin: 5, priceCurrency: 'usd');
+      // Case-insensitive on the price's stored code.
+      final lower = priced([
+        price(priceType: 'set', priceMin: 5, priceCurrency: 'usd'),
+      ]);
       expect(
         matchesPriceFilter(lower, const PriceFilter(currency: 'USD')),
         isTrue,
@@ -142,7 +231,9 @@ void main() {
     });
 
     test('null currency compares amounts verbatim across currencies', () {
-      final ils = priced(priceType: 'set', priceMin: 5, priceCurrency: 'ILS');
+      final ils = priced([
+        price(priceType: 'set', priceMin: 5, priceCurrency: 'ILS'),
+      ]);
       expect(matchesPriceFilter(ils, const PriceFilter(min: 3)), isTrue);
     });
 


### PR DESCRIPTION
## Summary

Adopts the server's per-store item price API: an item's price moved from four flat fields to a one-to-many `prices[]` array, so a price can vary by store. The change is gated on the new `item-price-per-store` capability — servers (and users) without it keep the old single-price system working end to end.

## Behaviour

- **Reading** — `ListItem` decodes both shapes: the new `prices` array (new servers + local cache) and the legacy flat `priceType/priceMin/priceMax/priceCurrency` fields, which collapse to a single store-less price.
- **Writing** — the in-memory model is always `List<ItemPrice>`; serialization adapts at the HTTP boundary. With the capability it sends the full `prices` array (empty clears all); without it, it collapses to the store-less price as the legacy flat fields, clearing via the old `priceType: ''` sentinel on update. Checked at send time, so queued offline ops replay correctly.
- **Editing** — a new multi-row `ItemPricesEditor` (pinned "Any store" row + add-a-store rows, mirroring the web `ItemPricesEditor`) in the item form and compose bar. On legacy servers it collapses to exactly the old single price input — nothing regresses.
- **Display** — price chips resolve by store context (`resolveItemPrice`): store-grouped list views and shopping session/review rows show that store's price with a store-less fallback; flat/category/detail views show the store-less price.
- **Filtering** — the price filter now matches if **any** of an item's prices falls in range, so a store-only price isn't hidden.

## Tests

- Model: legacy flat-shape read, new-array-takes-precedence, `prices` round-trip and copyWith semantics.
- Utils: `storelessPrice`/`resolveItemPrice`, store-aware extension getters, any-price filter matching.
- Service: `itemPriceBody` across both capability modes (array vs. flat, clear sentinel, create vs. update).

Full suite green (402 tests); `flutter analyze` clean apart from pre-existing `onReorder` deprecations.

## Notes

Relates to chenasraf/nextcloud-pantry#221
Complements chenasraf/nextcloud-pantry#231
