### PR TITLE
feat: custom fields for checklist items

### DIFF
--- a/lib/i18n/messages.i18n.dart
+++ b/lib/i18n/messages.i18n.dart
@@ -1837,6 +1837,41 @@ class CustomFieldsMessages {
   String get noDefault => """No default""";
 
   /// ```dart
+  /// "No value"
+  /// ```
+  String get noValue => """No value""";
+
+  /// ```dart
+  /// "Days from today"
+  /// ```
+  String get daysFromToday => """Days from today""";
+
+  /// ```dart
+  /// "Due ${date}"
+  /// ```
+  String due(String date) => """Due ${date}""";
+
+  /// ```dart
+  /// "Re-anchor date"
+  /// ```
+  String get reanchor => """Re-anchor date""";
+
+  /// ```dart
+  /// "Remind me"
+  /// ```
+  String get remindMe => """Remind me""";
+
+  /// ```dart
+  /// "Custom reminder for this item"
+  /// ```
+  String get customReminder => """Custom reminder for this item""";
+
+  /// ```dart
+  /// "Use field default"
+  /// ```
+  String get useFieldDefault => """Use field default""";
+
+  /// ```dart
   /// "Done"
   /// ```
   String get done => """Done""";
@@ -5426,6 +5461,12 @@ Password: pantry-rocks""",
   """customFields.defaultValue""": """Default value""",
   """customFields.defaultChecked""": """On by default""",
   """customFields.noDefault""": """No default""",
+  """customFields.noValue""": """No value""",
+  """customFields.daysFromToday""": """Days from today""",
+  """customFields.reanchor""": """Re-anchor date""",
+  """customFields.remindMe""": """Remind me""",
+  """customFields.customReminder""": """Custom reminder for this item""",
+  """customFields.useFieldDefault""": """Use field default""",
   """customFields.done""": """Done""",
   """customFields.remapTitle""": """Option in use""",
   """customFields.remapClear""": """Clear it from those items""",

--- a/lib/i18n/messages.i18n.dart
+++ b/lib/i18n/messages.i18n.dart
@@ -74,6 +74,7 @@ class Messages {
   SettingsMessages get settings => SettingsMessages(this);
   NotificationsMessages get notifications => NotificationsMessages(this);
   CategoriesMessages get categories => CategoriesMessages(this);
+  CustomFieldsMessages get customFields => CustomFieldsMessages(this);
   StoresMessages get stores => StoresMessages(this);
   LabelsMessages get labels => LabelsMessages(this);
   ChecklistsMessages get checklists => ChecklistsMessages(this);
@@ -1635,6 +1636,261 @@ class SortCategoriesMessages {
   /// "Custom"
   /// ```
   String get custom => """Custom""";
+}
+
+class CustomFieldsMessages {
+  final Messages _parent;
+  const CustomFieldsMessages(this._parent);
+
+  /// ```dart
+  /// "Custom fields"
+  /// ```
+  String get manageTitle => """Custom fields""";
+
+  /// ```dart
+  /// "No custom fields yet. Add one to attach extra info to items."
+  /// ```
+  String get empty =>
+      """No custom fields yet. Add one to attach extra info to items.""";
+
+  /// ```dart
+  /// "Add field"
+  /// ```
+  String get addField => """Add field""";
+
+  /// ```dart
+  /// "All lists"
+  /// ```
+  String get allLists => """All lists""";
+
+  /// ```dart
+  /// "Delete field"
+  /// ```
+  String get deleteTitle => """Delete field""";
+
+  /// ```dart
+  /// "Delete this field? Values already set on items are kept but hidden."
+  /// ```
+  String get deleteConfirm =>
+      """Delete this field? Values already set on items are kept but hidden.""";
+
+  /// ```dart
+  /// "Failed to remove option."
+  /// ```
+  String get optionDeleteFailed => """Failed to remove option.""";
+  TypesCustomFieldsMessages get types => TypesCustomFieldsMessages(this);
+
+  /// ```dart
+  /// "Name"
+  /// ```
+  String get name => """Name""";
+
+  /// ```dart
+  /// "e.g. Expiry, Aisle"
+  /// ```
+  String get namePlaceholder => """e.g. Expiry, Aisle""";
+
+  /// ```dart
+  /// "Type"
+  /// ```
+  String get type => """Type""";
+
+  /// ```dart
+  /// "The type can't be changed after the field is created."
+  /// ```
+  String get typeLocked =>
+      """The type can't be changed after the field is created.""";
+
+  /// ```dart
+  /// "Scope"
+  /// ```
+  String get scope => """Scope""";
+
+  /// ```dart
+  /// "Hint text"
+  /// ```
+  String get hint => """Hint text""";
+
+  /// ```dart
+  /// "Shown as the value's placeholder"
+  /// ```
+  String get hintPlaceholder => """Shown as the value's placeholder""";
+
+  /// ```dart
+  /// "Multi-line text area"
+  /// ```
+  String get multiline => """Multi-line text area""";
+
+  /// ```dart
+  /// "Options"
+  /// ```
+  String get options => """Options""";
+
+  /// ```dart
+  /// "Option label"
+  /// ```
+  String get optionPlaceholder => """Option label""";
+
+  /// ```dart
+  /// "Add option"
+  /// ```
+  String get addOption => """Add option""";
+
+  /// ```dart
+  /// "Remove option"
+  /// ```
+  String get removeOption => """Remove option""";
+
+  /// ```dart
+  /// "Date entry"
+  /// ```
+  String get entryMode => """Date entry""";
+
+  /// ```dart
+  /// "Absolute"
+  /// ```
+  String get dateAbsolute => """Absolute""";
+
+  /// ```dart
+  /// "Relative"
+  /// ```
+  String get dateRelative => """Relative""";
+
+  /// ```dart
+  /// "Default offset (days)"
+  /// ```
+  String get defaultOffset => """Default offset (days)""";
+
+  /// ```dart
+  /// "e.g. 7"
+  /// ```
+  String get defaultOffsetPlaceholder => """e.g. 7""";
+
+  /// ```dart
+  /// "Remind by default"
+  /// ```
+  String get notifyDefault => """Remind by default""";
+
+  /// ```dart
+  /// "Remind"
+  /// ```
+  String get leadTime => """Remind""";
+
+  /// ```dart
+  /// "On the day"
+  /// ```
+  String get leadOnDay => """On the day""";
+
+  /// ```dart
+  /// "1 day before"
+  /// ```
+  String get leadDay1 => """1 day before""";
+
+  /// ```dart
+  /// "2 days before"
+  /// ```
+  String get leadDay2 => """2 days before""";
+
+  /// ```dart
+  /// "3 days before"
+  /// ```
+  String get leadDay3 => """3 days before""";
+
+  /// ```dart
+  /// "1 week before"
+  /// ```
+  String get leadWeek1 => """1 week before""";
+
+  /// ```dart
+  /// "Reminder override"
+  /// ```
+  String get overridePolicy => """Reminder override""";
+
+  /// ```dart
+  /// "Same reminder for every item"
+  /// ```
+  String get overrideFieldOnly => """Same reminder for every item""";
+
+  /// ```dart
+  /// "Each item sets its own reminder"
+  /// ```
+  String get overrideItem => """Each item sets its own reminder""";
+
+  /// ```dart
+  /// "Stop reminding once the item is done"
+  /// ```
+  String get stopWhenDone => """Stop reminding once the item is done""";
+
+  /// ```dart
+  /// "Default value"
+  /// ```
+  String get defaultValue => """Default value""";
+
+  /// ```dart
+  /// "On by default"
+  /// ```
+  String get defaultChecked => """On by default""";
+
+  /// ```dart
+  /// "No default"
+  /// ```
+  String get noDefault => """No default""";
+
+  /// ```dart
+  /// "Done"
+  /// ```
+  String get done => """Done""";
+
+  /// ```dart
+  /// "Option in use"
+  /// ```
+  String get remapTitle => """Option in use""";
+
+  /// ```dart
+  /// "Clear it from those items"
+  /// ```
+  String get remapClear => """Clear it from those items""";
+
+  /// ```dart
+  /// "Move it to ${label}"
+  /// ```
+  String remapMoveTo(String label) => """Move it to ${label}""";
+
+  /// ```dart
+  /// "${_plural(count, one: '${label} is used by 1 item. What should happen to it?', many: '${label} is used by ${count} items. What should happen to them?')}"
+  /// ```
+  String remapPrompt(int count, String label) =>
+      """${_plural(count, one: '${label} is used by 1 item. What should happen to it?', many: '${label} is used by ${count} items. What should happen to them?')}""";
+}
+
+class TypesCustomFieldsMessages {
+  final CustomFieldsMessages _parent;
+  const TypesCustomFieldsMessages(this._parent);
+
+  /// ```dart
+  /// "Text"
+  /// ```
+  String get text => """Text""";
+
+  /// ```dart
+  /// "Number"
+  /// ```
+  String get number => """Number""";
+
+  /// ```dart
+  /// "Checkbox"
+  /// ```
+  String get checkbox => """Checkbox""";
+
+  /// ```dart
+  /// "Date"
+  /// ```
+  String get date => """Date""";
+
+  /// ```dart
+  /// "Select"
+  /// ```
+  String get select => """Select""";
 }
 
 class StoresMessages {
@@ -5124,6 +5380,55 @@ Password: pantry-rocks""",
   """categories.sort.nameAZ""": """Name A–Z""",
   """categories.sort.nameZA""": """Name Z–A""",
   """categories.sort.custom""": """Custom""",
+  """customFields.manageTitle""": """Custom fields""",
+  """customFields.empty""":
+      """No custom fields yet. Add one to attach extra info to items.""",
+  """customFields.addField""": """Add field""",
+  """customFields.allLists""": """All lists""",
+  """customFields.deleteTitle""": """Delete field""",
+  """customFields.deleteConfirm""":
+      """Delete this field? Values already set on items are kept but hidden.""",
+  """customFields.optionDeleteFailed""": """Failed to remove option.""",
+  """customFields.types.text""": """Text""",
+  """customFields.types.number""": """Number""",
+  """customFields.types.checkbox""": """Checkbox""",
+  """customFields.types.date""": """Date""",
+  """customFields.types.select""": """Select""",
+  """customFields.name""": """Name""",
+  """customFields.namePlaceholder""": """e.g. Expiry, Aisle""",
+  """customFields.type""": """Type""",
+  """customFields.typeLocked""":
+      """The type can't be changed after the field is created.""",
+  """customFields.scope""": """Scope""",
+  """customFields.hint""": """Hint text""",
+  """customFields.hintPlaceholder""": """Shown as the value's placeholder""",
+  """customFields.multiline""": """Multi-line text area""",
+  """customFields.options""": """Options""",
+  """customFields.optionPlaceholder""": """Option label""",
+  """customFields.addOption""": """Add option""",
+  """customFields.removeOption""": """Remove option""",
+  """customFields.entryMode""": """Date entry""",
+  """customFields.dateAbsolute""": """Absolute""",
+  """customFields.dateRelative""": """Relative""",
+  """customFields.defaultOffset""": """Default offset (days)""",
+  """customFields.defaultOffsetPlaceholder""": """e.g. 7""",
+  """customFields.notifyDefault""": """Remind by default""",
+  """customFields.leadTime""": """Remind""",
+  """customFields.leadOnDay""": """On the day""",
+  """customFields.leadDay1""": """1 day before""",
+  """customFields.leadDay2""": """2 days before""",
+  """customFields.leadDay3""": """3 days before""",
+  """customFields.leadWeek1""": """1 week before""",
+  """customFields.overridePolicy""": """Reminder override""",
+  """customFields.overrideFieldOnly""": """Same reminder for every item""",
+  """customFields.overrideItem""": """Each item sets its own reminder""",
+  """customFields.stopWhenDone""": """Stop reminding once the item is done""",
+  """customFields.defaultValue""": """Default value""",
+  """customFields.defaultChecked""": """On by default""",
+  """customFields.noDefault""": """No default""",
+  """customFields.done""": """Done""",
+  """customFields.remapTitle""": """Option in use""",
+  """customFields.remapClear""": """Clear it from those items""",
   """stores.manageTitle""": """Manage stores""",
   """stores.noStores""": """No stores yet.""",
   """stores.editTitle""": """Edit store""",

--- a/lib/i18n/messages.i18n.yaml
+++ b/lib/i18n/messages.i18n.yaml
@@ -304,6 +304,57 @@ categories:
     nameZA: "Name Z–A"
     custom: Custom
 
+customFields:
+  manageTitle: Custom fields
+  empty: No custom fields yet. Add one to attach extra info to items.
+  addField: Add field
+  allLists: All lists
+  deleteTitle: Delete field
+  deleteConfirm: "Delete this field? Values already set on items are kept but hidden."
+  optionDeleteFailed: Failed to remove option.
+  types:
+    text: Text
+    number: Number
+    checkbox: Checkbox
+    date: Date
+    select: Select
+  name: Name
+  namePlaceholder: "e.g. Expiry, Aisle"
+  type: Type
+  typeLocked: The type can't be changed after the field is created.
+  scope: Scope
+  hint: Hint text
+  hintPlaceholder: Shown as the value's placeholder
+  multiline: Multi-line text area
+  options: Options
+  optionPlaceholder: Option label
+  addOption: Add option
+  removeOption: Remove option
+  entryMode: Date entry
+  dateAbsolute: Absolute
+  dateRelative: Relative
+  defaultOffset: "Default offset (days)"
+  defaultOffsetPlaceholder: "e.g. 7"
+  notifyDefault: Remind by default
+  leadTime: Remind
+  leadOnDay: On the day
+  leadDay1: 1 day before
+  leadDay2: 2 days before
+  leadDay3: 3 days before
+  leadWeek1: 1 week before
+  overridePolicy: Reminder override
+  overrideFieldOnly: Same reminder for every item
+  overrideItem: Each item sets its own reminder
+  stopWhenDone: Stop reminding once the item is done
+  defaultValue: Default value
+  defaultChecked: On by default
+  noDefault: No default
+  done: Done
+  remapTitle: Option in use
+  remapClear: Clear it from those items
+  remapMoveTo(String label): "Move it to ${label}"
+  remapPrompt(int count, String label): "${_plural(count, one: '${label} is used by 1 item. What should happen to it?', many: '${label} is used by ${count} items. What should happen to them?')}"
+
 stores:
   manageTitle: Manage stores
   noStores: No stores yet.

--- a/lib/i18n/messages.i18n.yaml
+++ b/lib/i18n/messages.i18n.yaml
@@ -349,6 +349,13 @@ customFields:
   defaultValue: Default value
   defaultChecked: On by default
   noDefault: No default
+  noValue: No value
+  daysFromToday: Days from today
+  due(String date): "Due ${date}"
+  reanchor: Re-anchor date
+  remindMe: Remind me
+  customReminder: Custom reminder for this item
+  useFieldDefault: Use field default
   done: Done
   remapTitle: Option in use
   remapClear: Clear it from those items

--- a/lib/i18n/messages_de.i18n.dart
+++ b/lib/i18n/messages_de.i18n.dart
@@ -1856,6 +1856,41 @@ class CustomFieldsMessagesDe extends CustomFieldsMessages {
   String get noDefault => """Kein Standard""";
 
   /// ```dart
+  /// "Kein Wert"
+  /// ```
+  String get noValue => """Kein Wert""";
+
+  /// ```dart
+  /// "Tage ab heute"
+  /// ```
+  String get daysFromToday => """Tage ab heute""";
+
+  /// ```dart
+  /// "Fällig am ${date}"
+  /// ```
+  String due(String date) => """Fällig am ${date}""";
+
+  /// ```dart
+  /// "Datum neu verankern"
+  /// ```
+  String get reanchor => """Datum neu verankern""";
+
+  /// ```dart
+  /// "Mich erinnern"
+  /// ```
+  String get remindMe => """Mich erinnern""";
+
+  /// ```dart
+  /// "Eigene Erinnerung für diesen Eintrag"
+  /// ```
+  String get customReminder => """Eigene Erinnerung für diesen Eintrag""";
+
+  /// ```dart
+  /// "Feldstandard verwenden"
+  /// ```
+  String get useFieldDefault => """Feldstandard verwenden""";
+
+  /// ```dart
   /// "Fertig"
   /// ```
   String get done => """Fertig""";
@@ -5498,6 +5533,12 @@ Passwort: pantry-rocks""",
   """customFields.defaultValue""": """Standardwert""",
   """customFields.defaultChecked""": """Standardmäßig aktiviert""",
   """customFields.noDefault""": """Kein Standard""",
+  """customFields.noValue""": """Kein Wert""",
+  """customFields.daysFromToday""": """Tage ab heute""",
+  """customFields.reanchor""": """Datum neu verankern""",
+  """customFields.remindMe""": """Mich erinnern""",
+  """customFields.customReminder""": """Eigene Erinnerung für diesen Eintrag""",
+  """customFields.useFieldDefault""": """Feldstandard verwenden""",
   """customFields.done""": """Fertig""",
   """customFields.remapTitle""": """Option in Verwendung""",
   """customFields.remapClear""": """Aus diesen Einträgen entfernen""",

--- a/lib/i18n/messages_de.i18n.dart
+++ b/lib/i18n/messages_de.i18n.dart
@@ -75,6 +75,7 @@ class MessagesDe extends Messages {
   SettingsMessagesDe get settings => SettingsMessagesDe(this);
   NotificationsMessagesDe get notifications => NotificationsMessagesDe(this);
   CategoriesMessagesDe get categories => CategoriesMessagesDe(this);
+  CustomFieldsMessagesDe get customFields => CustomFieldsMessagesDe(this);
   StoresMessagesDe get stores => StoresMessagesDe(this);
   LabelsMessagesDe get labels => LabelsMessagesDe(this);
   ChecklistsMessagesDe get checklists => ChecklistsMessagesDe(this);
@@ -1652,6 +1653,263 @@ class SortCategoriesMessagesDe extends SortCategoriesMessages {
   /// "Benutzerdefiniert"
   /// ```
   String get custom => """Benutzerdefiniert""";
+}
+
+class CustomFieldsMessagesDe extends CustomFieldsMessages {
+  final MessagesDe _parent;
+  const CustomFieldsMessagesDe(this._parent) : super(_parent);
+
+  /// ```dart
+  /// "Benutzerdefinierte Felder"
+  /// ```
+  String get manageTitle => """Benutzerdefinierte Felder""";
+
+  /// ```dart
+  /// "Noch keine benutzerdefinierten Felder. Füge eines hinzu, um Einträgen zusätzliche Informationen anzuhängen."
+  /// ```
+  String get empty =>
+      """Noch keine benutzerdefinierten Felder. Füge eines hinzu, um Einträgen zusätzliche Informationen anzuhängen.""";
+
+  /// ```dart
+  /// "Feld hinzufügen"
+  /// ```
+  String get addField => """Feld hinzufügen""";
+
+  /// ```dart
+  /// "Alle Listen"
+  /// ```
+  String get allLists => """Alle Listen""";
+
+  /// ```dart
+  /// "Feld löschen"
+  /// ```
+  String get deleteTitle => """Feld löschen""";
+
+  /// ```dart
+  /// "Dieses Feld löschen? Bereits gesetzte Werte bleiben erhalten, werden aber ausgeblendet."
+  /// ```
+  String get deleteConfirm =>
+      """Dieses Feld löschen? Bereits gesetzte Werte bleiben erhalten, werden aber ausgeblendet.""";
+
+  /// ```dart
+  /// "Option konnte nicht entfernt werden."
+  /// ```
+  String get optionDeleteFailed => """Option konnte nicht entfernt werden.""";
+  TypesCustomFieldsMessagesDe get types => TypesCustomFieldsMessagesDe(this);
+
+  /// ```dart
+  /// "Name"
+  /// ```
+  String get name => """Name""";
+
+  /// ```dart
+  /// "z. B. Ablaufdatum, Gang"
+  /// ```
+  String get namePlaceholder => """z. B. Ablaufdatum, Gang""";
+
+  /// ```dart
+  /// "Typ"
+  /// ```
+  String get type => """Typ""";
+
+  /// ```dart
+  /// "Der Typ kann nach dem Erstellen des Felds nicht mehr geändert werden."
+  /// ```
+  String get typeLocked =>
+      """Der Typ kann nach dem Erstellen des Felds nicht mehr geändert werden.""";
+
+  /// ```dart
+  /// "Geltungsbereich"
+  /// ```
+  String get scope => """Geltungsbereich""";
+
+  /// ```dart
+  /// "Hinweistext"
+  /// ```
+  String get hint => """Hinweistext""";
+
+  /// ```dart
+  /// "Wird als Platzhalter des Werts angezeigt"
+  /// ```
+  String get hintPlaceholder => """Wird als Platzhalter des Werts angezeigt""";
+
+  /// ```dart
+  /// "Mehrzeiliges Textfeld"
+  /// ```
+  String get multiline => """Mehrzeiliges Textfeld""";
+
+  /// ```dart
+  /// "Optionen"
+  /// ```
+  String get options => """Optionen""";
+
+  /// ```dart
+  /// "Optionsbezeichnung"
+  /// ```
+  String get optionPlaceholder => """Optionsbezeichnung""";
+
+  /// ```dart
+  /// "Option hinzufügen"
+  /// ```
+  String get addOption => """Option hinzufügen""";
+
+  /// ```dart
+  /// "Option entfernen"
+  /// ```
+  String get removeOption => """Option entfernen""";
+
+  /// ```dart
+  /// "Datumseingabe"
+  /// ```
+  String get entryMode => """Datumseingabe""";
+
+  /// ```dart
+  /// "Absolut"
+  /// ```
+  String get dateAbsolute => """Absolut""";
+
+  /// ```dart
+  /// "Relativ"
+  /// ```
+  String get dateRelative => """Relativ""";
+
+  /// ```dart
+  /// "Standard-Versatz (Tage)"
+  /// ```
+  String get defaultOffset => """Standard-Versatz (Tage)""";
+
+  /// ```dart
+  /// "z. B. 7"
+  /// ```
+  String get defaultOffsetPlaceholder => """z. B. 7""";
+
+  /// ```dart
+  /// "Standardmäßig erinnern"
+  /// ```
+  String get notifyDefault => """Standardmäßig erinnern""";
+
+  /// ```dart
+  /// "Erinnern"
+  /// ```
+  String get leadTime => """Erinnern""";
+
+  /// ```dart
+  /// "Am selben Tag"
+  /// ```
+  String get leadOnDay => """Am selben Tag""";
+
+  /// ```dart
+  /// "1 Tag vorher"
+  /// ```
+  String get leadDay1 => """1 Tag vorher""";
+
+  /// ```dart
+  /// "2 Tage vorher"
+  /// ```
+  String get leadDay2 => """2 Tage vorher""";
+
+  /// ```dart
+  /// "3 Tage vorher"
+  /// ```
+  String get leadDay3 => """3 Tage vorher""";
+
+  /// ```dart
+  /// "1 Woche vorher"
+  /// ```
+  String get leadWeek1 => """1 Woche vorher""";
+
+  /// ```dart
+  /// "Erinnerungs-Übersteuerung"
+  /// ```
+  String get overridePolicy => """Erinnerungs-Übersteuerung""";
+
+  /// ```dart
+  /// "Gleiche Erinnerung für jeden Eintrag"
+  /// ```
+  String get overrideFieldOnly => """Gleiche Erinnerung für jeden Eintrag""";
+
+  /// ```dart
+  /// "Jeder Eintrag legt seine eigene Erinnerung fest"
+  /// ```
+  String get overrideItem =>
+      """Jeder Eintrag legt seine eigene Erinnerung fest""";
+
+  /// ```dart
+  /// "Nicht mehr erinnern, sobald der Eintrag erledigt ist"
+  /// ```
+  String get stopWhenDone =>
+      """Nicht mehr erinnern, sobald der Eintrag erledigt ist""";
+
+  /// ```dart
+  /// "Standardwert"
+  /// ```
+  String get defaultValue => """Standardwert""";
+
+  /// ```dart
+  /// "Standardmäßig aktiviert"
+  /// ```
+  String get defaultChecked => """Standardmäßig aktiviert""";
+
+  /// ```dart
+  /// "Kein Standard"
+  /// ```
+  String get noDefault => """Kein Standard""";
+
+  /// ```dart
+  /// "Fertig"
+  /// ```
+  String get done => """Fertig""";
+
+  /// ```dart
+  /// "Option in Verwendung"
+  /// ```
+  String get remapTitle => """Option in Verwendung""";
+
+  /// ```dart
+  /// "Aus diesen Einträgen entfernen"
+  /// ```
+  String get remapClear => """Aus diesen Einträgen entfernen""";
+
+  /// ```dart
+  /// "Zu ${label} verschieben"
+  /// ```
+  String remapMoveTo(String label) => """Zu ${label} verschieben""";
+
+  /// ```dart
+  /// "${_plural(count, one: '${label} wird von 1 Eintrag verwendet. Was soll damit geschehen?', many: '${label} wird von ${count} Einträgen verwendet. Was soll damit geschehen?')}"
+  /// ```
+  String remapPrompt(int count, String label) =>
+      """${_plural(count, one: '${label} wird von 1 Eintrag verwendet. Was soll damit geschehen?', many: '${label} wird von ${count} Einträgen verwendet. Was soll damit geschehen?')}""";
+}
+
+class TypesCustomFieldsMessagesDe extends TypesCustomFieldsMessages {
+  final CustomFieldsMessagesDe _parent;
+  const TypesCustomFieldsMessagesDe(this._parent) : super(_parent);
+
+  /// ```dart
+  /// "Text"
+  /// ```
+  String get text => """Text""";
+
+  /// ```dart
+  /// "Zahl"
+  /// ```
+  String get number => """Zahl""";
+
+  /// ```dart
+  /// "Kontrollkästchen"
+  /// ```
+  String get checkbox => """Kontrollkästchen""";
+
+  /// ```dart
+  /// "Datum"
+  /// ```
+  String get date => """Datum""";
+
+  /// ```dart
+  /// "Auswahl"
+  /// ```
+  String get select => """Auswahl""";
 }
 
 class StoresMessagesDe extends StoresMessages {
@@ -5189,6 +5447,60 @@ Passwort: pantry-rocks""",
   """categories.sort.nameAZ""": """Name A–Z""",
   """categories.sort.nameZA""": """Name Z–A""",
   """categories.sort.custom""": """Benutzerdefiniert""",
+  """customFields.manageTitle""": """Benutzerdefinierte Felder""",
+  """customFields.empty""":
+      """Noch keine benutzerdefinierten Felder. Füge eines hinzu, um Einträgen zusätzliche Informationen anzuhängen.""",
+  """customFields.addField""": """Feld hinzufügen""",
+  """customFields.allLists""": """Alle Listen""",
+  """customFields.deleteTitle""": """Feld löschen""",
+  """customFields.deleteConfirm""":
+      """Dieses Feld löschen? Bereits gesetzte Werte bleiben erhalten, werden aber ausgeblendet.""",
+  """customFields.optionDeleteFailed""":
+      """Option konnte nicht entfernt werden.""",
+  """customFields.types.text""": """Text""",
+  """customFields.types.number""": """Zahl""",
+  """customFields.types.checkbox""": """Kontrollkästchen""",
+  """customFields.types.date""": """Datum""",
+  """customFields.types.select""": """Auswahl""",
+  """customFields.name""": """Name""",
+  """customFields.namePlaceholder""": """z. B. Ablaufdatum, Gang""",
+  """customFields.type""": """Typ""",
+  """customFields.typeLocked""":
+      """Der Typ kann nach dem Erstellen des Felds nicht mehr geändert werden.""",
+  """customFields.scope""": """Geltungsbereich""",
+  """customFields.hint""": """Hinweistext""",
+  """customFields.hintPlaceholder""":
+      """Wird als Platzhalter des Werts angezeigt""",
+  """customFields.multiline""": """Mehrzeiliges Textfeld""",
+  """customFields.options""": """Optionen""",
+  """customFields.optionPlaceholder""": """Optionsbezeichnung""",
+  """customFields.addOption""": """Option hinzufügen""",
+  """customFields.removeOption""": """Option entfernen""",
+  """customFields.entryMode""": """Datumseingabe""",
+  """customFields.dateAbsolute""": """Absolut""",
+  """customFields.dateRelative""": """Relativ""",
+  """customFields.defaultOffset""": """Standard-Versatz (Tage)""",
+  """customFields.defaultOffsetPlaceholder""": """z. B. 7""",
+  """customFields.notifyDefault""": """Standardmäßig erinnern""",
+  """customFields.leadTime""": """Erinnern""",
+  """customFields.leadOnDay""": """Am selben Tag""",
+  """customFields.leadDay1""": """1 Tag vorher""",
+  """customFields.leadDay2""": """2 Tage vorher""",
+  """customFields.leadDay3""": """3 Tage vorher""",
+  """customFields.leadWeek1""": """1 Woche vorher""",
+  """customFields.overridePolicy""": """Erinnerungs-Übersteuerung""",
+  """customFields.overrideFieldOnly""":
+      """Gleiche Erinnerung für jeden Eintrag""",
+  """customFields.overrideItem""":
+      """Jeder Eintrag legt seine eigene Erinnerung fest""",
+  """customFields.stopWhenDone""":
+      """Nicht mehr erinnern, sobald der Eintrag erledigt ist""",
+  """customFields.defaultValue""": """Standardwert""",
+  """customFields.defaultChecked""": """Standardmäßig aktiviert""",
+  """customFields.noDefault""": """Kein Standard""",
+  """customFields.done""": """Fertig""",
+  """customFields.remapTitle""": """Option in Verwendung""",
+  """customFields.remapClear""": """Aus diesen Einträgen entfernen""",
   """stores.manageTitle""": """Geschäfte verwalten""",
   """stores.noStores""": """Noch keine Geschäfte.""",
   """stores.editTitle""": """Geschäft bearbeiten""",

--- a/lib/i18n/messages_de.i18n.yaml
+++ b/lib/i18n/messages_de.i18n.yaml
@@ -349,6 +349,13 @@ customFields:
   defaultValue: Standardwert
   defaultChecked: Standardmäßig aktiviert
   noDefault: Kein Standard
+  noValue: Kein Wert
+  daysFromToday: Tage ab heute
+  due(String date): "Fällig am ${date}"
+  reanchor: Datum neu verankern
+  remindMe: Mich erinnern
+  customReminder: Eigene Erinnerung für diesen Eintrag
+  useFieldDefault: Feldstandard verwenden
   done: Fertig
   remapTitle: Option in Verwendung
   remapClear: Aus diesen Einträgen entfernen

--- a/lib/i18n/messages_de.i18n.yaml
+++ b/lib/i18n/messages_de.i18n.yaml
@@ -304,6 +304,57 @@ categories:
     nameZA: "Name Z–A"
     custom: Benutzerdefiniert
 
+customFields:
+  manageTitle: Benutzerdefinierte Felder
+  empty: "Noch keine benutzerdefinierten Felder. Füge eines hinzu, um Einträgen zusätzliche Informationen anzuhängen."
+  addField: Feld hinzufügen
+  allLists: Alle Listen
+  deleteTitle: Feld löschen
+  deleteConfirm: "Dieses Feld löschen? Bereits gesetzte Werte bleiben erhalten, werden aber ausgeblendet."
+  optionDeleteFailed: Option konnte nicht entfernt werden.
+  types:
+    text: Text
+    number: Zahl
+    checkbox: Kontrollkästchen
+    date: Datum
+    select: Auswahl
+  name: Name
+  namePlaceholder: "z. B. Ablaufdatum, Gang"
+  type: Typ
+  typeLocked: Der Typ kann nach dem Erstellen des Felds nicht mehr geändert werden.
+  scope: Geltungsbereich
+  hint: Hinweistext
+  hintPlaceholder: Wird als Platzhalter des Werts angezeigt
+  multiline: Mehrzeiliges Textfeld
+  options: Optionen
+  optionPlaceholder: Optionsbezeichnung
+  addOption: Option hinzufügen
+  removeOption: Option entfernen
+  entryMode: Datumseingabe
+  dateAbsolute: Absolut
+  dateRelative: Relativ
+  defaultOffset: "Standard-Versatz (Tage)"
+  defaultOffsetPlaceholder: "z. B. 7"
+  notifyDefault: Standardmäßig erinnern
+  leadTime: Erinnern
+  leadOnDay: Am selben Tag
+  leadDay1: 1 Tag vorher
+  leadDay2: 2 Tage vorher
+  leadDay3: 3 Tage vorher
+  leadWeek1: 1 Woche vorher
+  overridePolicy: Erinnerungs-Übersteuerung
+  overrideFieldOnly: Gleiche Erinnerung für jeden Eintrag
+  overrideItem: Jeder Eintrag legt seine eigene Erinnerung fest
+  stopWhenDone: Nicht mehr erinnern, sobald der Eintrag erledigt ist
+  defaultValue: Standardwert
+  defaultChecked: Standardmäßig aktiviert
+  noDefault: Kein Standard
+  done: Fertig
+  remapTitle: Option in Verwendung
+  remapClear: Aus diesen Einträgen entfernen
+  remapMoveTo(String label): "Zu ${label} verschieben"
+  remapPrompt(int count, String label): "${_plural(count, one: '${label} wird von 1 Eintrag verwendet. Was soll damit geschehen?', many: '${label} wird von ${count} Einträgen verwendet. Was soll damit geschehen?')}"
+
 stores:
   manageTitle: Geschäfte verwalten
   noStores: Noch keine Geschäfte.

--- a/lib/i18n/messages_es.i18n.dart
+++ b/lib/i18n/messages_es.i18n.dart
@@ -1856,6 +1856,41 @@ class CustomFieldsMessagesEs extends CustomFieldsMessages {
   String get noDefault => """Sin valor predeterminado""";
 
   /// ```dart
+  /// "Sin valor"
+  /// ```
+  String get noValue => """Sin valor""";
+
+  /// ```dart
+  /// "Días desde hoy"
+  /// ```
+  String get daysFromToday => """Días desde hoy""";
+
+  /// ```dart
+  /// "Vence el ${date}"
+  /// ```
+  String due(String date) => """Vence el ${date}""";
+
+  /// ```dart
+  /// "Reanclar fecha"
+  /// ```
+  String get reanchor => """Reanclar fecha""";
+
+  /// ```dart
+  /// "Recordármelo"
+  /// ```
+  String get remindMe => """Recordármelo""";
+
+  /// ```dart
+  /// "Recordatorio propio para este artículo"
+  /// ```
+  String get customReminder => """Recordatorio propio para este artículo""";
+
+  /// ```dart
+  /// "Usar el valor predeterminado del campo"
+  /// ```
+  String get useFieldDefault => """Usar el valor predeterminado del campo""";
+
+  /// ```dart
   /// "Hecho"
   /// ```
   String get done => """Hecho""";
@@ -5481,6 +5516,14 @@ Contraseña: pantry-rocks""",
   """customFields.defaultValue""": """Valor predeterminado""",
   """customFields.defaultChecked""": """Activado de forma predeterminada""",
   """customFields.noDefault""": """Sin valor predeterminado""",
+  """customFields.noValue""": """Sin valor""",
+  """customFields.daysFromToday""": """Días desde hoy""",
+  """customFields.reanchor""": """Reanclar fecha""",
+  """customFields.remindMe""": """Recordármelo""",
+  """customFields.customReminder""":
+      """Recordatorio propio para este artículo""",
+  """customFields.useFieldDefault""":
+      """Usar el valor predeterminado del campo""",
   """customFields.done""": """Hecho""",
   """customFields.remapTitle""": """Opción en uso""",
   """customFields.remapClear""": """Quitarla de esos artículos""",

--- a/lib/i18n/messages_es.i18n.dart
+++ b/lib/i18n/messages_es.i18n.dart
@@ -75,6 +75,7 @@ class MessagesEs extends Messages {
   SettingsMessagesEs get settings => SettingsMessagesEs(this);
   NotificationsMessagesEs get notifications => NotificationsMessagesEs(this);
   CategoriesMessagesEs get categories => CategoriesMessagesEs(this);
+  CustomFieldsMessagesEs get customFields => CustomFieldsMessagesEs(this);
   StoresMessagesEs get stores => StoresMessagesEs(this);
   LabelsMessagesEs get labels => LabelsMessagesEs(this);
   ChecklistsMessagesEs get checklists => ChecklistsMessagesEs(this);
@@ -1651,6 +1652,264 @@ class SortCategoriesMessagesEs extends SortCategoriesMessages {
   /// "Personalizado"
   /// ```
   String get custom => """Personalizado""";
+}
+
+class CustomFieldsMessagesEs extends CustomFieldsMessages {
+  final MessagesEs _parent;
+  const CustomFieldsMessagesEs(this._parent) : super(_parent);
+
+  /// ```dart
+  /// "Campos personalizados"
+  /// ```
+  String get manageTitle => """Campos personalizados""";
+
+  /// ```dart
+  /// "Aún no hay campos personalizados. Añade uno para adjuntar información adicional a los artículos."
+  /// ```
+  String get empty =>
+      """Aún no hay campos personalizados. Añade uno para adjuntar información adicional a los artículos.""";
+
+  /// ```dart
+  /// "Añadir campo"
+  /// ```
+  String get addField => """Añadir campo""";
+
+  /// ```dart
+  /// "Todas las listas"
+  /// ```
+  String get allLists => """Todas las listas""";
+
+  /// ```dart
+  /// "Eliminar campo"
+  /// ```
+  String get deleteTitle => """Eliminar campo""";
+
+  /// ```dart
+  /// "¿Eliminar este campo? Los valores ya asignados a los artículos se conservan pero se ocultan."
+  /// ```
+  String get deleteConfirm =>
+      """¿Eliminar este campo? Los valores ya asignados a los artículos se conservan pero se ocultan.""";
+
+  /// ```dart
+  /// "No se pudo eliminar la opción."
+  /// ```
+  String get optionDeleteFailed => """No se pudo eliminar la opción.""";
+  TypesCustomFieldsMessagesEs get types => TypesCustomFieldsMessagesEs(this);
+
+  /// ```dart
+  /// "Nombre"
+  /// ```
+  String get name => """Nombre""";
+
+  /// ```dart
+  /// "p. ej. Caducidad, Pasillo"
+  /// ```
+  String get namePlaceholder => """p. ej. Caducidad, Pasillo""";
+
+  /// ```dart
+  /// "Tipo"
+  /// ```
+  String get type => """Tipo""";
+
+  /// ```dart
+  /// "El tipo no se puede cambiar una vez creado el campo."
+  /// ```
+  String get typeLocked =>
+      """El tipo no se puede cambiar una vez creado el campo.""";
+
+  /// ```dart
+  /// "Ámbito"
+  /// ```
+  String get scope => """Ámbito""";
+
+  /// ```dart
+  /// "Texto de ayuda"
+  /// ```
+  String get hint => """Texto de ayuda""";
+
+  /// ```dart
+  /// "Se muestra como marcador de posición del valor"
+  /// ```
+  String get hintPlaceholder =>
+      """Se muestra como marcador de posición del valor""";
+
+  /// ```dart
+  /// "Área de texto multilínea"
+  /// ```
+  String get multiline => """Área de texto multilínea""";
+
+  /// ```dart
+  /// "Opciones"
+  /// ```
+  String get options => """Opciones""";
+
+  /// ```dart
+  /// "Etiqueta de la opción"
+  /// ```
+  String get optionPlaceholder => """Etiqueta de la opción""";
+
+  /// ```dart
+  /// "Añadir opción"
+  /// ```
+  String get addOption => """Añadir opción""";
+
+  /// ```dart
+  /// "Quitar opción"
+  /// ```
+  String get removeOption => """Quitar opción""";
+
+  /// ```dart
+  /// "Entrada de fecha"
+  /// ```
+  String get entryMode => """Entrada de fecha""";
+
+  /// ```dart
+  /// "Absoluta"
+  /// ```
+  String get dateAbsolute => """Absoluta""";
+
+  /// ```dart
+  /// "Relativa"
+  /// ```
+  String get dateRelative => """Relativa""";
+
+  /// ```dart
+  /// "Desfase predeterminado (días)"
+  /// ```
+  String get defaultOffset => """Desfase predeterminado (días)""";
+
+  /// ```dart
+  /// "p. ej. 7"
+  /// ```
+  String get defaultOffsetPlaceholder => """p. ej. 7""";
+
+  /// ```dart
+  /// "Recordar de forma predeterminada"
+  /// ```
+  String get notifyDefault => """Recordar de forma predeterminada""";
+
+  /// ```dart
+  /// "Recordar"
+  /// ```
+  String get leadTime => """Recordar""";
+
+  /// ```dart
+  /// "El mismo día"
+  /// ```
+  String get leadOnDay => """El mismo día""";
+
+  /// ```dart
+  /// "1 día antes"
+  /// ```
+  String get leadDay1 => """1 día antes""";
+
+  /// ```dart
+  /// "2 días antes"
+  /// ```
+  String get leadDay2 => """2 días antes""";
+
+  /// ```dart
+  /// "3 días antes"
+  /// ```
+  String get leadDay3 => """3 días antes""";
+
+  /// ```dart
+  /// "1 semana antes"
+  /// ```
+  String get leadWeek1 => """1 semana antes""";
+
+  /// ```dart
+  /// "Anulación del recordatorio"
+  /// ```
+  String get overridePolicy => """Anulación del recordatorio""";
+
+  /// ```dart
+  /// "El mismo recordatorio para cada artículo"
+  /// ```
+  String get overrideFieldOnly =>
+      """El mismo recordatorio para cada artículo""";
+
+  /// ```dart
+  /// "Cada artículo define su propio recordatorio"
+  /// ```
+  String get overrideItem => """Cada artículo define su propio recordatorio""";
+
+  /// ```dart
+  /// "Dejar de recordar cuando el artículo esté completado"
+  /// ```
+  String get stopWhenDone =>
+      """Dejar de recordar cuando el artículo esté completado""";
+
+  /// ```dart
+  /// "Valor predeterminado"
+  /// ```
+  String get defaultValue => """Valor predeterminado""";
+
+  /// ```dart
+  /// "Activado de forma predeterminada"
+  /// ```
+  String get defaultChecked => """Activado de forma predeterminada""";
+
+  /// ```dart
+  /// "Sin valor predeterminado"
+  /// ```
+  String get noDefault => """Sin valor predeterminado""";
+
+  /// ```dart
+  /// "Hecho"
+  /// ```
+  String get done => """Hecho""";
+
+  /// ```dart
+  /// "Opción en uso"
+  /// ```
+  String get remapTitle => """Opción en uso""";
+
+  /// ```dart
+  /// "Quitarla de esos artículos"
+  /// ```
+  String get remapClear => """Quitarla de esos artículos""";
+
+  /// ```dart
+  /// "Moverla a ${label}"
+  /// ```
+  String remapMoveTo(String label) => """Moverla a ${label}""";
+
+  /// ```dart
+  /// "${_plural(count, one: '${label} la usa 1 artículo. ¿Qué debe pasar con él?', many: '${label} la usan ${count} artículos. ¿Qué debe pasar con ellos?')}"
+  /// ```
+  String remapPrompt(int count, String label) =>
+      """${_plural(count, one: '${label} la usa 1 artículo. ¿Qué debe pasar con él?', many: '${label} la usan ${count} artículos. ¿Qué debe pasar con ellos?')}""";
+}
+
+class TypesCustomFieldsMessagesEs extends TypesCustomFieldsMessages {
+  final CustomFieldsMessagesEs _parent;
+  const TypesCustomFieldsMessagesEs(this._parent) : super(_parent);
+
+  /// ```dart
+  /// "Texto"
+  /// ```
+  String get text => """Texto""";
+
+  /// ```dart
+  /// "Número"
+  /// ```
+  String get number => """Número""";
+
+  /// ```dart
+  /// "Casilla"
+  /// ```
+  String get checkbox => """Casilla""";
+
+  /// ```dart
+  /// "Fecha"
+  /// ```
+  String get date => """Fecha""";
+
+  /// ```dart
+  /// "Selección"
+  /// ```
+  String get select => """Selección""";
 }
 
 class StoresMessagesEs extends StoresMessages {
@@ -5172,6 +5431,59 @@ Contraseña: pantry-rocks""",
   """categories.sort.nameAZ""": """Nombre A–Z""",
   """categories.sort.nameZA""": """Nombre Z–A""",
   """categories.sort.custom""": """Personalizado""",
+  """customFields.manageTitle""": """Campos personalizados""",
+  """customFields.empty""":
+      """Aún no hay campos personalizados. Añade uno para adjuntar información adicional a los artículos.""",
+  """customFields.addField""": """Añadir campo""",
+  """customFields.allLists""": """Todas las listas""",
+  """customFields.deleteTitle""": """Eliminar campo""",
+  """customFields.deleteConfirm""":
+      """¿Eliminar este campo? Los valores ya asignados a los artículos se conservan pero se ocultan.""",
+  """customFields.optionDeleteFailed""": """No se pudo eliminar la opción.""",
+  """customFields.types.text""": """Texto""",
+  """customFields.types.number""": """Número""",
+  """customFields.types.checkbox""": """Casilla""",
+  """customFields.types.date""": """Fecha""",
+  """customFields.types.select""": """Selección""",
+  """customFields.name""": """Nombre""",
+  """customFields.namePlaceholder""": """p. ej. Caducidad, Pasillo""",
+  """customFields.type""": """Tipo""",
+  """customFields.typeLocked""":
+      """El tipo no se puede cambiar una vez creado el campo.""",
+  """customFields.scope""": """Ámbito""",
+  """customFields.hint""": """Texto de ayuda""",
+  """customFields.hintPlaceholder""":
+      """Se muestra como marcador de posición del valor""",
+  """customFields.multiline""": """Área de texto multilínea""",
+  """customFields.options""": """Opciones""",
+  """customFields.optionPlaceholder""": """Etiqueta de la opción""",
+  """customFields.addOption""": """Añadir opción""",
+  """customFields.removeOption""": """Quitar opción""",
+  """customFields.entryMode""": """Entrada de fecha""",
+  """customFields.dateAbsolute""": """Absoluta""",
+  """customFields.dateRelative""": """Relativa""",
+  """customFields.defaultOffset""": """Desfase predeterminado (días)""",
+  """customFields.defaultOffsetPlaceholder""": """p. ej. 7""",
+  """customFields.notifyDefault""": """Recordar de forma predeterminada""",
+  """customFields.leadTime""": """Recordar""",
+  """customFields.leadOnDay""": """El mismo día""",
+  """customFields.leadDay1""": """1 día antes""",
+  """customFields.leadDay2""": """2 días antes""",
+  """customFields.leadDay3""": """3 días antes""",
+  """customFields.leadWeek1""": """1 semana antes""",
+  """customFields.overridePolicy""": """Anulación del recordatorio""",
+  """customFields.overrideFieldOnly""":
+      """El mismo recordatorio para cada artículo""",
+  """customFields.overrideItem""":
+      """Cada artículo define su propio recordatorio""",
+  """customFields.stopWhenDone""":
+      """Dejar de recordar cuando el artículo esté completado""",
+  """customFields.defaultValue""": """Valor predeterminado""",
+  """customFields.defaultChecked""": """Activado de forma predeterminada""",
+  """customFields.noDefault""": """Sin valor predeterminado""",
+  """customFields.done""": """Hecho""",
+  """customFields.remapTitle""": """Opción en uso""",
+  """customFields.remapClear""": """Quitarla de esos artículos""",
   """stores.manageTitle""": """Gestionar tiendas""",
   """stores.noStores""": """Aún no hay tiendas.""",
   """stores.editTitle""": """Editar tienda""",

--- a/lib/i18n/messages_es.i18n.yaml
+++ b/lib/i18n/messages_es.i18n.yaml
@@ -304,6 +304,57 @@ categories:
     nameZA: "Nombre Z–A"
     custom: "Personalizado"
 
+customFields:
+  manageTitle: "Campos personalizados"
+  empty: "Aún no hay campos personalizados. Añade uno para adjuntar información adicional a los artículos."
+  addField: "Añadir campo"
+  allLists: "Todas las listas"
+  deleteTitle: "Eliminar campo"
+  deleteConfirm: "¿Eliminar este campo? Los valores ya asignados a los artículos se conservan pero se ocultan."
+  optionDeleteFailed: "No se pudo eliminar la opción."
+  types:
+    text: Texto
+    number: "Número"
+    checkbox: Casilla
+    date: Fecha
+    select: "Selección"
+  name: Nombre
+  namePlaceholder: "p. ej. Caducidad, Pasillo"
+  type: Tipo
+  typeLocked: "El tipo no se puede cambiar una vez creado el campo."
+  scope: "Ámbito"
+  hint: Texto de ayuda
+  hintPlaceholder: "Se muestra como marcador de posición del valor"
+  multiline: "Área de texto multilínea"
+  options: Opciones
+  optionPlaceholder: "Etiqueta de la opción"
+  addOption: "Añadir opción"
+  removeOption: "Quitar opción"
+  entryMode: Entrada de fecha
+  dateAbsolute: Absoluta
+  dateRelative: Relativa
+  defaultOffset: "Desfase predeterminado (días)"
+  defaultOffsetPlaceholder: "p. ej. 7"
+  notifyDefault: Recordar de forma predeterminada
+  leadTime: Recordar
+  leadOnDay: El mismo día
+  leadDay1: 1 día antes
+  leadDay2: 2 días antes
+  leadDay3: 3 días antes
+  leadWeek1: 1 semana antes
+  overridePolicy: "Anulación del recordatorio"
+  overrideFieldOnly: El mismo recordatorio para cada artículo
+  overrideItem: Cada artículo define su propio recordatorio
+  stopWhenDone: Dejar de recordar cuando el artículo esté completado
+  defaultValue: Valor predeterminado
+  defaultChecked: Activado de forma predeterminada
+  noDefault: Sin valor predeterminado
+  done: Hecho
+  remapTitle: "Opción en uso"
+  remapClear: Quitarla de esos artículos
+  remapMoveTo(String label): "Moverla a ${label}"
+  remapPrompt(int count, String label): "${_plural(count, one: '${label} la usa 1 artículo. ¿Qué debe pasar con él?', many: '${label} la usan ${count} artículos. ¿Qué debe pasar con ellos?')}"
+
 stores:
   manageTitle: Gestionar tiendas
   noStores: Aún no hay tiendas.

--- a/lib/i18n/messages_es.i18n.yaml
+++ b/lib/i18n/messages_es.i18n.yaml
@@ -349,6 +349,13 @@ customFields:
   defaultValue: Valor predeterminado
   defaultChecked: Activado de forma predeterminada
   noDefault: Sin valor predeterminado
+  noValue: Sin valor
+  daysFromToday: "Días desde hoy"
+  due(String date): "Vence el ${date}"
+  reanchor: Reanclar fecha
+  remindMe: Recordármelo
+  customReminder: Recordatorio propio para este artículo
+  useFieldDefault: Usar el valor predeterminado del campo
   done: Hecho
   remapTitle: "Opción en uso"
   remapClear: Quitarla de esos artículos

--- a/lib/i18n/messages_fr.i18n.dart
+++ b/lib/i18n/messages_fr.i18n.dart
@@ -75,6 +75,7 @@ class MessagesFr extends Messages {
   SettingsMessagesFr get settings => SettingsMessagesFr(this);
   NotificationsMessagesFr get notifications => NotificationsMessagesFr(this);
   CategoriesMessagesFr get categories => CategoriesMessagesFr(this);
+  CustomFieldsMessagesFr get customFields => CustomFieldsMessagesFr(this);
   StoresMessagesFr get stores => StoresMessagesFr(this);
   LabelsMessagesFr get labels => LabelsMessagesFr(this);
   ChecklistsMessagesFr get checklists => ChecklistsMessagesFr(this);
@@ -1656,6 +1657,263 @@ class SortCategoriesMessagesFr extends SortCategoriesMessages {
   /// "Personnalisé"
   /// ```
   String get custom => """Personnalisé""";
+}
+
+class CustomFieldsMessagesFr extends CustomFieldsMessages {
+  final MessagesFr _parent;
+  const CustomFieldsMessagesFr(this._parent) : super(_parent);
+
+  /// ```dart
+  /// "Champs personnalisés"
+  /// ```
+  String get manageTitle => """Champs personnalisés""";
+
+  /// ```dart
+  /// "Aucun champ personnalisé pour le moment. Ajoutez-en un pour attacher des informations supplémentaires aux articles."
+  /// ```
+  String get empty =>
+      """Aucun champ personnalisé pour le moment. Ajoutez-en un pour attacher des informations supplémentaires aux articles.""";
+
+  /// ```dart
+  /// "Ajouter un champ"
+  /// ```
+  String get addField => """Ajouter un champ""";
+
+  /// ```dart
+  /// "Toutes les listes"
+  /// ```
+  String get allLists => """Toutes les listes""";
+
+  /// ```dart
+  /// "Supprimer le champ"
+  /// ```
+  String get deleteTitle => """Supprimer le champ""";
+
+  /// ```dart
+  /// "Supprimer ce champ ? Les valeurs déjà définies sur les articles sont conservées mais masquées."
+  /// ```
+  String get deleteConfirm =>
+      """Supprimer ce champ ? Les valeurs déjà définies sur les articles sont conservées mais masquées.""";
+
+  /// ```dart
+  /// "Impossible de supprimer l'option."
+  /// ```
+  String get optionDeleteFailed => """Impossible de supprimer l'option.""";
+  TypesCustomFieldsMessagesFr get types => TypesCustomFieldsMessagesFr(this);
+
+  /// ```dart
+  /// "Nom"
+  /// ```
+  String get name => """Nom""";
+
+  /// ```dart
+  /// "p. ex. Péremption, Rayon"
+  /// ```
+  String get namePlaceholder => """p. ex. Péremption, Rayon""";
+
+  /// ```dart
+  /// "Type"
+  /// ```
+  String get type => """Type""";
+
+  /// ```dart
+  /// "Le type ne peut pas être modifié après la création du champ."
+  /// ```
+  String get typeLocked =>
+      """Le type ne peut pas être modifié après la création du champ.""";
+
+  /// ```dart
+  /// "Portée"
+  /// ```
+  String get scope => """Portée""";
+
+  /// ```dart
+  /// "Texte d'aide"
+  /// ```
+  String get hint => """Texte d'aide""";
+
+  /// ```dart
+  /// "Affiché comme texte indicatif de la valeur"
+  /// ```
+  String get hintPlaceholder =>
+      """Affiché comme texte indicatif de la valeur""";
+
+  /// ```dart
+  /// "Zone de texte multiligne"
+  /// ```
+  String get multiline => """Zone de texte multiligne""";
+
+  /// ```dart
+  /// "Options"
+  /// ```
+  String get options => """Options""";
+
+  /// ```dart
+  /// "Libellé de l'option"
+  /// ```
+  String get optionPlaceholder => """Libellé de l'option""";
+
+  /// ```dart
+  /// "Ajouter une option"
+  /// ```
+  String get addOption => """Ajouter une option""";
+
+  /// ```dart
+  /// "Retirer l'option"
+  /// ```
+  String get removeOption => """Retirer l'option""";
+
+  /// ```dart
+  /// "Saisie de la date"
+  /// ```
+  String get entryMode => """Saisie de la date""";
+
+  /// ```dart
+  /// "Absolue"
+  /// ```
+  String get dateAbsolute => """Absolue""";
+
+  /// ```dart
+  /// "Relative"
+  /// ```
+  String get dateRelative => """Relative""";
+
+  /// ```dart
+  /// "Décalage par défaut (jours)"
+  /// ```
+  String get defaultOffset => """Décalage par défaut (jours)""";
+
+  /// ```dart
+  /// "p. ex. 7"
+  /// ```
+  String get defaultOffsetPlaceholder => """p. ex. 7""";
+
+  /// ```dart
+  /// "Rappeler par défaut"
+  /// ```
+  String get notifyDefault => """Rappeler par défaut""";
+
+  /// ```dart
+  /// "Rappeler"
+  /// ```
+  String get leadTime => """Rappeler""";
+
+  /// ```dart
+  /// "Le jour même"
+  /// ```
+  String get leadOnDay => """Le jour même""";
+
+  /// ```dart
+  /// "1 jour avant"
+  /// ```
+  String get leadDay1 => """1 jour avant""";
+
+  /// ```dart
+  /// "2 jours avant"
+  /// ```
+  String get leadDay2 => """2 jours avant""";
+
+  /// ```dart
+  /// "3 jours avant"
+  /// ```
+  String get leadDay3 => """3 jours avant""";
+
+  /// ```dart
+  /// "1 semaine avant"
+  /// ```
+  String get leadWeek1 => """1 semaine avant""";
+
+  /// ```dart
+  /// "Remplacement du rappel"
+  /// ```
+  String get overridePolicy => """Remplacement du rappel""";
+
+  /// ```dart
+  /// "Même rappel pour chaque article"
+  /// ```
+  String get overrideFieldOnly => """Même rappel pour chaque article""";
+
+  /// ```dart
+  /// "Chaque article définit son propre rappel"
+  /// ```
+  String get overrideItem => """Chaque article définit son propre rappel""";
+
+  /// ```dart
+  /// "Arrêter de rappeler une fois l'article terminé"
+  /// ```
+  String get stopWhenDone =>
+      """Arrêter de rappeler une fois l'article terminé""";
+
+  /// ```dart
+  /// "Valeur par défaut"
+  /// ```
+  String get defaultValue => """Valeur par défaut""";
+
+  /// ```dart
+  /// "Activé par défaut"
+  /// ```
+  String get defaultChecked => """Activé par défaut""";
+
+  /// ```dart
+  /// "Aucune valeur par défaut"
+  /// ```
+  String get noDefault => """Aucune valeur par défaut""";
+
+  /// ```dart
+  /// "Terminé"
+  /// ```
+  String get done => """Terminé""";
+
+  /// ```dart
+  /// "Option utilisée"
+  /// ```
+  String get remapTitle => """Option utilisée""";
+
+  /// ```dart
+  /// "La retirer de ces articles"
+  /// ```
+  String get remapClear => """La retirer de ces articles""";
+
+  /// ```dart
+  /// "La déplacer vers ${label}"
+  /// ```
+  String remapMoveTo(String label) => """La déplacer vers ${label}""";
+
+  /// ```dart
+  /// "${_plural(count, one: '${label} est utilisée par 1 article. Que faut-il en faire ?', many: '${label} est utilisée par ${count} articles. Que faut-il en faire ?')}"
+  /// ```
+  String remapPrompt(int count, String label) =>
+      """${_plural(count, one: '${label} est utilisée par 1 article. Que faut-il en faire ?', many: '${label} est utilisée par ${count} articles. Que faut-il en faire ?')}""";
+}
+
+class TypesCustomFieldsMessagesFr extends TypesCustomFieldsMessages {
+  final CustomFieldsMessagesFr _parent;
+  const TypesCustomFieldsMessagesFr(this._parent) : super(_parent);
+
+  /// ```dart
+  /// "Texte"
+  /// ```
+  String get text => """Texte""";
+
+  /// ```dart
+  /// "Nombre"
+  /// ```
+  String get number => """Nombre""";
+
+  /// ```dart
+  /// "Case à cocher"
+  /// ```
+  String get checkbox => """Case à cocher""";
+
+  /// ```dart
+  /// "Date"
+  /// ```
+  String get date => """Date""";
+
+  /// ```dart
+  /// "Sélection"
+  /// ```
+  String get select => """Sélection""";
 }
 
 class StoresMessagesFr extends StoresMessages {
@@ -5190,6 +5448,59 @@ Mot de passe : pantry-rocks""",
   """categories.sort.nameAZ""": """Nom A–Z""",
   """categories.sort.nameZA""": """Nom Z–A""",
   """categories.sort.custom""": """Personnalisé""",
+  """customFields.manageTitle""": """Champs personnalisés""",
+  """customFields.empty""":
+      """Aucun champ personnalisé pour le moment. Ajoutez-en un pour attacher des informations supplémentaires aux articles.""",
+  """customFields.addField""": """Ajouter un champ""",
+  """customFields.allLists""": """Toutes les listes""",
+  """customFields.deleteTitle""": """Supprimer le champ""",
+  """customFields.deleteConfirm""":
+      """Supprimer ce champ ? Les valeurs déjà définies sur les articles sont conservées mais masquées.""",
+  """customFields.optionDeleteFailed""":
+      """Impossible de supprimer l'option.""",
+  """customFields.types.text""": """Texte""",
+  """customFields.types.number""": """Nombre""",
+  """customFields.types.checkbox""": """Case à cocher""",
+  """customFields.types.date""": """Date""",
+  """customFields.types.select""": """Sélection""",
+  """customFields.name""": """Nom""",
+  """customFields.namePlaceholder""": """p. ex. Péremption, Rayon""",
+  """customFields.type""": """Type""",
+  """customFields.typeLocked""":
+      """Le type ne peut pas être modifié après la création du champ.""",
+  """customFields.scope""": """Portée""",
+  """customFields.hint""": """Texte d'aide""",
+  """customFields.hintPlaceholder""":
+      """Affiché comme texte indicatif de la valeur""",
+  """customFields.multiline""": """Zone de texte multiligne""",
+  """customFields.options""": """Options""",
+  """customFields.optionPlaceholder""": """Libellé de l'option""",
+  """customFields.addOption""": """Ajouter une option""",
+  """customFields.removeOption""": """Retirer l'option""",
+  """customFields.entryMode""": """Saisie de la date""",
+  """customFields.dateAbsolute""": """Absolue""",
+  """customFields.dateRelative""": """Relative""",
+  """customFields.defaultOffset""": """Décalage par défaut (jours)""",
+  """customFields.defaultOffsetPlaceholder""": """p. ex. 7""",
+  """customFields.notifyDefault""": """Rappeler par défaut""",
+  """customFields.leadTime""": """Rappeler""",
+  """customFields.leadOnDay""": """Le jour même""",
+  """customFields.leadDay1""": """1 jour avant""",
+  """customFields.leadDay2""": """2 jours avant""",
+  """customFields.leadDay3""": """3 jours avant""",
+  """customFields.leadWeek1""": """1 semaine avant""",
+  """customFields.overridePolicy""": """Remplacement du rappel""",
+  """customFields.overrideFieldOnly""": """Même rappel pour chaque article""",
+  """customFields.overrideItem""":
+      """Chaque article définit son propre rappel""",
+  """customFields.stopWhenDone""":
+      """Arrêter de rappeler une fois l'article terminé""",
+  """customFields.defaultValue""": """Valeur par défaut""",
+  """customFields.defaultChecked""": """Activé par défaut""",
+  """customFields.noDefault""": """Aucune valeur par défaut""",
+  """customFields.done""": """Terminé""",
+  """customFields.remapTitle""": """Option utilisée""",
+  """customFields.remapClear""": """La retirer de ces articles""",
   """stores.manageTitle""": """Gérer les magasins""",
   """stores.noStores""": """Aucun magasin pour le moment.""",
   """stores.editTitle""": """Modifier le magasin""",

--- a/lib/i18n/messages_fr.i18n.dart
+++ b/lib/i18n/messages_fr.i18n.dart
@@ -1860,6 +1860,41 @@ class CustomFieldsMessagesFr extends CustomFieldsMessages {
   String get noDefault => """Aucune valeur par défaut""";
 
   /// ```dart
+  /// "Aucune valeur"
+  /// ```
+  String get noValue => """Aucune valeur""";
+
+  /// ```dart
+  /// "Jours à partir d'aujourd'hui"
+  /// ```
+  String get daysFromToday => """Jours à partir d'aujourd'hui""";
+
+  /// ```dart
+  /// "Échéance le ${date}"
+  /// ```
+  String due(String date) => """Échéance le ${date}""";
+
+  /// ```dart
+  /// "Réancrer la date"
+  /// ```
+  String get reanchor => """Réancrer la date""";
+
+  /// ```dart
+  /// "Me rappeler"
+  /// ```
+  String get remindMe => """Me rappeler""";
+
+  /// ```dart
+  /// "Rappel personnalisé pour cet article"
+  /// ```
+  String get customReminder => """Rappel personnalisé pour cet article""";
+
+  /// ```dart
+  /// "Utiliser la valeur par défaut du champ"
+  /// ```
+  String get useFieldDefault => """Utiliser la valeur par défaut du champ""";
+
+  /// ```dart
   /// "Terminé"
   /// ```
   String get done => """Terminé""";
@@ -5498,6 +5533,13 @@ Mot de passe : pantry-rocks""",
   """customFields.defaultValue""": """Valeur par défaut""",
   """customFields.defaultChecked""": """Activé par défaut""",
   """customFields.noDefault""": """Aucune valeur par défaut""",
+  """customFields.noValue""": """Aucune valeur""",
+  """customFields.daysFromToday""": """Jours à partir d'aujourd'hui""",
+  """customFields.reanchor""": """Réancrer la date""",
+  """customFields.remindMe""": """Me rappeler""",
+  """customFields.customReminder""": """Rappel personnalisé pour cet article""",
+  """customFields.useFieldDefault""":
+      """Utiliser la valeur par défaut du champ""",
   """customFields.done""": """Terminé""",
   """customFields.remapTitle""": """Option utilisée""",
   """customFields.remapClear""": """La retirer de ces articles""",

--- a/lib/i18n/messages_fr.i18n.yaml
+++ b/lib/i18n/messages_fr.i18n.yaml
@@ -349,6 +349,13 @@ customFields:
   defaultValue: Valeur par défaut
   defaultChecked: "Activé par défaut"
   noDefault: Aucune valeur par défaut
+  noValue: Aucune valeur
+  daysFromToday: "Jours à partir d'aujourd'hui"
+  due(String date): "Échéance le ${date}"
+  reanchor: "Réancrer la date"
+  remindMe: Me rappeler
+  customReminder: Rappel personnalisé pour cet article
+  useFieldDefault: "Utiliser la valeur par défaut du champ"
   done: "Terminé"
   remapTitle: Option utilisée
   remapClear: La retirer de ces articles

--- a/lib/i18n/messages_fr.i18n.yaml
+++ b/lib/i18n/messages_fr.i18n.yaml
@@ -304,6 +304,57 @@ categories:
     nameZA: "Nom Z–A"
     custom: "Personnalisé"
 
+customFields:
+  manageTitle: "Champs personnalisés"
+  empty: "Aucun champ personnalisé pour le moment. Ajoutez-en un pour attacher des informations supplémentaires aux articles."
+  addField: "Ajouter un champ"
+  allLists: Toutes les listes
+  deleteTitle: Supprimer le champ
+  deleteConfirm: "Supprimer ce champ ? Les valeurs déjà définies sur les articles sont conservées mais masquées."
+  optionDeleteFailed: "Impossible de supprimer l'option."
+  types:
+    text: Texte
+    number: Nombre
+    checkbox: "Case à cocher"
+    date: Date
+    select: "Sélection"
+  name: Nom
+  namePlaceholder: "p. ex. Péremption, Rayon"
+  type: Type
+  typeLocked: "Le type ne peut pas être modifié après la création du champ."
+  scope: "Portée"
+  hint: Texte d'aide
+  hintPlaceholder: "Affiché comme texte indicatif de la valeur"
+  multiline: Zone de texte multiligne
+  options: Options
+  optionPlaceholder: "Libellé de l'option"
+  addOption: "Ajouter une option"
+  removeOption: "Retirer l'option"
+  entryMode: Saisie de la date
+  dateAbsolute: Absolue
+  dateRelative: Relative
+  defaultOffset: "Décalage par défaut (jours)"
+  defaultOffsetPlaceholder: "p. ex. 7"
+  notifyDefault: Rappeler par défaut
+  leadTime: Rappeler
+  leadOnDay: Le jour même
+  leadDay1: 1 jour avant
+  leadDay2: 2 jours avant
+  leadDay3: 3 jours avant
+  leadWeek1: 1 semaine avant
+  overridePolicy: Remplacement du rappel
+  overrideFieldOnly: "Même rappel pour chaque article"
+  overrideItem: Chaque article définit son propre rappel
+  stopWhenDone: "Arrêter de rappeler une fois l'article terminé"
+  defaultValue: Valeur par défaut
+  defaultChecked: "Activé par défaut"
+  noDefault: Aucune valeur par défaut
+  done: "Terminé"
+  remapTitle: Option utilisée
+  remapClear: La retirer de ces articles
+  remapMoveTo(String label): "La déplacer vers ${label}"
+  remapPrompt(int count, String label): "${_plural(count, one: '${label} est utilisée par 1 article. Que faut-il en faire ?', many: '${label} est utilisée par ${count} articles. Que faut-il en faire ?')}"
+
 stores:
   manageTitle: Gérer les magasins
   noStores: Aucun magasin pour le moment.

--- a/lib/i18n/messages_he.i18n.dart
+++ b/lib/i18n/messages_he.i18n.dart
@@ -1841,6 +1841,41 @@ class CustomFieldsMessagesHe extends CustomFieldsMessages {
   String get noDefault => """ללא ברירת מחדל""";
 
   /// ```dart
+  /// "אין ערך"
+  /// ```
+  String get noValue => """אין ערך""";
+
+  /// ```dart
+  /// "ימים מהיום"
+  /// ```
+  String get daysFromToday => """ימים מהיום""";
+
+  /// ```dart
+  /// "יעד ${date}"
+  /// ```
+  String due(String date) => """יעד ${date}""";
+
+  /// ```dart
+  /// "עיגון מחדש של התאריך"
+  /// ```
+  String get reanchor => """עיגון מחדש של התאריך""";
+
+  /// ```dart
+  /// "להזכיר לי"
+  /// ```
+  String get remindMe => """להזכיר לי""";
+
+  /// ```dart
+  /// "תזכורת מותאמת לפריט זה"
+  /// ```
+  String get customReminder => """תזכורת מותאמת לפריט זה""";
+
+  /// ```dart
+  /// "להשתמש בברירת המחדל של השדה"
+  /// ```
+  String get useFieldDefault => """להשתמש בברירת המחדל של השדה""";
+
+  /// ```dart
   /// "סיום"
   /// ```
   String get done => """סיום""";
@@ -5425,6 +5460,12 @@ Map<String, String> get messagesHeMap => {
   """customFields.defaultValue""": """ערך ברירת מחדל""",
   """customFields.defaultChecked""": """מופעל כברירת מחדל""",
   """customFields.noDefault""": """ללא ברירת מחדל""",
+  """customFields.noValue""": """אין ערך""",
+  """customFields.daysFromToday""": """ימים מהיום""",
+  """customFields.reanchor""": """עיגון מחדש של התאריך""",
+  """customFields.remindMe""": """להזכיר לי""",
+  """customFields.customReminder""": """תזכורת מותאמת לפריט זה""",
+  """customFields.useFieldDefault""": """להשתמש בברירת המחדל של השדה""",
   """customFields.done""": """סיום""",
   """customFields.remapTitle""": """האפשרות בשימוש""",
   """customFields.remapClear""": """לנקות אותה מהפריטים האלה""",

--- a/lib/i18n/messages_he.i18n.dart
+++ b/lib/i18n/messages_he.i18n.dart
@@ -75,6 +75,7 @@ class MessagesHe extends Messages {
   SettingsMessagesHe get settings => SettingsMessagesHe(this);
   NotificationsMessagesHe get notifications => NotificationsMessagesHe(this);
   CategoriesMessagesHe get categories => CategoriesMessagesHe(this);
+  CustomFieldsMessagesHe get customFields => CustomFieldsMessagesHe(this);
   StoresMessagesHe get stores => StoresMessagesHe(this);
   LabelsMessagesHe get labels => LabelsMessagesHe(this);
   ChecklistsMessagesHe get checklists => ChecklistsMessagesHe(this);
@@ -1640,6 +1641,260 @@ class SortCategoriesMessagesHe extends SortCategoriesMessages {
   /// "מותאם אישית"
   /// ```
   String get custom => """מותאם אישית""";
+}
+
+class CustomFieldsMessagesHe extends CustomFieldsMessages {
+  final MessagesHe _parent;
+  const CustomFieldsMessagesHe(this._parent) : super(_parent);
+
+  /// ```dart
+  /// "שדות מותאמים אישית"
+  /// ```
+  String get manageTitle => """שדות מותאמים אישית""";
+
+  /// ```dart
+  /// "אין עדיין שדות מותאמים אישית. הוסיפו אחד כדי לצרף מידע נוסף לפריטים."
+  /// ```
+  String get empty =>
+      """אין עדיין שדות מותאמים אישית. הוסיפו אחד כדי לצרף מידע נוסף לפריטים.""";
+
+  /// ```dart
+  /// "הוספת שדה"
+  /// ```
+  String get addField => """הוספת שדה""";
+
+  /// ```dart
+  /// "כל הרשימות"
+  /// ```
+  String get allLists => """כל הרשימות""";
+
+  /// ```dart
+  /// "מחיקת שדה"
+  /// ```
+  String get deleteTitle => """מחיקת שדה""";
+
+  /// ```dart
+  /// "למחוק את השדה? ערכים שכבר הוגדרו על פריטים נשמרים אך מוסתרים."
+  /// ```
+  String get deleteConfirm =>
+      """למחוק את השדה? ערכים שכבר הוגדרו על פריטים נשמרים אך מוסתרים.""";
+
+  /// ```dart
+  /// "הסרת האפשרות נכשלה."
+  /// ```
+  String get optionDeleteFailed => """הסרת האפשרות נכשלה.""";
+  TypesCustomFieldsMessagesHe get types => TypesCustomFieldsMessagesHe(this);
+
+  /// ```dart
+  /// "שם"
+  /// ```
+  String get name => """שם""";
+
+  /// ```dart
+  /// "למשל תפוגה, מעבר"
+  /// ```
+  String get namePlaceholder => """למשל תפוגה, מעבר""";
+
+  /// ```dart
+  /// "סוג"
+  /// ```
+  String get type => """סוג""";
+
+  /// ```dart
+  /// "לא ניתן לשנות את הסוג לאחר יצירת השדה."
+  /// ```
+  String get typeLocked => """לא ניתן לשנות את הסוג לאחר יצירת השדה.""";
+
+  /// ```dart
+  /// "היקף"
+  /// ```
+  String get scope => """היקף""";
+
+  /// ```dart
+  /// "טקסט רמז"
+  /// ```
+  String get hint => """טקסט רמז""";
+
+  /// ```dart
+  /// "מוצג כטקסט מציין מקום של הערך"
+  /// ```
+  String get hintPlaceholder => """מוצג כטקסט מציין מקום של הערך""";
+
+  /// ```dart
+  /// "אזור טקסט מרובה שורות"
+  /// ```
+  String get multiline => """אזור טקסט מרובה שורות""";
+
+  /// ```dart
+  /// "אפשרויות"
+  /// ```
+  String get options => """אפשרויות""";
+
+  /// ```dart
+  /// "תווית האפשרות"
+  /// ```
+  String get optionPlaceholder => """תווית האפשרות""";
+
+  /// ```dart
+  /// "הוספת אפשרות"
+  /// ```
+  String get addOption => """הוספת אפשרות""";
+
+  /// ```dart
+  /// "הסרת אפשרות"
+  /// ```
+  String get removeOption => """הסרת אפשרות""";
+
+  /// ```dart
+  /// "הזנת תאריך"
+  /// ```
+  String get entryMode => """הזנת תאריך""";
+
+  /// ```dart
+  /// "מוחלט"
+  /// ```
+  String get dateAbsolute => """מוחלט""";
+
+  /// ```dart
+  /// "יחסי"
+  /// ```
+  String get dateRelative => """יחסי""";
+
+  /// ```dart
+  /// "היסט ברירת מחדל (ימים)"
+  /// ```
+  String get defaultOffset => """היסט ברירת מחדל (ימים)""";
+
+  /// ```dart
+  /// "למשל 7"
+  /// ```
+  String get defaultOffsetPlaceholder => """למשל 7""";
+
+  /// ```dart
+  /// "תזכורת כברירת מחדל"
+  /// ```
+  String get notifyDefault => """תזכורת כברירת מחדל""";
+
+  /// ```dart
+  /// "להזכיר"
+  /// ```
+  String get leadTime => """להזכיר""";
+
+  /// ```dart
+  /// "באותו יום"
+  /// ```
+  String get leadOnDay => """באותו יום""";
+
+  /// ```dart
+  /// "יום לפני"
+  /// ```
+  String get leadDay1 => """יום לפני""";
+
+  /// ```dart
+  /// "יומיים לפני"
+  /// ```
+  String get leadDay2 => """יומיים לפני""";
+
+  /// ```dart
+  /// "3 ימים לפני"
+  /// ```
+  String get leadDay3 => """3 ימים לפני""";
+
+  /// ```dart
+  /// "שבוע לפני"
+  /// ```
+  String get leadWeek1 => """שבוע לפני""";
+
+  /// ```dart
+  /// "עקיפת תזכורת"
+  /// ```
+  String get overridePolicy => """עקיפת תזכורת""";
+
+  /// ```dart
+  /// "אותה תזכורת לכל פריט"
+  /// ```
+  String get overrideFieldOnly => """אותה תזכורת לכל פריט""";
+
+  /// ```dart
+  /// "כל פריט מגדיר תזכורת משלו"
+  /// ```
+  String get overrideItem => """כל פריט מגדיר תזכורת משלו""";
+
+  /// ```dart
+  /// "להפסיק להזכיר כשהפריט הושלם"
+  /// ```
+  String get stopWhenDone => """להפסיק להזכיר כשהפריט הושלם""";
+
+  /// ```dart
+  /// "ערך ברירת מחדל"
+  /// ```
+  String get defaultValue => """ערך ברירת מחדל""";
+
+  /// ```dart
+  /// "מופעל כברירת מחדל"
+  /// ```
+  String get defaultChecked => """מופעל כברירת מחדל""";
+
+  /// ```dart
+  /// "ללא ברירת מחדל"
+  /// ```
+  String get noDefault => """ללא ברירת מחדל""";
+
+  /// ```dart
+  /// "סיום"
+  /// ```
+  String get done => """סיום""";
+
+  /// ```dart
+  /// "האפשרות בשימוש"
+  /// ```
+  String get remapTitle => """האפשרות בשימוש""";
+
+  /// ```dart
+  /// "לנקות אותה מהפריטים האלה"
+  /// ```
+  String get remapClear => """לנקות אותה מהפריטים האלה""";
+
+  /// ```dart
+  /// "להעביר אל ${label}"
+  /// ```
+  String remapMoveTo(String label) => """להעביר אל ${label}""";
+
+  /// ```dart
+  /// "${_plural(count, one: '${label} בשימוש על ידי פריט אחד. מה לעשות איתו?', many: '${label} בשימוש על ידי ${count} פריטים. מה לעשות איתם?')}"
+  /// ```
+  String remapPrompt(int count, String label) =>
+      """${_plural(count, one: '${label} בשימוש על ידי פריט אחד. מה לעשות איתו?', many: '${label} בשימוש על ידי ${count} פריטים. מה לעשות איתם?')}""";
+}
+
+class TypesCustomFieldsMessagesHe extends TypesCustomFieldsMessages {
+  final CustomFieldsMessagesHe _parent;
+  const TypesCustomFieldsMessagesHe(this._parent) : super(_parent);
+
+  /// ```dart
+  /// "טקסט"
+  /// ```
+  String get text => """טקסט""";
+
+  /// ```dart
+  /// "מספר"
+  /// ```
+  String get number => """מספר""";
+
+  /// ```dart
+  /// "תיבת סימון"
+  /// ```
+  String get checkbox => """תיבת סימון""";
+
+  /// ```dart
+  /// "תאריך"
+  /// ```
+  String get date => """תאריך""";
+
+  /// ```dart
+  /// "בחירה"
+  /// ```
+  String get select => """בחירה""";
 }
 
 class StoresMessagesHe extends StoresMessages {
@@ -5125,6 +5380,54 @@ Map<String, String> get messagesHeMap => {
   """categories.sort.nameAZ""": """שם א'–ת'""",
   """categories.sort.nameZA""": """שם ת'–א'""",
   """categories.sort.custom""": """מותאם אישית""",
+  """customFields.manageTitle""": """שדות מותאמים אישית""",
+  """customFields.empty""":
+      """אין עדיין שדות מותאמים אישית. הוסיפו אחד כדי לצרף מידע נוסף לפריטים.""",
+  """customFields.addField""": """הוספת שדה""",
+  """customFields.allLists""": """כל הרשימות""",
+  """customFields.deleteTitle""": """מחיקת שדה""",
+  """customFields.deleteConfirm""":
+      """למחוק את השדה? ערכים שכבר הוגדרו על פריטים נשמרים אך מוסתרים.""",
+  """customFields.optionDeleteFailed""": """הסרת האפשרות נכשלה.""",
+  """customFields.types.text""": """טקסט""",
+  """customFields.types.number""": """מספר""",
+  """customFields.types.checkbox""": """תיבת סימון""",
+  """customFields.types.date""": """תאריך""",
+  """customFields.types.select""": """בחירה""",
+  """customFields.name""": """שם""",
+  """customFields.namePlaceholder""": """למשל תפוגה, מעבר""",
+  """customFields.type""": """סוג""",
+  """customFields.typeLocked""": """לא ניתן לשנות את הסוג לאחר יצירת השדה.""",
+  """customFields.scope""": """היקף""",
+  """customFields.hint""": """טקסט רמז""",
+  """customFields.hintPlaceholder""": """מוצג כטקסט מציין מקום של הערך""",
+  """customFields.multiline""": """אזור טקסט מרובה שורות""",
+  """customFields.options""": """אפשרויות""",
+  """customFields.optionPlaceholder""": """תווית האפשרות""",
+  """customFields.addOption""": """הוספת אפשרות""",
+  """customFields.removeOption""": """הסרת אפשרות""",
+  """customFields.entryMode""": """הזנת תאריך""",
+  """customFields.dateAbsolute""": """מוחלט""",
+  """customFields.dateRelative""": """יחסי""",
+  """customFields.defaultOffset""": """היסט ברירת מחדל (ימים)""",
+  """customFields.defaultOffsetPlaceholder""": """למשל 7""",
+  """customFields.notifyDefault""": """תזכורת כברירת מחדל""",
+  """customFields.leadTime""": """להזכיר""",
+  """customFields.leadOnDay""": """באותו יום""",
+  """customFields.leadDay1""": """יום לפני""",
+  """customFields.leadDay2""": """יומיים לפני""",
+  """customFields.leadDay3""": """3 ימים לפני""",
+  """customFields.leadWeek1""": """שבוע לפני""",
+  """customFields.overridePolicy""": """עקיפת תזכורת""",
+  """customFields.overrideFieldOnly""": """אותה תזכורת לכל פריט""",
+  """customFields.overrideItem""": """כל פריט מגדיר תזכורת משלו""",
+  """customFields.stopWhenDone""": """להפסיק להזכיר כשהפריט הושלם""",
+  """customFields.defaultValue""": """ערך ברירת מחדל""",
+  """customFields.defaultChecked""": """מופעל כברירת מחדל""",
+  """customFields.noDefault""": """ללא ברירת מחדל""",
+  """customFields.done""": """סיום""",
+  """customFields.remapTitle""": """האפשרות בשימוש""",
+  """customFields.remapClear""": """לנקות אותה מהפריטים האלה""",
   """stores.manageTitle""": """ניהול חנויות""",
   """stores.noStores""": """אין חנויות עדיין.""",
   """stores.editTitle""": """עריכת חנות""",

--- a/lib/i18n/messages_he.i18n.yaml
+++ b/lib/i18n/messages_he.i18n.yaml
@@ -349,6 +349,13 @@ customFields:
   defaultValue: ערך ברירת מחדל
   defaultChecked: מופעל כברירת מחדל
   noDefault: ללא ברירת מחדל
+  noValue: אין ערך
+  daysFromToday: ימים מהיום
+  due(String date): "יעד ${date}"
+  reanchor: עיגון מחדש של התאריך
+  remindMe: להזכיר לי
+  customReminder: תזכורת מותאמת לפריט זה
+  useFieldDefault: להשתמש בברירת המחדל של השדה
   done: סיום
   remapTitle: האפשרות בשימוש
   remapClear: לנקות אותה מהפריטים האלה

--- a/lib/i18n/messages_he.i18n.yaml
+++ b/lib/i18n/messages_he.i18n.yaml
@@ -304,6 +304,57 @@ categories:
     nameZA: "שם ת'–א'"
     custom: מותאם אישית
 
+customFields:
+  manageTitle: שדות מותאמים אישית
+  empty: "אין עדיין שדות מותאמים אישית. הוסיפו אחד כדי לצרף מידע נוסף לפריטים."
+  addField: הוספת שדה
+  allLists: כל הרשימות
+  deleteTitle: מחיקת שדה
+  deleteConfirm: "למחוק את השדה? ערכים שכבר הוגדרו על פריטים נשמרים אך מוסתרים."
+  optionDeleteFailed: הסרת האפשרות נכשלה.
+  types:
+    text: טקסט
+    number: מספר
+    checkbox: תיבת סימון
+    date: תאריך
+    select: בחירה
+  name: שם
+  namePlaceholder: "למשל תפוגה, מעבר"
+  type: סוג
+  typeLocked: לא ניתן לשנות את הסוג לאחר יצירת השדה.
+  scope: היקף
+  hint: טקסט רמז
+  hintPlaceholder: מוצג כטקסט מציין מקום של הערך
+  multiline: אזור טקסט מרובה שורות
+  options: אפשרויות
+  optionPlaceholder: תווית האפשרות
+  addOption: הוספת אפשרות
+  removeOption: הסרת אפשרות
+  entryMode: הזנת תאריך
+  dateAbsolute: מוחלט
+  dateRelative: יחסי
+  defaultOffset: "היסט ברירת מחדל (ימים)"
+  defaultOffsetPlaceholder: "למשל 7"
+  notifyDefault: תזכורת כברירת מחדל
+  leadTime: להזכיר
+  leadOnDay: באותו יום
+  leadDay1: יום לפני
+  leadDay2: יומיים לפני
+  leadDay3: 3 ימים לפני
+  leadWeek1: שבוע לפני
+  overridePolicy: עקיפת תזכורת
+  overrideFieldOnly: אותה תזכורת לכל פריט
+  overrideItem: כל פריט מגדיר תזכורת משלו
+  stopWhenDone: להפסיק להזכיר כשהפריט הושלם
+  defaultValue: ערך ברירת מחדל
+  defaultChecked: מופעל כברירת מחדל
+  noDefault: ללא ברירת מחדל
+  done: סיום
+  remapTitle: האפשרות בשימוש
+  remapClear: לנקות אותה מהפריטים האלה
+  remapMoveTo(String label): "להעביר אל ${label}"
+  remapPrompt(int count, String label): "${_plural(count, one: '${label} בשימוש על ידי פריט אחד. מה לעשות איתו?', many: '${label} בשימוש על ידי ${count} פריטים. מה לעשות איתם?')}"
+
 stores:
   manageTitle: ניהול חנויות
   noStores: אין חנויות עדיין.

--- a/lib/i18n/messages_nn.i18n.dart
+++ b/lib/i18n/messages_nn.i18n.dart
@@ -75,6 +75,7 @@ class MessagesNn extends Messages {
   SettingsMessagesNn get settings => SettingsMessagesNn(this);
   NotificationsMessagesNn get notifications => NotificationsMessagesNn(this);
   CategoriesMessagesNn get categories => CategoriesMessagesNn(this);
+  CustomFieldsMessagesNn get customFields => CustomFieldsMessagesNn(this);
   StoresMessagesNn get stores => StoresMessagesNn(this);
   LabelsMessagesNn get labels => LabelsMessagesNn(this);
   ChecklistsMessagesNn get checklists => ChecklistsMessagesNn(this);
@@ -1647,6 +1648,261 @@ class SortCategoriesMessagesNn extends SortCategoriesMessages {
   /// "Sjølvvald"
   /// ```
   String get custom => """Sjølvvald""";
+}
+
+class CustomFieldsMessagesNn extends CustomFieldsMessages {
+  final MessagesNn _parent;
+  const CustomFieldsMessagesNn(this._parent) : super(_parent);
+
+  /// ```dart
+  /// "Eigendefinerte felt"
+  /// ```
+  String get manageTitle => """Eigendefinerte felt""";
+
+  /// ```dart
+  /// "Ingen eigendefinerte felt enno. Legg til eitt for å knyte ekstra informasjon til oppføringar."
+  /// ```
+  String get empty =>
+      """Ingen eigendefinerte felt enno. Legg til eitt for å knyte ekstra informasjon til oppføringar.""";
+
+  /// ```dart
+  /// "Legg til felt"
+  /// ```
+  String get addField => """Legg til felt""";
+
+  /// ```dart
+  /// "Alle lister"
+  /// ```
+  String get allLists => """Alle lister""";
+
+  /// ```dart
+  /// "Slett felt"
+  /// ```
+  String get deleteTitle => """Slett felt""";
+
+  /// ```dart
+  /// "Slette dette feltet? Verdiar som alt er sette på oppføringar vert tekne vare på, men gøymde."
+  /// ```
+  String get deleteConfirm =>
+      """Slette dette feltet? Verdiar som alt er sette på oppføringar vert tekne vare på, men gøymde.""";
+
+  /// ```dart
+  /// "Klarte ikkje fjerne alternativet."
+  /// ```
+  String get optionDeleteFailed => """Klarte ikkje fjerne alternativet.""";
+  TypesCustomFieldsMessagesNn get types => TypesCustomFieldsMessagesNn(this);
+
+  /// ```dart
+  /// "Namn"
+  /// ```
+  String get name => """Namn""";
+
+  /// ```dart
+  /// "t.d. Utløp, Gang"
+  /// ```
+  String get namePlaceholder => """t.d. Utløp, Gang""";
+
+  /// ```dart
+  /// "Type"
+  /// ```
+  String get type => """Type""";
+
+  /// ```dart
+  /// "Typen kan ikkje endrast etter at feltet er oppretta."
+  /// ```
+  String get typeLocked =>
+      """Typen kan ikkje endrast etter at feltet er oppretta.""";
+
+  /// ```dart
+  /// "Omfang"
+  /// ```
+  String get scope => """Omfang""";
+
+  /// ```dart
+  /// "Hjelpetekst"
+  /// ```
+  String get hint => """Hjelpetekst""";
+
+  /// ```dart
+  /// "Vist som plasshaldar for verdien"
+  /// ```
+  String get hintPlaceholder => """Vist som plasshaldar for verdien""";
+
+  /// ```dart
+  /// "Fleirlinja tekstområde"
+  /// ```
+  String get multiline => """Fleirlinja tekstområde""";
+
+  /// ```dart
+  /// "Alternativ"
+  /// ```
+  String get options => """Alternativ""";
+
+  /// ```dart
+  /// "Alternativnamn"
+  /// ```
+  String get optionPlaceholder => """Alternativnamn""";
+
+  /// ```dart
+  /// "Legg til alternativ"
+  /// ```
+  String get addOption => """Legg til alternativ""";
+
+  /// ```dart
+  /// "Fjern alternativ"
+  /// ```
+  String get removeOption => """Fjern alternativ""";
+
+  /// ```dart
+  /// "Datoinntasting"
+  /// ```
+  String get entryMode => """Datoinntasting""";
+
+  /// ```dart
+  /// "Absolutt"
+  /// ```
+  String get dateAbsolute => """Absolutt""";
+
+  /// ```dart
+  /// "Relativ"
+  /// ```
+  String get dateRelative => """Relativ""";
+
+  /// ```dart
+  /// "Standardforskyving (dagar)"
+  /// ```
+  String get defaultOffset => """Standardforskyving (dagar)""";
+
+  /// ```dart
+  /// "t.d. 7"
+  /// ```
+  String get defaultOffsetPlaceholder => """t.d. 7""";
+
+  /// ```dart
+  /// "Minn på som standard"
+  /// ```
+  String get notifyDefault => """Minn på som standard""";
+
+  /// ```dart
+  /// "Minn på"
+  /// ```
+  String get leadTime => """Minn på""";
+
+  /// ```dart
+  /// "Same dag"
+  /// ```
+  String get leadOnDay => """Same dag""";
+
+  /// ```dart
+  /// "1 dag før"
+  /// ```
+  String get leadDay1 => """1 dag før""";
+
+  /// ```dart
+  /// "2 dagar før"
+  /// ```
+  String get leadDay2 => """2 dagar før""";
+
+  /// ```dart
+  /// "3 dagar før"
+  /// ```
+  String get leadDay3 => """3 dagar før""";
+
+  /// ```dart
+  /// "1 veke før"
+  /// ```
+  String get leadWeek1 => """1 veke før""";
+
+  /// ```dart
+  /// "Overstyring av påminning"
+  /// ```
+  String get overridePolicy => """Overstyring av påminning""";
+
+  /// ```dart
+  /// "Same påminning for kvar oppføring"
+  /// ```
+  String get overrideFieldOnly => """Same påminning for kvar oppføring""";
+
+  /// ```dart
+  /// "Kvar oppføring set si eiga påminning"
+  /// ```
+  String get overrideItem => """Kvar oppføring set si eiga påminning""";
+
+  /// ```dart
+  /// "Slutt å minne på når oppføringa er ferdig"
+  /// ```
+  String get stopWhenDone => """Slutt å minne på når oppføringa er ferdig""";
+
+  /// ```dart
+  /// "Standardverdi"
+  /// ```
+  String get defaultValue => """Standardverdi""";
+
+  /// ```dart
+  /// "På som standard"
+  /// ```
+  String get defaultChecked => """På som standard""";
+
+  /// ```dart
+  /// "Ingen standard"
+  /// ```
+  String get noDefault => """Ingen standard""";
+
+  /// ```dart
+  /// "Ferdig"
+  /// ```
+  String get done => """Ferdig""";
+
+  /// ```dart
+  /// "Alternativet er i bruk"
+  /// ```
+  String get remapTitle => """Alternativet er i bruk""";
+
+  /// ```dart
+  /// "Fjern det frå desse oppføringane"
+  /// ```
+  String get remapClear => """Fjern det frå desse oppføringane""";
+
+  /// ```dart
+  /// "Flytt det til ${label}"
+  /// ```
+  String remapMoveTo(String label) => """Flytt det til ${label}""";
+
+  /// ```dart
+  /// "${_plural(count, one: '${label} vert brukt av 1 oppføring. Kva skal skje med det?', many: '${label} vert brukt av ${count} oppføringar. Kva skal skje med dei?')}"
+  /// ```
+  String remapPrompt(int count, String label) =>
+      """${_plural(count, one: '${label} vert brukt av 1 oppføring. Kva skal skje med det?', many: '${label} vert brukt av ${count} oppføringar. Kva skal skje med dei?')}""";
+}
+
+class TypesCustomFieldsMessagesNn extends TypesCustomFieldsMessages {
+  final CustomFieldsMessagesNn _parent;
+  const TypesCustomFieldsMessagesNn(this._parent) : super(_parent);
+
+  /// ```dart
+  /// "Tekst"
+  /// ```
+  String get text => """Tekst""";
+
+  /// ```dart
+  /// "Tal"
+  /// ```
+  String get number => """Tal""";
+
+  /// ```dart
+  /// "Avkryssingsrute"
+  /// ```
+  String get checkbox => """Avkryssingsrute""";
+
+  /// ```dart
+  /// "Dato"
+  /// ```
+  String get date => """Dato""";
+
+  /// ```dart
+  /// "Val"
+  /// ```
+  String get select => """Val""";
 }
 
 class StoresMessagesNn extends StoresMessages {
@@ -5157,6 +5413,57 @@ Passord: pantry""",
   """categories.sort.nameAZ""": """Namn A-Z""",
   """categories.sort.nameZA""": """Namn Z-A""",
   """categories.sort.custom""": """Sjølvvald""",
+  """customFields.manageTitle""": """Eigendefinerte felt""",
+  """customFields.empty""":
+      """Ingen eigendefinerte felt enno. Legg til eitt for å knyte ekstra informasjon til oppføringar.""",
+  """customFields.addField""": """Legg til felt""",
+  """customFields.allLists""": """Alle lister""",
+  """customFields.deleteTitle""": """Slett felt""",
+  """customFields.deleteConfirm""":
+      """Slette dette feltet? Verdiar som alt er sette på oppføringar vert tekne vare på, men gøymde.""",
+  """customFields.optionDeleteFailed""":
+      """Klarte ikkje fjerne alternativet.""",
+  """customFields.types.text""": """Tekst""",
+  """customFields.types.number""": """Tal""",
+  """customFields.types.checkbox""": """Avkryssingsrute""",
+  """customFields.types.date""": """Dato""",
+  """customFields.types.select""": """Val""",
+  """customFields.name""": """Namn""",
+  """customFields.namePlaceholder""": """t.d. Utløp, Gang""",
+  """customFields.type""": """Type""",
+  """customFields.typeLocked""":
+      """Typen kan ikkje endrast etter at feltet er oppretta.""",
+  """customFields.scope""": """Omfang""",
+  """customFields.hint""": """Hjelpetekst""",
+  """customFields.hintPlaceholder""": """Vist som plasshaldar for verdien""",
+  """customFields.multiline""": """Fleirlinja tekstområde""",
+  """customFields.options""": """Alternativ""",
+  """customFields.optionPlaceholder""": """Alternativnamn""",
+  """customFields.addOption""": """Legg til alternativ""",
+  """customFields.removeOption""": """Fjern alternativ""",
+  """customFields.entryMode""": """Datoinntasting""",
+  """customFields.dateAbsolute""": """Absolutt""",
+  """customFields.dateRelative""": """Relativ""",
+  """customFields.defaultOffset""": """Standardforskyving (dagar)""",
+  """customFields.defaultOffsetPlaceholder""": """t.d. 7""",
+  """customFields.notifyDefault""": """Minn på som standard""",
+  """customFields.leadTime""": """Minn på""",
+  """customFields.leadOnDay""": """Same dag""",
+  """customFields.leadDay1""": """1 dag før""",
+  """customFields.leadDay2""": """2 dagar før""",
+  """customFields.leadDay3""": """3 dagar før""",
+  """customFields.leadWeek1""": """1 veke før""",
+  """customFields.overridePolicy""": """Overstyring av påminning""",
+  """customFields.overrideFieldOnly""": """Same påminning for kvar oppføring""",
+  """customFields.overrideItem""": """Kvar oppføring set si eiga påminning""",
+  """customFields.stopWhenDone""":
+      """Slutt å minne på når oppføringa er ferdig""",
+  """customFields.defaultValue""": """Standardverdi""",
+  """customFields.defaultChecked""": """På som standard""",
+  """customFields.noDefault""": """Ingen standard""",
+  """customFields.done""": """Ferdig""",
+  """customFields.remapTitle""": """Alternativet er i bruk""",
+  """customFields.remapClear""": """Fjern det frå desse oppføringane""",
   """stores.manageTitle""": """Behandle butikkar""",
   """stores.noStores""": """Ingen butikkar enno.""",
   """stores.editTitle""": """Rediger butikk""",

--- a/lib/i18n/messages_nn.i18n.dart
+++ b/lib/i18n/messages_nn.i18n.dart
@@ -1849,6 +1849,41 @@ class CustomFieldsMessagesNn extends CustomFieldsMessages {
   String get noDefault => """Ingen standard""";
 
   /// ```dart
+  /// "Ingen verdi"
+  /// ```
+  String get noValue => """Ingen verdi""";
+
+  /// ```dart
+  /// "Dagar frå i dag"
+  /// ```
+  String get daysFromToday => """Dagar frå i dag""";
+
+  /// ```dart
+  /// "Forfell ${date}"
+  /// ```
+  String due(String date) => """Forfell ${date}""";
+
+  /// ```dart
+  /// "Forankre datoen på nytt"
+  /// ```
+  String get reanchor => """Forankre datoen på nytt""";
+
+  /// ```dart
+  /// "Minn meg på"
+  /// ```
+  String get remindMe => """Minn meg på""";
+
+  /// ```dart
+  /// "Eiga påminning for denne oppføringa"
+  /// ```
+  String get customReminder => """Eiga påminning for denne oppføringa""";
+
+  /// ```dart
+  /// "Bruk feltstandarden"
+  /// ```
+  String get useFieldDefault => """Bruk feltstandarden""";
+
+  /// ```dart
   /// "Ferdig"
   /// ```
   String get done => """Ferdig""";
@@ -5461,6 +5496,12 @@ Passord: pantry""",
   """customFields.defaultValue""": """Standardverdi""",
   """customFields.defaultChecked""": """På som standard""",
   """customFields.noDefault""": """Ingen standard""",
+  """customFields.noValue""": """Ingen verdi""",
+  """customFields.daysFromToday""": """Dagar frå i dag""",
+  """customFields.reanchor""": """Forankre datoen på nytt""",
+  """customFields.remindMe""": """Minn meg på""",
+  """customFields.customReminder""": """Eiga påminning for denne oppføringa""",
+  """customFields.useFieldDefault""": """Bruk feltstandarden""",
   """customFields.done""": """Ferdig""",
   """customFields.remapTitle""": """Alternativet er i bruk""",
   """customFields.remapClear""": """Fjern det frå desse oppføringane""",

--- a/lib/i18n/messages_nn.i18n.yaml
+++ b/lib/i18n/messages_nn.i18n.yaml
@@ -387,6 +387,58 @@ categories:
     nameAZ: "Namn A-Z"
     nameZA: "Namn Z-A"
     custom: Sjølvvald
+
+customFields:
+  manageTitle: Eigendefinerte felt
+  empty: "Ingen eigendefinerte felt enno. Legg til eitt for å knyte ekstra informasjon til oppføringar."
+  addField: Legg til felt
+  allLists: Alle lister
+  deleteTitle: Slett felt
+  deleteConfirm: "Slette dette feltet? Verdiar som alt er sette på oppføringar vert tekne vare på, men gøymde."
+  optionDeleteFailed: Klarte ikkje fjerne alternativet.
+  types:
+    text: Tekst
+    number: Tal
+    checkbox: Avkryssingsrute
+    date: Dato
+    select: Val
+  name: Namn
+  namePlaceholder: "t.d. Utløp, Gang"
+  type: Type
+  typeLocked: Typen kan ikkje endrast etter at feltet er oppretta.
+  scope: Omfang
+  hint: Hjelpetekst
+  hintPlaceholder: Vist som plasshaldar for verdien
+  multiline: Fleirlinja tekstområde
+  options: Alternativ
+  optionPlaceholder: Alternativnamn
+  addOption: Legg til alternativ
+  removeOption: Fjern alternativ
+  entryMode: Datoinntasting
+  dateAbsolute: Absolutt
+  dateRelative: Relativ
+  defaultOffset: "Standardforskyving (dagar)"
+  defaultOffsetPlaceholder: "t.d. 7"
+  notifyDefault: Minn på som standard
+  leadTime: Minn på
+  leadOnDay: Same dag
+  leadDay1: 1 dag før
+  leadDay2: 2 dagar før
+  leadDay3: 3 dagar før
+  leadWeek1: 1 veke før
+  overridePolicy: Overstyring av påminning
+  overrideFieldOnly: Same påminning for kvar oppføring
+  overrideItem: Kvar oppføring set si eiga påminning
+  stopWhenDone: Slutt å minne på når oppføringa er ferdig
+  defaultValue: Standardverdi
+  defaultChecked: På som standard
+  noDefault: Ingen standard
+  done: Ferdig
+  remapTitle: Alternativet er i bruk
+  remapClear: Fjern det frå desse oppføringane
+  remapMoveTo(String label): "Flytt det til ${label}"
+  remapPrompt(int count, String label): "${_plural(count, one: '${label} vert brukt av 1 oppføring. Kva skal skje med det?', many: '${label} vert brukt av ${count} oppføringar. Kva skal skje med dei?')}"
+
 stores:
   manageTitle: Behandle butikkar
   noStores: Ingen butikkar enno.

--- a/lib/i18n/messages_nn.i18n.yaml
+++ b/lib/i18n/messages_nn.i18n.yaml
@@ -433,6 +433,13 @@ customFields:
   defaultValue: Standardverdi
   defaultChecked: På som standard
   noDefault: Ingen standard
+  noValue: Ingen verdi
+  daysFromToday: Dagar frå i dag
+  due(String date): "Forfell ${date}"
+  reanchor: Forankre datoen på nytt
+  remindMe: Minn meg på
+  customReminder: Eiga påminning for denne oppføringa
+  useFieldDefault: Bruk feltstandarden
   done: Ferdig
   remapTitle: Alternativet er i bruk
   remapClear: Fjern det frå desse oppføringane

--- a/lib/models/checklist.dart
+++ b/lib/models/checklist.dart
@@ -1,3 +1,4 @@
+import 'package:pantry/models/custom_field.dart';
 import 'package:pantry/services/server_version_service.dart';
 
 class ChecklistList {
@@ -200,6 +201,11 @@ class ListItem {
   /// Empty when the item carries no price. See [ItemPrice] and the resolution
   /// helpers in `utils/price.dart`. Gated behind the `item-price` capability.
   final List<ItemPrice> prices;
+
+  /// Per-item custom-field values, one per filled field. Empty when the item
+  /// carries none. Gated behind the `custom-fields` capability; mirrors
+  /// [prices] in how it rides the item's create/update payload.
+  final List<FieldValue> customFields;
   final int sortOrder;
   final int createdAt;
   final int updatedAt;
@@ -227,6 +233,7 @@ class ListItem {
     this.addedBy,
     this.barcode,
     this.prices = const [],
+    this.customFields = const [],
     required this.sortOrder,
     required this.createdAt,
     required this.updatedAt,
@@ -259,6 +266,7 @@ class ListItem {
     addedBy: json['addedBy'] as String?,
     barcode: json['barcode'] as String?,
     prices: _pricesFromJson(json),
+    customFields: _customFieldsFromJson(json),
     sortOrder: json['sortOrder'] as int,
     createdAt: json['createdAt'] as int,
     updatedAt: json['updatedAt'] as int,
@@ -292,6 +300,18 @@ class ListItem {
     return const [];
   }
 
+  /// Read custom-field values from the `customFields` array (present on servers
+  /// advertising `custom-fields`, and our own cache); absent elsewhere.
+  static List<FieldValue> _customFieldsFromJson(Map<String, dynamic> json) {
+    final raw = json['customFields'];
+    if (raw is List) {
+      return raw
+          .map((e) => FieldValue.fromJson(e as Map<String, dynamic>))
+          .toList();
+    }
+    return const [];
+  }
+
   Map<String, dynamic> toJson() => {
     'id': id,
     'listId': listId,
@@ -313,6 +333,7 @@ class ListItem {
     'addedBy': addedBy,
     'barcode': barcode,
     'prices': prices.map((p) => p.toJson()).toList(),
+    'customFields': customFields.map((v) => v.toJson()).toList(),
     'sortOrder': sortOrder,
     'createdAt': createdAt,
     'updatedAt': updatedAt,
@@ -341,6 +362,7 @@ class ListItem {
     String? imageUploadedBy,
     String? barcode,
     List<ItemPrice>? prices,
+    List<FieldValue>? customFields,
     int? sortOrder,
     int? updatedAt,
     int? deletedAt,
@@ -370,6 +392,7 @@ class ListItem {
     addedBy: addedBy,
     barcode: barcode ?? this.barcode,
     prices: prices ?? this.prices,
+    customFields: customFields ?? this.customFields,
     sortOrder: sortOrder ?? this.sortOrder,
     createdAt: createdAt,
     updatedAt: updatedAt ?? this.updatedAt,

--- a/lib/models/custom_field.dart
+++ b/lib/models/custom_field.dart
@@ -196,6 +196,31 @@ class FieldDefinition {
     'updatedAt': updatedAt,
   };
 
+  /// The value to seed on a newly-created item, or `null` when the field
+  /// defines no default. `date` fields have no default value (a fixed default
+  /// date isn't meaningful), and an unset default yields nothing.
+  FieldValue? seedValue() {
+    switch (type) {
+      case FieldType.text:
+        final t = defaultText?.trim();
+        return (t == null || t.isEmpty)
+            ? null
+            : FieldValue(fieldId: id, valueText: defaultText);
+      case FieldType.number:
+        return defaultNumber == null
+            ? null
+            : FieldValue(fieldId: id, valueNumber: defaultNumber);
+      case FieldType.checkbox:
+        return defaultBool ? FieldValue(fieldId: id, valueBool: true) : null;
+      case FieldType.select:
+        return defaultOptionId == null
+            ? null
+            : FieldValue(fieldId: id, valueOptionId: defaultOptionId);
+      case FieldType.date:
+        return null;
+    }
+  }
+
   /// Pass `listId: null` to make the field house-wide, an int to scope it, or
   /// omit it to leave the current scope unchanged.
   FieldDefinition copyWith({
@@ -241,6 +266,19 @@ class FieldDefinition {
     createdAt: createdAt,
     updatedAt: updatedAt ?? this.updatedAt,
   );
+}
+
+/// The values a newly-created item should carry: each applicable field's
+/// default ([FieldDefinition.seedValue]), for the fields in scope for [listId]
+/// (house-wide ∪ that list) that define one. Empty when nothing has a default.
+List<FieldValue> seedFieldValues(Iterable<FieldDefinition> defs, int? listId) {
+  final out = <FieldValue>[];
+  for (final def in defs) {
+    if (def.listId != null && def.listId != listId) continue;
+    final seed = def.seedValue();
+    if (seed != null) out.add(seed);
+  }
+  return out;
 }
 
 /// A per-item typed value for a custom field. Rides the checklist item (like

--- a/lib/models/custom_field.dart
+++ b/lib/models/custom_field.dart
@@ -1,0 +1,305 @@
+/// Sentinel for [FieldDefinition.copyWith]'s `listId`, where `null` is a
+/// meaningful value ("All lists" / house-wide) and must be distinguishable
+/// from "leave unchanged".
+const Object _unset = Object();
+
+/// The five custom-field types, in their locked presentation order (per the
+/// UI contract). The wire form is the lowercase [name].
+enum FieldType {
+  text,
+  number,
+  checkbox,
+  date,
+  select;
+
+  static FieldType fromWire(String wire) =>
+      FieldType.values.firstWhere((t) => t.name == wire, orElse: () => text);
+}
+
+/// Entry mode for a `date` field: a picked calendar date, or an offset
+/// materialized to an absolute date at entry.
+enum FieldDateMode {
+  absolute,
+  relative;
+
+  static FieldDateMode? fromWire(String? wire) => wire == null
+      ? null
+      : FieldDateMode.values.firstWhere(
+          (m) => m.name == wire,
+          orElse: () => absolute,
+        );
+}
+
+/// Per-item reminder policy for a `date` field.
+enum FieldOverridePolicy {
+  fieldOnly('field-only'),
+  itemOverride('item-override');
+
+  const FieldOverridePolicy(this.wire);
+
+  final String wire;
+
+  static FieldOverridePolicy? fromWire(String? wire) => wire == null
+      ? null
+      : FieldOverridePolicy.values.firstWhere(
+          (p) => p.wire == wire,
+          orElse: () => fieldOnly,
+        );
+}
+
+/// One choice of a `select` field. Stored item values reference an option by
+/// [id], so rename/reorder are safe.
+class FieldOption {
+  final int id;
+  final String label;
+  final int sortOrder;
+
+  /// How many stored item values currently reference this option. Drives the
+  /// remap-or-clear prompt when deleting an option that's in use.
+  final int valueCount;
+
+  const FieldOption({
+    required this.id,
+    required this.label,
+    required this.sortOrder,
+    this.valueCount = 0,
+  });
+
+  factory FieldOption.fromJson(Map<String, dynamic> json) => FieldOption(
+    id: json['id'] as int,
+    label: json['label'] as String,
+    sortOrder: json['sortOrder'] as int? ?? 0,
+    valueCount: json['valueCount'] as int? ?? 0,
+  );
+
+  Map<String, dynamic> toJson() => {
+    'id': id,
+    'label': label,
+    'sortOrder': sortOrder,
+    'valueCount': valueCount,
+  };
+
+  FieldOption copyWith({int? id, String? label, int? sortOrder}) => FieldOption(
+    id: id ?? this.id,
+    label: label ?? this.label,
+    sortOrder: sortOrder ?? this.sortOrder,
+    valueCount: valueCount,
+  );
+}
+
+/// A custom-field definition, scoped to a house and optionally to a single
+/// list ([listId] `null` = house-wide, offered on every list). Type-specific
+/// config lives in the matching fields; [options] is populated for `select`.
+/// Mirrors [Category]'s house/list scoping and gated behind the
+/// `custom-fields` capability.
+class FieldDefinition {
+  final int id;
+  final int houseId;
+
+  /// The list this field is scoped to, or `null` when it's house-wide.
+  final int? listId;
+  final String name;
+  final FieldType type;
+  final int sortOrder;
+  final String? hint;
+  final bool multiline;
+  final String? defaultText;
+  final double? defaultNumber;
+  final bool defaultBool;
+  final int? defaultOptionId;
+  final FieldDateMode? dateMode;
+  final int? defaultOffsetDays;
+  final bool notifyDefault;
+  final int leadDays;
+  final FieldOverridePolicy? overridePolicy;
+  final bool stopWhenDone;
+  final List<FieldOption> options;
+  final int createdAt;
+  final int updatedAt;
+
+  const FieldDefinition({
+    required this.id,
+    required this.houseId,
+    this.listId,
+    required this.name,
+    required this.type,
+    required this.sortOrder,
+    this.hint,
+    this.multiline = false,
+    this.defaultText,
+    this.defaultNumber,
+    this.defaultBool = false,
+    this.defaultOptionId,
+    this.dateMode,
+    this.defaultOffsetDays,
+    this.notifyDefault = false,
+    this.leadDays = 0,
+    this.overridePolicy,
+    this.stopWhenDone = false,
+    this.options = const [],
+    required this.createdAt,
+    required this.updatedAt,
+  });
+
+  factory FieldDefinition.fromJson(Map<String, dynamic> json) =>
+      FieldDefinition(
+        id: json['id'] as int,
+        houseId: json['houseId'] as int,
+        listId: json['listId'] as int?,
+        name: json['name'] as String,
+        type: FieldType.fromWire(json['type'] as String),
+        sortOrder: json['sortOrder'] as int? ?? 0,
+        hint: json['hint'] as String?,
+        multiline: json['multiline'] as bool? ?? false,
+        defaultText: json['defaultText'] as String?,
+        defaultNumber: (json['defaultNumber'] as num?)?.toDouble(),
+        defaultBool: json['defaultBool'] as bool? ?? false,
+        defaultOptionId: json['defaultOptionId'] as int?,
+        dateMode: FieldDateMode.fromWire(json['dateMode'] as String?),
+        defaultOffsetDays: json['defaultOffsetDays'] as int?,
+        notifyDefault: json['notifyDefault'] as bool? ?? false,
+        leadDays: json['leadDays'] as int? ?? 0,
+        overridePolicy: FieldOverridePolicy.fromWire(
+          json['overridePolicy'] as String?,
+        ),
+        stopWhenDone: json['stopWhenDone'] as bool? ?? false,
+        options:
+            (json['options'] as List?)
+                ?.map((e) => FieldOption.fromJson(e as Map<String, dynamic>))
+                .toList() ??
+            const [],
+        createdAt: json['createdAt'] as int? ?? 0,
+        updatedAt: json['updatedAt'] as int? ?? 0,
+      );
+
+  Map<String, dynamic> toJson() => {
+    'id': id,
+    'houseId': houseId,
+    'listId': listId,
+    'name': name,
+    'type': type.name,
+    'sortOrder': sortOrder,
+    'hint': hint,
+    'multiline': multiline,
+    'defaultText': defaultText,
+    'defaultNumber': defaultNumber,
+    'defaultBool': defaultBool,
+    'defaultOptionId': defaultOptionId,
+    'dateMode': dateMode?.name,
+    'defaultOffsetDays': defaultOffsetDays,
+    'notifyDefault': notifyDefault,
+    'leadDays': leadDays,
+    'overridePolicy': overridePolicy?.wire,
+    'stopWhenDone': stopWhenDone,
+    'options': options.map((o) => o.toJson()).toList(),
+    'createdAt': createdAt,
+    'updatedAt': updatedAt,
+  };
+
+  /// Pass `listId: null` to make the field house-wide, an int to scope it, or
+  /// omit it to leave the current scope unchanged.
+  FieldDefinition copyWith({
+    int? id,
+    Object? listId = _unset,
+    String? name,
+    int? sortOrder,
+    String? hint,
+    bool? multiline,
+    String? defaultText,
+    double? defaultNumber,
+    bool? defaultBool,
+    int? defaultOptionId,
+    FieldDateMode? dateMode,
+    int? defaultOffsetDays,
+    bool? notifyDefault,
+    int? leadDays,
+    FieldOverridePolicy? overridePolicy,
+    bool? stopWhenDone,
+    List<FieldOption>? options,
+    int? updatedAt,
+  }) => FieldDefinition(
+    id: id ?? this.id,
+    houseId: houseId,
+    listId: identical(listId, _unset) ? this.listId : listId as int?,
+    name: name ?? this.name,
+    // The type is immutable after creation, so it's never a copyWith argument.
+    type: type,
+    sortOrder: sortOrder ?? this.sortOrder,
+    hint: hint ?? this.hint,
+    multiline: multiline ?? this.multiline,
+    defaultText: defaultText ?? this.defaultText,
+    defaultNumber: defaultNumber ?? this.defaultNumber,
+    defaultBool: defaultBool ?? this.defaultBool,
+    defaultOptionId: defaultOptionId ?? this.defaultOptionId,
+    dateMode: dateMode ?? this.dateMode,
+    defaultOffsetDays: defaultOffsetDays ?? this.defaultOffsetDays,
+    notifyDefault: notifyDefault ?? this.notifyDefault,
+    leadDays: leadDays ?? this.leadDays,
+    overridePolicy: overridePolicy ?? this.overridePolicy,
+    stopWhenDone: stopWhenDone ?? this.stopWhenDone,
+    options: options ?? this.options,
+    createdAt: createdAt,
+    updatedAt: updatedAt ?? this.updatedAt,
+  );
+}
+
+/// A per-item typed value for a custom field. Rides the checklist item (like
+/// [ItemPrice]); which value column is populated depends on the field's type,
+/// and the `notify*` fields carry a date field's per-item reminder override.
+class FieldValue {
+  final int fieldId;
+  final String? valueText;
+  final double? valueNumber;
+  final bool valueBool;
+  final int? valueDate;
+  final int? valueOptionId;
+
+  /// Relative-date offset in days; drives the Re-anchor action.
+  final int? offsetDays;
+
+  /// Whether this value overrides the field's reminder default.
+  final bool notifyOverride;
+  final bool notifyEnabled;
+
+  /// `null` inherits the field's `leadDays`.
+  final int? notifyLeadDays;
+
+  const FieldValue({
+    required this.fieldId,
+    this.valueText,
+    this.valueNumber,
+    this.valueBool = false,
+    this.valueDate,
+    this.valueOptionId,
+    this.offsetDays,
+    this.notifyOverride = false,
+    this.notifyEnabled = false,
+    this.notifyLeadDays,
+  });
+
+  factory FieldValue.fromJson(Map<String, dynamic> json) => FieldValue(
+    fieldId: json['fieldId'] as int,
+    valueText: json['valueText'] as String?,
+    valueNumber: (json['valueNumber'] as num?)?.toDouble(),
+    valueBool: json['valueBool'] as bool? ?? false,
+    valueDate: json['valueDate'] as int?,
+    valueOptionId: json['valueOptionId'] as int?,
+    offsetDays: json['offsetDays'] as int?,
+    notifyOverride: json['notifyOverride'] as bool? ?? false,
+    notifyEnabled: json['notifyEnabled'] as bool? ?? false,
+    notifyLeadDays: json['notifyLeadDays'] as int?,
+  );
+
+  Map<String, dynamic> toJson() => {
+    'fieldId': fieldId,
+    'valueText': valueText,
+    'valueNumber': valueNumber,
+    'valueBool': valueBool,
+    'valueDate': valueDate,
+    'valueOptionId': valueOptionId,
+    'offsetDays': offsetDays,
+    'notifyOverride': notifyOverride,
+    'notifyEnabled': notifyEnabled,
+    'notifyLeadDays': notifyLeadDays,
+  };
+}

--- a/lib/models/house.dart
+++ b/lib/models/house.dart
@@ -26,6 +26,7 @@ class HousePermissions {
   final bool canCreateNotes;
   final bool canUpdateNotes;
   final bool canDeleteNotes;
+  final bool canEditFields;
 
   const HousePermissions({
     this.canViewLists = true,
@@ -46,6 +47,7 @@ class HousePermissions {
     this.canCreateNotes = true,
     this.canUpdateNotes = true,
     this.canDeleteNotes = true,
+    this.canEditFields = true,
   });
 
   /// Every capability granted — used as the default for pre-roles servers and
@@ -74,6 +76,7 @@ class HousePermissions {
       canCreateNotes: read('canCreateNotes'),
       canUpdateNotes: read('canUpdateNotes'),
       canDeleteNotes: read('canDeleteNotes'),
+      canEditFields: read('canEditFields'),
     );
   }
 
@@ -96,6 +99,7 @@ class HousePermissions {
     'canCreateNotes': canCreateNotes,
     'canUpdateNotes': canUpdateNotes,
     'canDeleteNotes': canDeleteNotes,
+    'canEditFields': canEditFields,
   };
 }
 

--- a/lib/models/notification.dart
+++ b/lib/models/notification.dart
@@ -69,9 +69,27 @@ class NcNotification {
       case 'note':
         return NotificationTarget.notes;
       case 'item':
+      // A custom-field date reminder deep-links to the item detail.
+      case 'cf_reminder':
         return NotificationTarget.checklists;
       default:
         return null;
     }
+  }
+
+  /// House / list / item ids parsed from [link] (shaped
+  /// `…/houses/{h}/lists/{l}?item={i}`), for reminders that deep-link straight
+  /// to an item detail. Null when the link doesn't carry all three.
+  ({int houseId, int listId, int itemId})? get itemLinkTarget {
+    final url = link;
+    if (url == null) return null;
+    final scope = RegExp(r'/houses/(\d+)/lists/(\d+)').firstMatch(url);
+    final item = RegExp(r'[?&]item=(\d+)').firstMatch(url);
+    if (scope == null || item == null) return null;
+    return (
+      houseId: int.parse(scope.group(1)!),
+      listId: int.parse(scope.group(2)!),
+      itemId: int.parse(item.group(1)!),
+    );
   }
 }

--- a/lib/services/api_client.dart
+++ b/lib/services/api_client.dart
@@ -155,6 +155,25 @@ class ApiClient {
     }
   }
 
+  /// DELETE that carries a request body and parses a response — for endpoints
+  /// where the deletion needs parameters (e.g. remap-or-clear) and returns the
+  /// updated resource.
+  Future<T> deleteWithResult<D, T>(
+    String path, {
+    Map<String, dynamic>? body,
+    required T Function(D data) fromJson,
+  }) async {
+    _ensureOnline();
+    final response = await http
+        .delete(
+          _uri(path),
+          headers: _headers,
+          body: body != null ? jsonEncode(body) : null,
+        )
+        .timeout(_timeout);
+    return _handleResponse<D, T>(response, fromJson);
+  }
+
   /// Upload raw bytes (e.g. image) via POST with a given content type.
   Future<T> uploadBytes<D, T>(
     String path, {

--- a/lib/services/background_notification_task.dart
+++ b/lib/services/background_notification_task.dart
@@ -124,5 +124,16 @@ String? _payloadFor(NcNotification n) {
     NotificationTarget.photos => 1,
     NotificationTarget.notes => 2,
   };
+  // Custom-field date reminders carry a list+item link — open that item detail
+  // directly rather than just landing on the checklists tab.
+  final itemTarget = n.itemLinkTarget;
+  if (itemTarget != null) {
+    return DeepLink(
+      tabIndex: tab,
+      houseId: itemTarget.houseId,
+      listId: itemTarget.listId,
+      itemId: itemTarget.itemId,
+    ).encode();
+  }
   return DeepLink(tabIndex: tab, houseId: n.houseId).encode();
 }

--- a/lib/services/checklist_service.dart
+++ b/lib/services/checklist_service.dart
@@ -1,4 +1,5 @@
 import 'package:pantry/models/checklist.dart';
+import 'package:pantry/models/custom_field.dart';
 import 'package:pantry/services/api_client.dart';
 import 'package:pantry/services/auth_service.dart';
 import 'package:pantry/services/cache_store.dart';
@@ -42,6 +43,20 @@ Map<String, dynamic> itemPriceBody(
     if (storeless.priceCurrency != null)
       'priceCurrency': storeless.priceCurrency,
   };
+}
+
+/// Capability advertised by servers that store per-item custom-field values.
+const kCustomFieldsFeature = 'custom-fields';
+
+/// Serialize [customFields] for the item create/update body. `null` omits the
+/// field (values unchanged); a list — even empty — is sent so an update can
+/// clear every value. Sent only on servers advertising `custom-fields`; older
+/// servers ignore custom fields entirely, so nothing is emitted for them.
+Map<String, dynamic> customFieldsBody(List<FieldValue>? customFields) {
+  if (customFields == null || !hasFeature(kCustomFieldsFeature)) {
+    return const {};
+  }
+  return {'customFields': customFields.map((v) => v.toJson()).toList()};
 }
 
 class ChecklistService {
@@ -542,6 +557,7 @@ class ChecklistService {
     bool? deleteOnDone,
     String? barcode,
     List<ItemPrice>? prices,
+    List<FieldValue>? customFields,
   }) async {
     final loginName = AuthService.instance.credentials?.loginName;
     return ApiClient.instance.post<Map<String, dynamic>, ListItem>(
@@ -562,6 +578,9 @@ class ChecklistService {
         // Adapts to the server: `prices` array on item-price-per-store servers,
         // legacy flat fields otherwise. null omits (no prices).
         ...itemPriceBody(prices, isUpdate: false),
+        // Custom-field values ride the item; null omits, sent only when the
+        // server advertises the capability.
+        ...customFieldsBody(customFields),
       },
       fromJson: (data) => ListItem.fromJson(data),
     );
@@ -583,6 +602,7 @@ class ChecklistService {
     bool? deleteOnDone,
     String? barcode,
     List<ItemPrice>? prices,
+    List<FieldValue>? customFields,
   }) async {
     return ApiClient.instance.patch<Map<String, dynamic>, ListItem>(
       '/houses/$houseId/lists/$listId/items/$itemId',
@@ -604,6 +624,9 @@ class ChecklistService {
         // all prices, otherwise the full set replaces the item's prices. On
         // legacy servers this collapses to the store-less flat fields.
         ...itemPriceBody(prices, isUpdate: true),
+        // Custom fields mirror prices: null omits (unchanged), an empty list
+        // clears every value, otherwise the set replaces the item's values.
+        ...customFieldsBody(customFields),
       },
       fromJson: (data) => ListItem.fromJson(data),
     );

--- a/lib/services/custom_field_service.dart
+++ b/lib/services/custom_field_service.dart
@@ -1,0 +1,184 @@
+import 'package:pantry/models/custom_field.dart';
+import 'package:pantry/services/api_client.dart';
+import 'package:pantry/services/cache_store.dart';
+
+/// Sentinel for [CustomFieldService.updateField]'s `listId`: pass it (the
+/// default) to omit `listId` from the PATCH entirely, leaving the scope
+/// unchanged. `null` is a *meaningful* value ("make house-wide"), so it can't
+/// double as "unset".
+const Object fieldListIdUnset = Object();
+
+/// How to treat item values referencing a `select` option being deleted:
+/// `remap` moves them to another option, `clear` empties them.
+enum OptionDeleteAction {
+  remap,
+  clear;
+
+  String get wire => name;
+}
+
+/// Owns the field-definition REST calls and their cache. Mirrors
+/// [CategoryService]; gated by the `custom-fields` capability at the call site.
+class CustomFieldService {
+  CustomFieldService._();
+  static final CustomFieldService instance = CustomFieldService._();
+
+  final cache = CacheStore('custom_field_cache.json');
+
+  static const _prefix = 'fields';
+
+  List<FieldDefinition>? getCached(int houseId) =>
+      cache.getKeyedList(_prefix, '$houseId', FieldDefinition.fromJson);
+
+  Future<List<FieldDefinition>> getFields(int houseId) async {
+    final fields = await ApiClient.instance.get<List, List<FieldDefinition>>(
+      '/houses/$houseId/fields',
+      fromJson: (data) => data
+          .map((e) => FieldDefinition.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+    cache.setKeyedList(_prefix, '$houseId', fields, (f) => f.toJson());
+    return fields;
+  }
+
+  /// Order fields for display: by [FieldDefinition.sortOrder], then id
+  /// (creation order) as a tiebreaker so fresh fields sharing a sortOrder
+  /// stay put. Returns a new list; the input is not mutated.
+  static List<FieldDefinition> sortFields(Iterable<FieldDefinition> fields) {
+    final list = fields.toList();
+    list.sort((a, b) {
+      final c = a.sortOrder.compareTo(b.sortOrder);
+      return c != 0 ? c : a.id.compareTo(b.id);
+    });
+    return list;
+  }
+
+  Future<FieldDefinition> createField(
+    int houseId, {
+    required String name,
+    required FieldType type,
+    int? listId,
+    String? hint,
+    bool? multiline,
+    String? defaultText,
+    double? defaultNumber,
+    bool? defaultBool,
+    String? dateMode,
+    int? defaultOffsetDays,
+    bool? notifyDefault,
+    int? leadDays,
+    String? overridePolicy,
+    bool? stopWhenDone,
+    List<Map<String, dynamic>>? options,
+  }) async {
+    return ApiClient.instance.post<Map<String, dynamic>, FieldDefinition>(
+      '/houses/$houseId/fields',
+      // A null `listId` means house-wide — the server default — so it's only
+      // sent when scoping to a real list.
+      body: {
+        'name': name,
+        'type': type.name,
+        'listId': ?listId,
+        'hint': ?hint,
+        'multiline': ?multiline,
+        'defaultText': ?defaultText,
+        'defaultNumber': ?defaultNumber,
+        'defaultBool': ?defaultBool,
+        'dateMode': ?dateMode,
+        'defaultOffsetDays': ?defaultOffsetDays,
+        'notifyDefault': ?notifyDefault,
+        'leadDays': ?leadDays,
+        'overridePolicy': ?overridePolicy,
+        'stopWhenDone': ?stopWhenDone,
+        'options': ?options,
+      },
+      fromJson: (data) => FieldDefinition.fromJson(data),
+    );
+  }
+
+  /// Pass [listId] as an int to scope the field, `null` to make it house-wide,
+  /// or leave it as [fieldListIdUnset] to keep the current scope. The `?`
+  /// map-spread would silently drop an explicit `null`, so `listId` is added
+  /// separately.
+  Future<FieldDefinition> updateField(
+    int houseId,
+    int fieldId, {
+    String? name,
+    Object? listId = fieldListIdUnset,
+    String? hint,
+    bool? multiline,
+    String? defaultText,
+    double? defaultNumber,
+    bool? defaultBool,
+    int? defaultOptionId,
+    String? dateMode,
+    int? defaultOffsetDays,
+    bool? notifyDefault,
+    int? leadDays,
+    String? overridePolicy,
+    bool? stopWhenDone,
+    List<Map<String, dynamic>>? options,
+  }) async {
+    final body = <String, dynamic>{
+      'name': ?name,
+      'hint': ?hint,
+      'multiline': ?multiline,
+      'defaultText': ?defaultText,
+      'defaultNumber': ?defaultNumber,
+      'defaultBool': ?defaultBool,
+      'defaultOptionId': ?defaultOptionId,
+      'dateMode': ?dateMode,
+      'defaultOffsetDays': ?defaultOffsetDays,
+      'notifyDefault': ?notifyDefault,
+      'leadDays': ?leadDays,
+      'overridePolicy': ?overridePolicy,
+      'stopWhenDone': ?stopWhenDone,
+      'options': ?options,
+    };
+    if (!identical(listId, fieldListIdUnset)) body['listId'] = listId;
+    return ApiClient.instance.patch<Map<String, dynamic>, FieldDefinition>(
+      '/houses/$houseId/fields/$fieldId',
+      body: body,
+      fromJson: (data) => FieldDefinition.fromJson(data),
+    );
+  }
+
+  Future<void> deleteField(int houseId, int fieldId) async {
+    await ApiClient.instance.delete('/houses/$houseId/fields/$fieldId');
+  }
+
+  /// Delete one `select` option. An unused option is removed outright (pass no
+  /// [action]). An option in use requires an action: [OptionDeleteAction.remap]
+  /// moves its values to [remapToId], [OptionDeleteAction.clear] empties them.
+  /// Returns the updated definition. Needs a live connection — the usage count
+  /// and remap are resolved server-side.
+  Future<FieldDefinition> deleteFieldOption(
+    int houseId,
+    int fieldId,
+    int optionId, {
+    OptionDeleteAction? action,
+    int? remapToId,
+  }) async {
+    return ApiClient.instance
+        .deleteWithResult<Map<String, dynamic>, FieldDefinition>(
+          '/houses/$houseId/fields/$fieldId/options/$optionId',
+          body: {'action': ?action?.wire, 'remapToId': ?remapToId},
+          fromJson: (data) => FieldDefinition.fromJson(data),
+        );
+  }
+
+  Future<void> reorderFields(
+    int houseId,
+    List<({int id, int sortOrder})> order,
+  ) async {
+    await ApiClient.instance.patch<Map<String, dynamic>, void>(
+      '/houses/$houseId/fields/reorder',
+      body: {
+        'items': order
+            .map((e) => {'id': e.id, 'sortOrder': e.sortOrder})
+            .toList(),
+      },
+      fromJson: (_) {},
+    );
+  }
+}

--- a/lib/services/deep_link_service.dart
+++ b/lib/services/deep_link_service.dart
@@ -7,22 +7,38 @@ class DeepLink {
   final int tabIndex;
   final int? houseId;
 
-  const DeepLink({required this.tabIndex, this.houseId});
+  /// When both are set (a checklists deep link), the target list is preselected
+  /// and its item is opened once loaded — used by custom-field date reminders.
+  final int? listId;
+  final int? itemId;
+
+  const DeepLink({
+    required this.tabIndex,
+    this.houseId,
+    this.listId,
+    this.itemId,
+  });
 
   /// Serialize to a compact string for notification payloads.
-  String encode() => '$tabIndex:${houseId ?? ''}';
+  String encode() =>
+      '$tabIndex:${houseId ?? ''}:${listId ?? ''}:${itemId ?? ''}';
 
-  /// Parse a payload string. Returns null if invalid.
+  /// Parse a payload string. Returns null if invalid. Tolerates the older
+  /// two-field form (`tab:house`) so payloads already scheduled still decode.
   static DeepLink? decode(String? payload) {
     if (payload == null || payload.isEmpty) return null;
     final parts = payload.split(':');
     if (parts.isEmpty) return null;
     final tab = int.tryParse(parts[0]);
     if (tab == null || tab < 0 || tab > 2) return null;
-    final houseId = parts.length > 1 && parts[1].isNotEmpty
-        ? int.tryParse(parts[1])
-        : null;
-    return DeepLink(tabIndex: tab, houseId: houseId);
+    int? at(int i) =>
+        parts.length > i && parts[i].isNotEmpty ? int.tryParse(parts[i]) : null;
+    return DeepLink(
+      tabIndex: tab,
+      houseId: at(1),
+      listId: at(2),
+      itemId: at(3),
+    );
   }
 }
 

--- a/lib/sync/sync_executor.dart
+++ b/lib/sync/sync_executor.dart
@@ -174,6 +174,7 @@ class SyncExecutor {
           deleteOnDone: op.body['deleteOnDone'] as bool?,
           barcode: op.body['barcode'] as String?,
           prices: _pricesFromBody(op.body['prices']),
+          customFields: _customFieldsFromBody(op.body['customFields']),
         );
         return SyncResult(item);
       case SyncOpKind.update:
@@ -194,6 +195,7 @@ class SyncExecutor {
           deleteOnDone: op.body['deleteOnDone'] as bool?,
           barcode: op.body['barcode'] as String?,
           prices: _pricesFromBody(op.body['prices']),
+          customFields: _customFieldsFromBody(op.body['customFields']),
         );
         return SyncResult(item);
       case SyncOpKind.delete:
@@ -615,6 +617,16 @@ List<ItemPrice>? _pricesFromBody(Object? raw) {
   if (raw == null) return null;
   return (raw as List)
       .map((e) => ItemPrice.fromJson(e as Map<String, dynamic>))
+      .toList();
+}
+
+/// Decode a queued `customFields` payload back into [FieldValue]s. Null (the
+/// key was omitted) leaves values unchanged; a list — even empty — is passed
+/// through so an empty array can clear all values on update.
+List<FieldValue>? _customFieldsFromBody(Object? raw) {
+  if (raw == null) return null;
+  return (raw as List)
+      .map((e) => FieldValue.fromJson(e as Map<String, dynamic>))
       .toList();
 }
 

--- a/lib/sync/sync_executor.dart
+++ b/lib/sync/sync_executor.dart
@@ -1,10 +1,12 @@
 import 'package:pantry/models/category.dart';
 import 'package:pantry/models/checklist.dart';
+import 'package:pantry/models/custom_field.dart';
 import 'package:pantry/models/label.dart';
 import 'package:pantry/models/note.dart';
 import 'package:pantry/models/store.dart';
 import 'package:pantry/services/category_service.dart';
 import 'package:pantry/services/checklist_service.dart';
+import 'package:pantry/services/custom_field_service.dart';
 import 'package:pantry/services/label_service.dart';
 import 'package:pantry/services/note_service.dart';
 import 'package:pantry/services/shopping_service.dart';
@@ -43,6 +45,8 @@ class SyncExecutor {
         return _executeLabel(op);
       case SyncEntity.note:
         return _executeNote(op);
+      case SyncEntity.customField:
+        return _executeCustomField(op);
       case SyncEntity.shoppingCheck:
         return _executeShoppingCheck(op);
       case SyncEntity.shoppingSkip:
@@ -360,6 +364,79 @@ class SyncExecutor {
     }
   }
 
+  Future<SyncResult> _executeCustomField(SyncOp op) async {
+    final svc = CustomFieldService.instance;
+    final houseId = op.houseId;
+    final id = op.entityId;
+    switch (op.op) {
+      case SyncOpKind.create:
+        final field = await svc.createField(
+          houseId,
+          name: op.body['name'] as String,
+          type: FieldType.fromWire(op.body['type'] as String),
+          listId: op.body['listId'] as int?,
+          hint: op.body['hint'] as String?,
+          multiline: op.body['multiline'] as bool?,
+          defaultText: op.body['defaultText'] as String?,
+          defaultNumber: (op.body['defaultNumber'] as num?)?.toDouble(),
+          defaultBool: op.body['defaultBool'] as bool?,
+          dateMode: op.body['dateMode'] as String?,
+          defaultOffsetDays: op.body['defaultOffsetDays'] as int?,
+          notifyDefault: op.body['notifyDefault'] as bool?,
+          leadDays: op.body['leadDays'] as int?,
+          overridePolicy: op.body['overridePolicy'] as String?,
+          stopWhenDone: op.body['stopWhenDone'] as bool?,
+          options: _fieldOptionsFromBody(op.body['options']),
+        );
+        return SyncResult(field);
+      case SyncOpKind.update:
+        if (id == null) return SyncResult.empty;
+        // Presence is significant: `listId` absent leaves the scope alone; a
+        // key present with a value (including null → house-wide) re-scopes it.
+        final field = await svc.updateField(
+          houseId,
+          id,
+          name: op.body['name'] as String?,
+          listId: op.body.containsKey('listId')
+              ? op.body['listId']
+              : fieldListIdUnset,
+          hint: op.body['hint'] as String?,
+          multiline: op.body['multiline'] as bool?,
+          defaultText: op.body['defaultText'] as String?,
+          defaultNumber: (op.body['defaultNumber'] as num?)?.toDouble(),
+          defaultBool: op.body['defaultBool'] as bool?,
+          defaultOptionId: op.body['defaultOptionId'] as int?,
+          dateMode: op.body['dateMode'] as String?,
+          defaultOffsetDays: op.body['defaultOffsetDays'] as int?,
+          notifyDefault: op.body['notifyDefault'] as bool?,
+          leadDays: op.body['leadDays'] as int?,
+          overridePolicy: op.body['overridePolicy'] as String?,
+          stopWhenDone: op.body['stopWhenDone'] as bool?,
+          options: _fieldOptionsFromBody(op.body['options']),
+        );
+        return SyncResult(field);
+      case SyncOpKind.delete:
+        if (id == null) return SyncResult.empty;
+        await svc.deleteField(houseId, id);
+        return SyncResult.empty;
+      case SyncOpKind.reorder:
+        final raw = (op.body['order'] as List).cast<Map>();
+        final order = raw
+            .map((e) => (id: e['id'] as int, sortOrder: e['sortOrder'] as int))
+            .toList();
+        await svc.reorderFields(houseId, order);
+        return SyncResult.empty;
+      case SyncOpKind.toggle:
+      case SyncOpKind.restore:
+      case SyncOpKind.permanentDelete:
+      case SyncOpKind.emptyTrash:
+      case SyncOpKind.archive:
+      case SyncOpKind.unarchive:
+      case SyncOpKind.batch:
+        return SyncResult.empty;
+    }
+  }
+
   Future<SyncResult> _executeStore(SyncOp op) async {
     final svc = StoreService.instance;
     final houseId = op.houseId;
@@ -541,6 +618,14 @@ List<ItemPrice>? _pricesFromBody(Object? raw) {
       .toList();
 }
 
+/// Decode a queued `options` payload back into the option-input maps
+/// [CustomFieldService] sends. Null (key omitted) leaves options unchanged; a
+/// list — even empty — is passed through so an update can clear them.
+List<Map<String, dynamic>>? _fieldOptionsFromBody(Object? raw) {
+  if (raw == null) return null;
+  return (raw as List).cast<Map<String, dynamic>>();
+}
+
 /// Helpers to extract the server id from a result, used by the manager to
 /// bind temp ids after a create.
 int? serverIdOf(Object? entity) {
@@ -550,5 +635,6 @@ int? serverIdOf(Object? entity) {
   if (entity is Store) return entity.id;
   if (entity is Label) return entity.id;
   if (entity is Note) return entity.id;
+  if (entity is FieldDefinition) return entity.id;
   return null;
 }

--- a/lib/sync/sync_manager.dart
+++ b/lib/sync/sync_manager.dart
@@ -208,6 +208,7 @@ class SyncManager {
         case SyncEntity.store:
         case SyncEntity.label:
         case SyncEntity.note:
+        case SyncEntity.customField:
         case SyncEntity.shoppingCheck:
         case SyncEntity.shoppingSkip:
           break;
@@ -549,6 +550,10 @@ class SyncManager {
           );
         }
       case SyncEntity.note:
+        break;
+      case SyncEntity.customField:
+        // Field-definition ops address their own record by id (rewritten by
+        // the id-remap), never another entity's temp id in their body.
         break;
       case SyncEntity.shoppingCheck:
       case SyncEntity.shoppingSkip:

--- a/lib/sync/sync_op.dart
+++ b/lib/sync/sync_op.dart
@@ -5,6 +5,7 @@ enum SyncEntity {
   store,
   label,
   note,
+  customField,
 
   /// A Shopping Mode item check-log write. [SyncOp.op] is [SyncOpKind.create]
   /// for a check and [SyncOpKind.delete] for an uncheck; [SyncOp.entityId] is

--- a/lib/utils/field_type_icons.dart
+++ b/lib/utils/field_type_icons.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import 'package:pantry/i18n.dart';
+import 'package:pantry/models/custom_field.dart';
+
+/// The five field types in their locked presentation order (per the UI
+/// contract).
+const List<FieldType> kFieldTypesInOrder = [
+  FieldType.text,
+  FieldType.number,
+  FieldType.checkbox,
+  FieldType.date,
+  FieldType.select,
+];
+
+IconData fieldTypeIcon(FieldType type) => switch (type) {
+  FieldType.text => Icons.text_fields,
+  FieldType.number => Icons.numbers,
+  FieldType.checkbox => Icons.check_box_outlined,
+  FieldType.date => Icons.event,
+  FieldType.select => Icons.list,
+};
+
+String fieldTypeLabel(FieldType type) => switch (type) {
+  FieldType.text => m.customFields.types.text,
+  FieldType.number => m.customFields.types.number,
+  FieldType.checkbox => m.customFields.types.checkbox,
+  FieldType.date => m.customFields.types.date,
+  FieldType.select => m.customFields.types.select,
+};

--- a/lib/views/checklists/checklists_controller.dart
+++ b/lib/views/checklists/checklists_controller.dart
@@ -2803,10 +2803,12 @@ class ChecklistsController extends ChangeNotifier {
           notifyListeners();
         }
       case SyncEntity.note:
+      case SyncEntity.customField:
       case SyncEntity.shoppingCheck:
       case SyncEntity.shoppingSkip:
         // Not surfaced in the checklists view — the shopping session controller
-        // reconciles its own check/skip ops.
+        // reconciles its own check/skip ops, and the custom-fields manager
+        // reconciles its own definition ops.
         break;
     }
   }

--- a/lib/views/checklists/checklists_controller.dart
+++ b/lib/views/checklists/checklists_controller.dart
@@ -4,6 +4,7 @@ import 'package:flutter/foundation.dart';
 import 'package:pantry/i18n.dart';
 import 'package:pantry/models/category.dart' as models;
 import 'package:pantry/models/checklist.dart';
+import 'package:pantry/models/custom_field.dart';
 import 'package:pantry/models/house.dart';
 import 'package:pantry/models/label.dart' as models;
 import 'package:pantry/models/member.dart';
@@ -12,6 +13,7 @@ import 'package:pantry/services/api_client.dart';
 import 'package:pantry/services/auth_service.dart';
 import 'package:pantry/services/category_service.dart';
 import 'package:pantry/services/checklist_service.dart';
+import 'package:pantry/services/custom_field_service.dart';
 import 'package:pantry/services/label_service.dart';
 import 'package:pantry/services/store_service.dart';
 import 'package:pantry/services/house_service.dart';
@@ -384,6 +386,13 @@ class ChecklistsController extends ChangeNotifier {
       if (item.labelIds.contains(l.id)) l,
   ];
 
+  /// Custom-field definitions for the house, driving the compose bar's
+  /// custom-fields tray and its default seeding. Empty unless the
+  /// `custom-fields` capability is present. Loaded non-fatally with the rest.
+  List<FieldDefinition> _customFieldDefs = const [];
+  List<FieldDefinition> get customFieldDefs =>
+      hasFeature(kCustomFieldsFeature) ? _customFieldDefs : const [];
+
   String _sortBy = 'custom';
   String get sortBy => _sortBy;
 
@@ -600,6 +609,18 @@ class ChecklistsController extends ChangeNotifier {
         }
       }
 
+      // Custom-field definitions back the compose bar's default seeding; gated
+      // on the capability and fetched non-fatally.
+      if (hasFeature(kCustomFieldsFeature)) {
+        try {
+          _customFieldDefs = await CustomFieldService.instance.getFields(
+            houseId,
+          );
+        } catch (e) {
+          debugPrint('[ChecklistsController] Failed to load custom fields: $e');
+        }
+      }
+
       // House prefs are non-fatal
       try {
         final prefs = await _checklistService.getHousePrefs(houseId);
@@ -784,6 +805,11 @@ class ChecklistsController extends ChangeNotifier {
     final cachedStores = _storeService.getCached(houseId);
     if (cachedStores != null && _stores.isEmpty) {
       _stores = {for (final s in cachedStores) s.id: s};
+    }
+
+    final cachedDefs = CustomFieldService.instance.getCached(houseId);
+    if (cachedDefs != null && _customFieldDefs.isEmpty) {
+      _customFieldDefs = cachedDefs;
     }
 
     final cachedLabels = _labelService.getCached(houseId);
@@ -2139,6 +2165,7 @@ class ChecklistsController extends ChangeNotifier {
     bool? deleteOnDone,
     String? barcode,
     List<ItemPrice>? prices,
+    List<FieldValue>? customFields,
   }) async {
     final list = _currentList;
     if (list == null || list.id == kAllListsId) {
@@ -2161,6 +2188,7 @@ class ChecklistsController extends ChangeNotifier {
       deleteOnDone: deleteOnDone,
       barcode: barcode,
       prices: prices,
+      customFields: customFields,
     );
   }
 
@@ -2181,6 +2209,7 @@ class ChecklistsController extends ChangeNotifier {
     bool? deleteOnDone,
     String? barcode,
     List<ItemPrice>? prices,
+    List<FieldValue>? customFields,
   }) async {
     final listId = targetListId;
     final tempId = _sync.newTempId();
@@ -2201,6 +2230,7 @@ class ChecklistsController extends ChangeNotifier {
       addedBy: loginName,
       barcode: barcode,
       prices: prices ?? const [],
+      customFields: customFields ?? const [],
       sortOrder: 0,
       createdAt: _now(),
       updatedAt: _now(),
@@ -2231,6 +2261,8 @@ class ChecklistsController extends ChangeNotifier {
           'deleteOnDone': ?deleteOnDone,
           'barcode': ?barcode,
           if (prices != null) 'prices': prices.map((p) => p.toJson()).toList(),
+          if (customFields != null)
+            'customFields': customFields.map((v) => v.toJson()).toList(),
         },
         createdAt: _now(),
       ),
@@ -2274,6 +2306,7 @@ class ChecklistsController extends ChangeNotifier {
     bool? deleteOnDone,
     String? barcode,
     List<ItemPrice>? prices,
+    List<FieldValue>? customFields,
   }) async {
     final updated = item.copyWith(
       name: name,
@@ -2289,6 +2322,8 @@ class ChecklistsController extends ChangeNotifier {
       barcode: barcode,
       // null leaves prices unchanged; a list (even empty) replaces them.
       prices: prices,
+      // Same contract for custom-field values.
+      customFields: customFields,
       updatedAt: _now(),
     );
     final index = _items.indexWhere((i) => i.id == item.id);
@@ -2319,6 +2354,8 @@ class ChecklistsController extends ChangeNotifier {
           'deleteOnDone': ?deleteOnDone,
           'barcode': ?barcode,
           if (prices != null) 'prices': prices.map((p) => p.toJson()).toList(),
+          if (customFields != null)
+            'customFields': customFields.map((v) => v.toJson()).toList(),
         },
         createdAt: _now(),
       ),

--- a/lib/views/checklists/checklists_view.dart
+++ b/lib/views/checklists/checklists_view.dart
@@ -935,6 +935,8 @@ class _BodyState extends State<_Body> with WidgetsBindingObserver {
                       return ItemComposeBar(
                         key: _composeKey,
                         listName: list.name,
+                        houseId: controller.houseId,
+                        listId: meta ? null : list.id,
                         deleteOnDoneDefault: meta
                             ? false
                             : list.deleteOnDoneDefault,
@@ -949,6 +951,7 @@ class _BodyState extends State<_Body> with WidgetsBindingObserver {
                                 meta ? _composeTargetListId : list.id,
                               )
                             : const [],
+                        customFieldDefs: controller.customFieldDefs,
                         priceEnabled: hasFeature('item-price'),
                         perStorePriceEnabled: hasFeature(
                           kItemPricePerStoreFeature,
@@ -1196,6 +1199,7 @@ class _BodyState extends State<_Body> with WidgetsBindingObserver {
           deleteOnDone: s.deleteOnDone,
           barcode: s.barcode,
           prices: s.prices,
+          customFields: s.customFields,
         );
       } else {
         created = await controller.addItem(
@@ -1210,6 +1214,7 @@ class _BodyState extends State<_Body> with WidgetsBindingObserver {
           deleteOnDone: s.deleteOnDone,
           barcode: s.barcode,
           prices: s.prices,
+          customFields: s.customFields,
         );
       }
       // Remember the chosen currency when the new item actually has a price:

--- a/lib/views/checklists/checklists_view.dart
+++ b/lib/views/checklists/checklists_view.dart
@@ -34,6 +34,7 @@ import 'package:pantry/utils/undo_snackbar.dart';
 import 'package:pantry/views/categories/categories_view.dart';
 import 'package:pantry/views/labels/labels_view.dart';
 import 'package:pantry/views/categories/category_form_view.dart';
+import 'package:pantry/views/custom_fields/custom_fields_view.dart';
 import 'package:pantry/views/shopping/shopping_history_view.dart';
 import 'package:pantry/views/shopping/shopping_session_view.dart';
 import 'package:pantry/views/shopping/shopping_start_view.dart';
@@ -1463,6 +1464,13 @@ class _BodyState extends State<_Body> with WidgetsBindingObserver {
               tooltip: m.labels.manageTitle,
               onPressed: () => _openManageLabels(context, controller),
             ),
+          if (controller.permissions.canEditFields &&
+              hasFeature('custom-fields'))
+            IconButton(
+              icon: const Icon(Icons.tune),
+              tooltip: m.customFields.manageTitle,
+              onPressed: () => _openManageCustomFields(context, controller),
+            ),
           // Meta view has no trash of its own; trash stays per-list.
           if (!controller.isMetaMode &&
               controller.isCurrentListWritable &&
@@ -1736,6 +1744,12 @@ class _BodyState extends State<_Body> with WidgetsBindingObserver {
             icon: Icons.sell_outlined,
             label: m.labels.manageTitle,
           ),
+        if (controller.permissions.canEditFields && hasFeature('custom-fields'))
+          _OverflowAction(
+            value: 'manage_custom_fields',
+            icon: Icons.tune,
+            label: m.customFields.manageTitle,
+          ),
         // Mobile has reliable pull-to-refresh, so it doesn't need a menu row.
         // Web (the other non-desktop host here) doesn't, so keep it there.
         if (PlatformInfo.isWeb)
@@ -1976,6 +1990,8 @@ class _BodyState extends State<_Body> with WidgetsBindingObserver {
         await _openManageStores(context, controller);
       case 'manage_labels':
         await _openManageLabels(context, controller);
+      case 'manage_custom_fields':
+        await _openManageCustomFields(context, controller);
       case 'start_shopping':
         await _openShopping(controller);
       case 'shopping_history':
@@ -2123,6 +2139,17 @@ class _BodyState extends State<_Body> with WidgetsBindingObserver {
       ),
     );
     await controller.onCategoriesChanged();
+  }
+
+  Future<void> _openManageCustomFields(
+    BuildContext context,
+    ChecklistsController controller,
+  ) async {
+    await Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => CustomFieldsView(houseId: controller.houseId),
+      ),
+    );
   }
 
   /// Opens the create-category dialog inline from the compose bar's category

--- a/lib/views/checklists/form_components.dart
+++ b/lib/views/checklists/form_components.dart
@@ -3,6 +3,84 @@ import 'package:flutter/material.dart';
 import 'package:pantry/i18n.dart';
 import 'package:pantry/utils/rrule.dart';
 
+/// The shared "filled field" frame used across item forms: a `surfaceContainer`
+/// card with a rounded-14 border that flips to the accent when focused. Pair
+/// with [fieldCardLabelStyle] for the uppercase caption.
+BoxDecoration fieldCardDecoration(ColorScheme cs, {bool focused = false}) =>
+    BoxDecoration(
+      color: cs.surfaceContainer,
+      border: Border.all(
+        color: focused ? cs.primary : cs.outlineVariant,
+        width: focused ? 1.5 : 1,
+      ),
+      borderRadius: BorderRadius.circular(14),
+    );
+
+/// The uppercase caption style used on field cards and section labels.
+TextStyle fieldCardLabelStyle(ColorScheme cs, {bool focused = false}) =>
+    TextStyle(
+      fontSize: 11,
+      fontWeight: FontWeight.w700,
+      letterSpacing: 0.6,
+      color: focused ? cs.primary : cs.onSurfaceVariant,
+    );
+
+/// A labeled, filled field card: an uppercase caption above [child], wrapped in
+/// [fieldCardDecoration]. The app's standard single-field container (name,
+/// quantity, custom fields, …).
+class LabeledFieldCard extends StatelessWidget {
+  final String label;
+
+  /// The control below the caption. Omit for boolean fields whose value sits
+  /// inline via [trailing].
+  final Widget? child;
+  final bool focused;
+
+  /// Optional control pinned to the right of the caption row (e.g. a switch),
+  /// for boolean fields where the value sits inline with the label.
+  final Widget? trailing;
+
+  const LabeledFieldCard({
+    super.key,
+    required this.label,
+    this.child,
+    this.focused = false,
+    this.trailing,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return AnimatedContainer(
+      duration: const Duration(milliseconds: 150),
+      padding: EdgeInsets.fromLTRB(
+        15,
+        trailing != null ? 6 : 11,
+        15,
+        trailing != null ? 6 : 12,
+      ),
+      decoration: fieldCardDecoration(cs, focused: focused),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Expanded(
+                child: Text(
+                  label.toUpperCase(),
+                  style: fieldCardLabelStyle(cs, focused: focused),
+                ),
+              ),
+              ?trailing,
+            ],
+          ),
+          if (child != null) ...[const SizedBox(height: 4), child!],
+        ],
+      ),
+    );
+  }
+}
+
 /// Mutable state for the inline recurrence panel. Edited in place by
 /// [RecurrenceInline] via [onChanged] callbacks; consumers read it back at save
 /// time and call [toRrule] to serialize.

--- a/lib/views/checklists/form_components.dart
+++ b/lib/views/checklists/form_components.dart
@@ -496,17 +496,24 @@ class RecurrenceInline extends StatelessWidget {
             ),
           ],
           const SizedBox(height: 8),
-          SwitchListTile(
-            contentPadding: EdgeInsets.zero,
-            value: state.repeatFromCompletion,
-            onChanged: (v) {
-              state.repeatFromCompletion = v;
-              onChanged();
-            },
-            title: Text(
-              r.countFromCompletion,
-              style: TextStyle(fontSize: 13, color: cs.onSurface),
-            ),
+          // A plain Row + Switch rather than a SwitchListTile: this sits inside
+          // a colored Container, where a ListTile's ink/background can't paint.
+          Row(
+            children: [
+              Expanded(
+                child: Text(
+                  r.countFromCompletion,
+                  style: TextStyle(fontSize: 13, color: cs.onSurface),
+                ),
+              ),
+              Switch(
+                value: state.repeatFromCompletion,
+                onChanged: (v) {
+                  state.repeatFromCompletion = v;
+                  onChanged();
+                },
+              ),
+            ],
           ),
         ],
       ),

--- a/lib/views/checklists/item_compose_bar.dart
+++ b/lib/views/checklists/item_compose_bar.dart
@@ -11,6 +11,7 @@ import 'package:pantry/models/category.dart' as models;
 import 'package:pantry/models/store.dart' as models;
 import 'package:pantry/models/label.dart' as models;
 import 'package:pantry/models/checklist.dart';
+import 'package:pantry/models/custom_field.dart';
 import 'package:pantry/services/barcode_service.dart';
 import 'package:pantry/utils/platform_info.dart';
 import 'package:pantry/views/checklists/barcode_scan_view.dart';
@@ -25,6 +26,7 @@ import 'package:pantry/utils/rrule.dart';
 import 'package:pantry/utils/store_icons.dart';
 import 'package:pantry/views/checklists/checklist_switcher_sheet.dart'
     show parseHexColor;
+import 'package:pantry/views/custom_fields/item_custom_fields_editor.dart';
 import 'checklist_item_tile.dart' show ItemLifecycle;
 import 'form_components.dart';
 import 'price_input.dart';
@@ -51,6 +53,11 @@ class ItemDraft {
   /// [reset] so the last-picked currency sticks for rapid same-currency adds.
   PricesDraft price = PricesDraft.empty(defaultCurrency);
 
+  /// Custom-field values the user has explicitly set via the custom-fields
+  /// tray. Only meaningful once [ItemComposeBarState] marks them edited; an
+  /// untouched item falls back to the fields' default seeds.
+  List<FieldValue> customFields = const [];
+
   void reset(ItemLifecycle defaultLifecycle) {
     name = '';
     description = '';
@@ -64,6 +71,7 @@ class ItemDraft {
     imageBytes = null;
     barcode = null;
     price = PricesDraft.empty(price.storeless.currency);
+    customFields = const [];
   }
 
   bool get repeatFromCompletion => recurrence.repeatFromCompletion;
@@ -96,6 +104,10 @@ class ComposeSubmission {
   /// semantics — omit the field).
   final List<ItemPrice>? prices;
 
+  /// Custom-field values for the created item (fields' defaults, plus any the
+  /// user set in the tray), or null when there are none.
+  final List<FieldValue>? customFields;
+
   const ComposeSubmission({
     required this.name,
     this.description,
@@ -111,11 +123,20 @@ class ComposeSubmission {
     this.imageMime,
     this.barcode,
     this.prices,
+    this.customFields,
   });
 }
 
 class ItemComposeBar extends StatefulWidget {
   final String listName;
+
+  /// House the item is added to, for loading custom-field definitions.
+  final int houseId;
+
+  /// The concrete list an item lands in when not in All-lists mode; `null` in
+  /// All-lists mode (the target is chosen via [selectedTargetListId]). Governs
+  /// which list-scoped custom fields apply.
+  final int? listId;
   final bool deleteOnDoneDefault;
   final List<models.Category> categories;
 
@@ -126,6 +147,11 @@ class ItemComposeBar extends StatefulWidget {
   /// Labels offered in the label tray. Empty (and the label chip hidden) when
   /// the server lacks the `labels` capability.
   final List<models.Label> labels;
+
+  /// Custom-field definitions for the house; empty (and the chip hidden) when
+  /// the server lacks `custom-fields`. Drives the custom-fields tray and the
+  /// default seeding.
+  final List<FieldDefinition> customFieldDefs;
   final Future<bool> Function(ComposeSubmission submission) onSubmit;
   final bool initiallyFocused;
   final bool dimmedListBackground;
@@ -199,10 +225,13 @@ class ItemComposeBar extends StatefulWidget {
   const ItemComposeBar({
     super.key,
     required this.listName,
+    required this.houseId,
+    this.listId,
     required this.deleteOnDoneDefault,
     required this.categories,
     this.stores = const [],
     this.labels = const [],
+    this.customFieldDefs = const [],
     required this.onSubmit,
     this.initiallyFocused = false,
     this.dimmedListBackground = false,
@@ -234,6 +263,7 @@ enum _Tray {
   label,
   quantity,
   price,
+  customFields,
   description,
   type,
   image,
@@ -251,6 +281,27 @@ class ItemComposeBarState extends State<ItemComposeBar> {
   bool _submitting = false;
   bool _multiple = false;
 
+  /// True once the user touches the custom-fields tray. Until then the item
+  /// falls back to the fields' default seeds, recomputed from the live target.
+  bool _customFieldsEdited = false;
+
+  /// The list the item will land in: the picked target in All-lists mode, else
+  /// the bar's concrete list. Governs which list-scoped fields apply.
+  int? get _targetListId =>
+      widget._allListsMode ? widget.selectedTargetListId : widget.listId;
+
+  /// Custom fields applicable to the current target (house-wide ∪ the list).
+  List<FieldDefinition> get _applicableCustomFields => [
+    for (final f in widget.customFieldDefs)
+      if (f.listId == null || f.listId == _targetListId) f,
+  ];
+
+  /// The values to carry: the user's edits once they've touched the tray,
+  /// otherwise the defaults seeded from the applicable fields.
+  List<FieldValue> get _effectiveCustomFields => _customFieldsEdited
+      ? _draft.customFields
+      : seedFieldValues(widget.customFieldDefs, _targetListId);
+
   @override
   void initState() {
     super.initState();
@@ -267,6 +318,18 @@ class ItemComposeBarState extends State<ItemComposeBar> {
       }
     });
     _nameCtrl.addListener(_onNameChanged);
+  }
+
+  @override
+  void didUpdateWidget(ItemComposeBar oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // Switching the target list changes which fields apply, so drop any
+    // in-progress custom-field edits and fall back to the new list's defaults.
+    if (oldWidget.listId != widget.listId ||
+        oldWidget.selectedTargetListId != widget.selectedTargetListId) {
+      _customFieldsEdited = false;
+      _draft.customFields = const [];
+    }
   }
 
   void _onNameChanged() {
@@ -342,9 +405,11 @@ class ItemComposeBarState extends State<ItemComposeBar> {
       if (_multiple) {
         _draft.imageFile = null;
         _draft.imageBytes = null;
-        // Image + price are single-item concerns; close their trays when
-        // switching to bulk entry.
-        if (_openTray == _Tray.image || _openTray == _Tray.price) {
+        // Image, price + custom fields are single-item concerns; close their
+        // trays when switching to bulk entry.
+        if (_openTray == _Tray.image ||
+            _openTray == _Tray.price ||
+            _openTray == _Tray.customFields) {
           _openTray = null;
         }
       }
@@ -551,7 +616,18 @@ class ItemComposeBarState extends State<ItemComposeBar> {
       prices: (!_multiple && widget.priceEnabled && _draft.price.hasAnyPrice)
           ? _draft.price.toItemPrices()
           : null,
+      // Custom fields are single-item too; carry the fields' defaults plus any
+      // tray edits. Omitted in bulk mode or when no fields apply.
+      customFields: _composeCustomFields(),
     );
+  }
+
+  /// The custom-field values for the submission, or null when none apply or in
+  /// bulk mode.
+  List<FieldValue>? _composeCustomFields() {
+    if (_multiple || _applicableCustomFields.isEmpty) return null;
+    final values = _effectiveCustomFields;
+    return values.isEmpty ? null : values;
   }
 
   Future<void> _submit() async {
@@ -573,6 +649,7 @@ class ItemComposeBarState extends State<ItemComposeBar> {
     if (allOk) {
       setState(() {
         _draft.reset(_defaultLifecycle());
+        _customFieldsEdited = false;
         _nameCtrl.clear();
         _qtyCtrl.clear();
         _openTray = null;
@@ -677,6 +754,21 @@ class ItemComposeBarState extends State<ItemComposeBar> {
           perStoreEnabled: widget.perStorePriceEnabled,
           onChanged: () => setState(() {}),
         );
+      case _Tray.customFields:
+        // Keyed by the target list so switching lists rebuilds with that list's
+        // applicable fields (and their re-seeded defaults).
+        trayChild = ItemCustomFieldsEditor(
+          key: ValueKey('compose-cf-${_targetListId ?? 0}'),
+          houseId: widget.houseId,
+          listId: _targetListId,
+          initial: _effectiveCustomFields,
+          onChanged: (values) {
+            _draft.customFields = values;
+            _customFieldsEdited = true;
+            // Rebuild so the chip's accent reflects the newly-set values.
+            setState(() {});
+          },
+        );
       case _Tray.description:
         trayChild = _DescriptionTray(
           initialValue: _draft.description,
@@ -720,6 +812,9 @@ class ItemComposeBarState extends State<ItemComposeBar> {
                     widget.labels.isNotEmpty ||
                     widget.onRequestCreateLabel != null,
                 showPriceChip: widget.priceEnabled && !_multiple,
+                showCustomFieldsChip:
+                    _applicableCustomFields.isNotEmpty && !_multiple,
+                customFieldsSet: _effectiveCustomFields.isNotEmpty,
                 openTray: _openTray,
                 onOpen: _toggleTray,
                 showImageChip: !_multiple,
@@ -1063,6 +1158,8 @@ class _ChipRow extends StatelessWidget {
   final bool showStoreChip;
   final bool showLabelChip;
   final bool showPriceChip;
+  final bool showCustomFieldsChip;
+  final bool customFieldsSet;
   final _Tray? openTray;
   final ValueChanged<_Tray> onOpen;
   final bool showImageChip;
@@ -1077,6 +1174,8 @@ class _ChipRow extends StatelessWidget {
     required this.showStoreChip,
     required this.showLabelChip,
     required this.showPriceChip,
+    required this.showCustomFieldsChip,
+    required this.customFieldsSet,
     required this.openTray,
     required this.onOpen,
     required this.multiple,
@@ -1218,6 +1317,16 @@ class _ChipRow extends StatelessWidget {
               icon: Icons.sell_outlined,
               selected: openTray == _Tray.price,
               onTap: () => onOpen(_Tray.price),
+            ),
+          ],
+          if (showCustomFieldsChip) ...[
+            const SizedBox(width: 8),
+            _ComposeChip(
+              label: m.customFields.manageTitle,
+              color: customFieldsSet ? cs.primary : null,
+              icon: Icons.tune,
+              selected: openTray == _Tray.customFields,
+              onTap: () => onOpen(_Tray.customFields),
             ),
           ],
           const SizedBox(width: 8),

--- a/lib/views/checklists/item_detail_view.dart
+++ b/lib/views/checklists/item_detail_view.dart
@@ -9,6 +9,7 @@ import 'package:pantry/models/checklist.dart';
 import 'package:pantry/services/auth_service.dart';
 import 'package:pantry/services/checklist_service.dart';
 import 'package:pantry/services/server_version_service.dart';
+import 'package:pantry/views/custom_fields/item_custom_fields_display.dart';
 import 'package:pantry/utils/category_icons.dart';
 import 'package:pantry/utils/checklist_icons.dart';
 import 'package:pantry/utils/label_icons.dart';
@@ -96,6 +97,14 @@ class ItemDetailView extends StatelessWidget {
                       if (hasFeature('item-price') && item.hasPrice) ...[
                         const SizedBox(height: 12),
                         _PriceTile(item: item),
+                      ],
+                      if (hasFeature('custom-fields') &&
+                          item.customFields.isNotEmpty) ...[
+                        const SizedBox(height: 12),
+                        ItemCustomFieldsDisplay(
+                          houseId: houseId,
+                          values: item.customFields,
+                        ),
                       ],
                       const SizedBox(height: 12),
                       _DescriptionCard(

--- a/lib/views/checklists/item_form_view.dart
+++ b/lib/views/checklists/item_form_view.dart
@@ -9,6 +9,7 @@ import 'package:pantry/models/category.dart' as models;
 import 'package:pantry/models/store.dart' as models;
 import 'package:pantry/models/label.dart' as models;
 import 'package:pantry/models/checklist.dart';
+import 'package:pantry/models/custom_field.dart';
 import 'package:pantry/services/auth_service.dart';
 import 'package:pantry/services/checklist_service.dart';
 import 'package:pantry/services/server_version_service.dart';
@@ -20,6 +21,7 @@ import 'package:pantry/utils/label_icons.dart';
 import 'package:pantry/utils/store_icons.dart';
 import 'package:pantry/utils/text_direction.dart';
 import 'package:pantry/views/categories/category_form_view.dart';
+import 'package:pantry/views/custom_fields/item_custom_fields_editor.dart';
 import 'package:pantry/widgets/app_bar_back_leading.dart';
 import 'package:pantry/widgets/avif_image.dart';
 import 'package:pantry/widgets/create_label_dialog.dart';
@@ -55,6 +57,11 @@ class _ItemFormViewState extends State<ItemFormView> {
   late RecurrenceState _recurrence;
   late final bool _priceEnabled;
   late final PricesDraft _prices;
+  late final bool _customFieldsEnabled;
+
+  /// Composed custom-field values, kept up to date by the editor's `onChanged`
+  /// (no rebuild needed — it's only read on save).
+  late List<FieldValue> _customFields;
   bool _saving = false;
   bool _deleting = false;
   bool _catPickerOpen = false;
@@ -133,6 +140,8 @@ class _ItemFormViewState extends State<ItemFormView> {
             fallbackCurrency: widget.controller.lastCurrency,
           )
         : PricesDraft.empty(widget.controller.lastCurrency);
+    _customFieldsEnabled = hasFeature(kCustomFieldsFeature);
+    _customFields = List.of(item?.customFields ?? const []);
     _nameDir = detectTextDirection(item?.name);
     _nameController.addListener(() {
       final dir = detectTextDirection(_nameController.text);
@@ -233,6 +242,8 @@ class _ItemFormViewState extends State<ItemFormView> {
           // Always send the full price set on edit (an empty list clears).
           // Omitted entirely when the server lacks the capability.
           prices: _priceEnabled ? _prices.toItemPrices() : null,
+          // Full value set on edit (empty clears); omitted without the feature.
+          customFields: _customFieldsEnabled ? _customFields : null,
         );
       } else {
         savedItem = await widget.controller.addItem(
@@ -250,6 +261,9 @@ class _ItemFormViewState extends State<ItemFormView> {
           deleteOnDone: isOnce,
           prices: _priceEnabled && _prices.hasAnyPrice
               ? _prices.toItemPrices()
+              : null,
+          customFields: _customFieldsEnabled && _customFields.isNotEmpty
+              ? _customFields
               : null,
         );
       }
@@ -532,6 +546,17 @@ class _ItemFormViewState extends State<ItemFormView> {
                       parseColor: _parseColor,
                     ),
                   ],
+                ],
+                if (_customFieldsEnabled) ...[
+                  const SizedBox(height: 16),
+                  _SectionLabel(text: m.customFields.manageTitle),
+                  const SizedBox(height: 10),
+                  ItemCustomFieldsEditor(
+                    houseId: widget.controller.houseId,
+                    listId: _effectiveListId,
+                    initial: _customFields,
+                    onChanged: (values) => _customFields = values,
+                  ),
                 ],
                 const SizedBox(height: 16),
                 _SectionLabel(text: m.checklists.itemTypes.label),

--- a/lib/views/checklists/item_form_view.dart
+++ b/lib/views/checklists/item_form_view.dart
@@ -840,36 +840,8 @@ class _LabeledField extends StatelessWidget {
   });
 
   @override
-  Widget build(BuildContext context) {
-    final cs = Theme.of(context).colorScheme;
-    final labelColor = focused ? cs.primary : cs.onSurfaceVariant;
-    final borderColor = focused ? cs.primary : cs.outlineVariant;
-    return AnimatedContainer(
-      duration: const Duration(milliseconds: 150),
-      padding: const EdgeInsets.fromLTRB(15, 11, 15, 12),
-      decoration: BoxDecoration(
-        color: cs.surfaceContainer,
-        border: Border.all(color: borderColor, width: focused ? 1.5 : 1),
-        borderRadius: BorderRadius.circular(14),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(
-            label.toUpperCase(),
-            style: TextStyle(
-              fontSize: 11,
-              fontWeight: FontWeight.w700,
-              letterSpacing: 0.6,
-              color: labelColor,
-            ),
-          ),
-          const SizedBox(height: 4),
-          child,
-        ],
-      ),
-    );
-  }
+  Widget build(BuildContext context) =>
+      LabeledFieldCard(label: label, focused: focused, child: child);
 }
 
 class _QuantityField extends StatelessWidget {

--- a/lib/views/custom_fields/custom_fields_view.dart
+++ b/lib/views/custom_fields/custom_fields_view.dart
@@ -10,6 +10,7 @@ import 'package:pantry/sync/sync_ids.dart';
 import 'package:pantry/sync/sync_manager.dart';
 import 'package:pantry/sync/sync_op.dart';
 import 'package:pantry/utils/field_type_icons.dart';
+import 'package:pantry/views/checklists/form_components.dart';
 import 'package:pantry/utils/platform_info.dart';
 import 'package:pantry/utils/text_direction.dart';
 import 'package:pantry/widgets/app_bar_back_leading.dart';
@@ -498,7 +499,7 @@ class _CustomFieldsViewState extends State<CustomFieldsView> {
             child: Card(
               margin: EdgeInsets.zero,
               shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(12),
+                borderRadius: BorderRadius.circular(14),
                 side: BorderSide(color: theme.colorScheme.primary),
               ),
               child: Padding(
@@ -556,7 +557,7 @@ class _CustomFieldsViewState extends State<CustomFieldsView> {
         margin: EdgeInsets.zero,
         clipBehavior: Clip.antiAlias,
         shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(12),
+          borderRadius: BorderRadius.circular(14),
           side: BorderSide(color: expanded ? cs.primary : cs.outlineVariant),
         ),
         child: ExpansionTile(
@@ -1256,22 +1257,32 @@ class _FieldEditorState extends State<_FieldEditor> {
   };
 
   Widget _label(String text) => Padding(
-    padding: const EdgeInsetsDirectional.only(bottom: 4, top: 2),
+    padding: const EdgeInsetsDirectional.only(bottom: 6, top: 2),
     child: Text(
-      text,
-      style: TextStyle(
-        fontSize: 12.5,
-        fontWeight: FontWeight.w600,
-        color: Theme.of(context).colorScheme.onSurfaceVariant,
-      ),
+      text.toUpperCase(),
+      style: fieldCardLabelStyle(Theme.of(context).colorScheme),
     ),
   );
 
-  InputDecoration _dec({String? hint}) => InputDecoration(
-    isDense: true,
-    hintText: hint,
-    border: const OutlineInputBorder(),
-  );
+  /// Filled, rounded input matching the app's field cards (surfaceContainer
+  /// fill, radius-14 outlineVariant border, accent on focus).
+  InputDecoration _dec({String? hint}) {
+    final cs = Theme.of(context).colorScheme;
+    OutlineInputBorder border(Color color, double width) => OutlineInputBorder(
+      borderRadius: BorderRadius.circular(14),
+      borderSide: BorderSide(color: color, width: width),
+    );
+    return InputDecoration(
+      isDense: true,
+      hintText: hint,
+      filled: true,
+      fillColor: cs.surfaceContainer,
+      contentPadding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+      border: border(cs.outlineVariant, 1),
+      enabledBorder: border(cs.outlineVariant, 1),
+      focusedBorder: border(cs.primary, 1.5),
+    );
+  }
 }
 
 /// The user's answer to the remap-or-clear prompt: [clear] empties the values,

--- a/lib/views/custom_fields/custom_fields_view.dart
+++ b/lib/views/custom_fields/custom_fields_view.dart
@@ -1,0 +1,1284 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:pantry/i18n.dart';
+import 'package:pantry/models/checklist.dart';
+import 'package:pantry/models/custom_field.dart';
+import 'package:pantry/services/checklist_service.dart';
+import 'package:pantry/services/custom_field_service.dart';
+import 'package:pantry/sync/sync_ids.dart';
+import 'package:pantry/sync/sync_manager.dart';
+import 'package:pantry/sync/sync_op.dart';
+import 'package:pantry/utils/field_type_icons.dart';
+import 'package:pantry/utils/platform_info.dart';
+import 'package:pantry/utils/text_direction.dart';
+import 'package:pantry/widgets/app_bar_back_leading.dart';
+
+/// The unified custom-fields manager: field definitions grouped by scope,
+/// each editable inline (accordion). Reachable from a list's manage menu,
+/// gated by `hasFeature('custom-fields')` and the `canEditFields` capability.
+class CustomFieldsView extends StatefulWidget {
+  final int houseId;
+
+  const CustomFieldsView({super.key, required this.houseId});
+
+  @override
+  State<CustomFieldsView> createState() => _CustomFieldsViewState();
+}
+
+class _CustomFieldsViewState extends State<CustomFieldsView> {
+  List<FieldDefinition> _fields = [];
+
+  /// Lists in display order, backing the scope grouping and the scope selector.
+  List<ChecklistList> _lists = [];
+  bool _isLoading = true;
+  String? _error;
+
+  /// The id of the field whose editor is expanded, or `null` when none is.
+  int? _expandedId;
+
+  /// Whether the new-field editor is open at the bottom of the list.
+  bool _creating = false;
+
+  /// One [ExpansibleController] per field, so opening one row can collapse
+  /// the previously open one (single-open accordion).
+  final Map<int, ExpansibleController> _controllers = {};
+
+  StreamSubscription<SyncOpApplied>? _appliedSub;
+
+  /// Fields can be dragged to reorder only while nothing is being edited — the
+  /// row header doubles as the expand toggle, and an expanded editor is tall.
+  bool get _canReorder => _expandedId == null && !_creating;
+
+  @override
+  void initState() {
+    super.initState();
+    _appliedSub = SyncManager.instance.onApplied.listen(_onApplied);
+    _load();
+  }
+
+  @override
+  void dispose() {
+    _appliedSub?.cancel();
+    super.dispose();
+  }
+
+  /// Replace an optimistic field with the server's canonical record (real id,
+  /// real option ids) once its create/update flushes.
+  void _onApplied(SyncOpApplied e) {
+    if (!mounted) return;
+    if (e.op.entity != SyncEntity.customField) return;
+    final entity = e.entity;
+    if (entity is! FieldDefinition) return;
+    setState(() {
+      final tempId = e.op.tempEntityId;
+      final idx = _fields.indexWhere(
+        (f) => f.id == entity.id || (tempId != null && f.id == tempId),
+      );
+      if (idx != -1) {
+        _fields[idx] = entity;
+      } else {
+        _fields.add(entity);
+      }
+      _fields = CustomFieldService.sortFields(_fields);
+    });
+  }
+
+  Future<void> _load() async {
+    setState(() {
+      _isLoading = true;
+      _error = null;
+    });
+    // Show cached fields immediately so the screen is usable offline.
+    final cached = CustomFieldService.instance.getCached(widget.houseId);
+    if (cached != null && mounted) {
+      setState(() => _fields = CustomFieldService.sortFields(cached));
+    }
+    try {
+      final results = await Future.wait([
+        CustomFieldService.instance.getFields(widget.houseId),
+        ChecklistService.instance.getLists(widget.houseId),
+      ]);
+      if (!mounted) return;
+      setState(() {
+        _fields = CustomFieldService.sortFields(
+          results[0] as List<FieldDefinition>,
+        );
+        _lists = ChecklistService.sortLists(
+          results[1] as List<ChecklistList>,
+          'custom',
+        );
+        _isLoading = false;
+      });
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        // Keep any cached fields on screen; only surface the error when we have
+        // nothing to show.
+        _error = _fields.isEmpty ? e.toString() : null;
+        _isLoading = false;
+      });
+    }
+  }
+
+  /// Partition [_fields] into scope groups: the house-wide ("All lists")
+  /// section first, then one section per list that has fields, in the lists'
+  /// display order. Fields scoped to a list that isn't loaded still get a
+  /// best-effort section so they stay reachable.
+  List<_FieldGroup> _buildGroups() {
+    final globals = [
+      for (final f in _fields)
+        if (f.listId == null) f,
+    ];
+    final byList = <int, List<FieldDefinition>>{};
+    for (final f in _fields) {
+      final lid = f.listId;
+      if (lid != null) byList.putIfAbsent(lid, () => []).add(f);
+    }
+
+    final groups = <_FieldGroup>[];
+    if (globals.isNotEmpty) {
+      groups.add(
+        _FieldGroup(
+          listId: null,
+          title: m.customFields.allLists,
+          fields: globals,
+        ),
+      );
+    }
+    for (final list in _lists) {
+      final fields = byList.remove(list.id);
+      if (fields != null && fields.isNotEmpty) {
+        groups.add(
+          _FieldGroup(listId: list.id, title: list.name, fields: fields),
+        );
+      }
+    }
+    for (final entry in byList.entries) {
+      groups.add(
+        _FieldGroup(
+          listId: entry.key,
+          title: '#${entry.key}',
+          fields: entry.value,
+        ),
+      );
+    }
+    return groups;
+  }
+
+  ExpansibleController _controllerFor(int id) =>
+      _controllers.putIfAbsent(id, ExpansibleController.new);
+
+  /// Close whatever editor is open — the expanded row (collapsing its tile) or
+  /// the new-field editor.
+  void _closeEditor() {
+    final open = _expandedId;
+    setState(() {
+      _expandedId = null;
+      _creating = false;
+    });
+    if (open != null) _controllers[open]?.collapse();
+  }
+
+  /// Enforce single-open: expanding a row collapses the previously open one.
+  void _onExpansionChanged(FieldDefinition field, bool expanded) {
+    if (expanded) {
+      final previous = _expandedId;
+      setState(() {
+        _expandedId = field.id;
+        _creating = false;
+      });
+      if (previous != null && previous != field.id) {
+        _controllers[previous]?.collapse();
+      }
+    } else if (_expandedId == field.id) {
+      setState(() => _expandedId = null);
+    }
+  }
+
+  void _startCreate() {
+    setState(() {
+      _expandedId = null;
+      _creating = true;
+    });
+  }
+
+  /// Reorder within one scope group. The drag can't move a field across scopes
+  /// (each group is its own reorderable), so the group's reordered slice is
+  /// spliced back into the full house-wide sequence, which is then renumbered.
+  void _reorderGroup(_FieldGroup group, int oldIndex, int newIndex) {
+    if (!_canReorder || oldIndex == newIndex) return;
+    final reordered = [...group.fields];
+    final moved = reordered.removeAt(oldIndex);
+    reordered.insert(newIndex, moved);
+
+    final flat = <FieldDefinition>[];
+    for (final g in _buildGroups()) {
+      flat.addAll(g.listId == group.listId ? reordered : g.fields);
+    }
+    setState(() => _fields = flat);
+    _persistOrder(flat);
+  }
+
+  void _persistOrder(List<FieldDefinition> ordered) {
+    final order = <Map<String, int>>[
+      for (var i = 0; i < ordered.length; i++)
+        {'id': ordered[i].id, 'sortOrder': i},
+    ];
+    SyncManager.instance.enqueue(
+      SyncOp(
+        uuid: SyncIds.newOpUuid(),
+        entity: SyncEntity.customField,
+        op: SyncOpKind.reorder,
+        houseId: widget.houseId,
+        body: {'order': order},
+        createdAt: DateTime.now().millisecondsSinceEpoch,
+      ),
+    );
+  }
+
+  void _submitCreate(_FieldDraft draft) {
+    final sync = SyncManager.instance;
+    final now = DateTime.now().millisecondsSinceEpoch;
+    final tempId = sync.newTempId();
+    final field = _optimisticField(draft, id: tempId, now: now);
+    sync.enqueue(
+      SyncOp(
+        uuid: SyncIds.newOpUuid(),
+        entity: SyncEntity.customField,
+        op: SyncOpKind.create,
+        houseId: widget.houseId,
+        tempEntityId: tempId,
+        body: _createBody(draft),
+        createdAt: now,
+      ),
+    );
+    setState(() {
+      _fields = CustomFieldService.sortFields([..._fields, field]);
+      _creating = false;
+    });
+  }
+
+  void _submitEdit(FieldDefinition existing, _FieldDraft draft) {
+    final sync = SyncManager.instance;
+    final now = DateTime.now().millisecondsSinceEpoch;
+    final field = _optimisticField(
+      draft,
+      id: existing.id,
+      now: now,
+      createdAt: existing.createdAt,
+    );
+    sync.enqueue(
+      SyncOp(
+        uuid: SyncIds.newOpUuid(),
+        entity: SyncEntity.customField,
+        op: SyncOpKind.update,
+        houseId: widget.houseId,
+        entityId: existing.id < 0 ? null : existing.id,
+        tempEntityId: existing.id < 0 ? existing.id : null,
+        body: _patchBody(draft),
+        createdAt: now,
+      ),
+    );
+    setState(() {
+      final idx = _fields.indexWhere((f) => f.id == existing.id);
+      if (idx != -1) _fields[idx] = field;
+      _fields = CustomFieldService.sortFields(_fields);
+      _expandedId = null;
+    });
+    _controllers[existing.id]?.collapse();
+  }
+
+  Future<void> _confirmDelete(FieldDefinition field) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text(m.customFields.deleteTitle),
+        content: Text(m.customFields.deleteConfirm),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: Text(m.common.cancel),
+          ),
+          FilledButton(
+            style: FilledButton.styleFrom(
+              backgroundColor: Theme.of(ctx).colorScheme.error,
+            ),
+            onPressed: () => Navigator.pop(ctx, true),
+            child: Text(m.common.delete),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true) return;
+    SyncManager.instance.enqueue(
+      SyncOp(
+        uuid: SyncIds.newOpUuid(),
+        entity: SyncEntity.customField,
+        op: SyncOpKind.delete,
+        houseId: widget.houseId,
+        entityId: field.id < 0 ? null : field.id,
+        tempEntityId: field.id < 0 ? field.id : null,
+        createdAt: DateTime.now().millisecondsSinceEpoch,
+      ),
+    );
+    setState(() {
+      _fields = _fields.where((f) => f.id != field.id).toList();
+      if (_expandedId == field.id) _expandedId = null;
+    });
+  }
+
+  /// Build the optimistic [FieldDefinition] shown until the server's canonical
+  /// record arrives via [_onApplied]. New `select` options carry no id yet.
+  FieldDefinition _optimisticField(
+    _FieldDraft d, {
+    required int id,
+    required int now,
+    int? createdAt,
+  }) {
+    return FieldDefinition(
+      id: id,
+      houseId: widget.houseId,
+      listId: d.listId,
+      name: d.name,
+      type: d.type,
+      sortOrder: 1 << 20,
+      hint: d.hint,
+      multiline: d.multiline,
+      defaultText: d.defaultText,
+      defaultNumber: d.defaultNumber,
+      defaultBool: d.defaultBool,
+      defaultOptionId: d.defaultOptionId,
+      dateMode: d.type == FieldType.date ? d.dateMode : null,
+      defaultOffsetDays: d.defaultOffsetDays,
+      notifyDefault: d.notifyDefault,
+      leadDays: d.leadDays,
+      overridePolicy: d.type == FieldType.date ? d.overridePolicy : null,
+      stopWhenDone: d.stopWhenDone,
+      options: [
+        for (var i = 0; i < d.options.length; i++)
+          FieldOption(
+            id: d.options[i].id ?? 0,
+            label: d.options[i].label,
+            sortOrder: i,
+            valueCount: d.options[i].valueCount,
+          ),
+      ],
+      createdAt: createdAt ?? now,
+      updatedAt: now,
+    );
+  }
+
+  Map<String, dynamic> _createBody(_FieldDraft d) {
+    final b = <String, dynamic>{'name': d.name, 'type': d.type.name};
+    if (d.listId != null) b['listId'] = d.listId;
+    _fillTypeConfig(b, d, forCreate: true);
+    return b;
+  }
+
+  Map<String, dynamic> _patchBody(_FieldDraft d) {
+    // `listId` is always present so a scope change persists; a null value moves
+    // the field house-wide.
+    final b = <String, dynamic>{'name': d.name, 'listId': d.listId};
+    _fillTypeConfig(b, d, forCreate: false);
+    return b;
+  }
+
+  /// Add the type-specific config to a create/update body. Only the fields that
+  /// apply to [d]'s type are sent.
+  void _fillTypeConfig(
+    Map<String, dynamic> b,
+    _FieldDraft d, {
+    required bool forCreate,
+  }) {
+    switch (d.type) {
+      case FieldType.text:
+        if (d.hint != null) b['hint'] = d.hint;
+        b['multiline'] = d.multiline;
+        b['defaultText'] = d.defaultText;
+      case FieldType.number:
+        if (d.hint != null) b['hint'] = d.hint;
+        b['defaultNumber'] = d.defaultNumber;
+      case FieldType.checkbox:
+        b['defaultBool'] = d.defaultBool;
+      case FieldType.date:
+        b['dateMode'] = d.dateMode.name;
+        b['defaultOffsetDays'] = d.dateMode == FieldDateMode.relative
+            ? d.defaultOffsetDays
+            : null;
+        b['notifyDefault'] = d.notifyDefault;
+        b['leadDays'] = d.leadDays;
+        b['overridePolicy'] = d.overridePolicy.wire;
+        b['stopWhenDone'] = d.stopWhenDone;
+      case FieldType.select:
+        if (d.hint != null) b['hint'] = d.hint;
+        b['options'] = [
+          for (var i = 0; i < d.options.length; i++)
+            {
+              // A real id targets an existing row; a new option omits it.
+              if ((d.options[i].id ?? 0) > 0) 'id': d.options[i].id,
+              'label': d.options[i].label,
+              'sortOrder': i,
+            },
+        ];
+        // The default option can only reference a saved option id.
+        if (!forCreate) b['defaultOptionId'] = d.defaultOptionId;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Scaffold(
+      appBar: AppBar(
+        leading: appBarBackLeading(context),
+        title: Text(m.customFields.manageTitle),
+        actions: [
+          if (PlatformInfo.isDesktop)
+            IconButton(
+              icon: const Icon(Icons.refresh),
+              tooltip: m.common.refresh,
+              onPressed: _load,
+            ),
+        ],
+      ),
+      body: _isLoading && _fields.isEmpty
+          ? const Center(child: CircularProgressIndicator())
+          : _error != null
+          ? Center(
+              child: Padding(
+                padding: const EdgeInsets.all(32),
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Text(_error!, textAlign: TextAlign.center),
+                    const SizedBox(height: 16),
+                    FilledButton(onPressed: _load, child: Text(m.common.retry)),
+                  ],
+                ),
+              ),
+            )
+          : RefreshIndicator(onRefresh: _load, child: _buildList(theme)),
+    );
+  }
+
+  Widget _buildList(ThemeData theme) {
+    final groups = _buildGroups();
+    return ListView(
+      padding: const EdgeInsets.only(bottom: 32),
+      children: [
+        if (groups.isEmpty && !_creating)
+          Padding(
+            padding: const EdgeInsets.all(24),
+            child: Text(
+              m.customFields.empty,
+              textAlign: TextAlign.center,
+              style: TextStyle(color: theme.colorScheme.onSurfaceVariant),
+            ),
+          ),
+        for (final group in groups) ...[
+          _buildSectionHeader(theme, group.title),
+          ReorderableListView.builder(
+            shrinkWrap: true,
+            physics: const NeverScrollableScrollPhysics(),
+            buildDefaultDragHandles: false,
+            itemCount: group.fields.length,
+            onReorderItem: (oldIndex, newIndex) =>
+                _reorderGroup(group, oldIndex, newIndex),
+            itemBuilder: (context, index) => _buildFieldTile(
+              theme,
+              group.fields[index],
+              dragIndex: _canReorder ? index : null,
+            ),
+          ),
+        ],
+        if (_creating)
+          Padding(
+            padding: const EdgeInsetsDirectional.fromSTEB(12, 8, 12, 8),
+            child: Card(
+              margin: EdgeInsets.zero,
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(12),
+                side: BorderSide(color: theme.colorScheme.primary),
+              ),
+              child: Padding(
+                padding: const EdgeInsets.all(12),
+                child: _FieldEditor(
+                  key: const ValueKey('cf-new'),
+                  houseId: widget.houseId,
+                  lists: _lists,
+                  initial: null,
+                  onSubmit: (draft) => _submitCreate(draft),
+                  onCancel: _closeEditor,
+                ),
+              ),
+            ),
+          ),
+        Padding(
+          padding: const EdgeInsetsDirectional.fromSTEB(12, 8, 12, 8),
+          child: OutlinedButton.icon(
+            onPressed: (_creating || _expandedId != null) ? null : _startCreate,
+            icon: const Icon(Icons.add),
+            label: Text(m.customFields.addField),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildSectionHeader(ThemeData theme, String title) => Padding(
+    padding: const EdgeInsetsDirectional.fromSTEB(16, 16, 16, 4),
+    child: Text(
+      title.toUpperCase(),
+      style: theme.textTheme.labelSmall?.copyWith(
+        color: theme.colorScheme.primary,
+        fontWeight: FontWeight.w700,
+        letterSpacing: 0.6,
+      ),
+    ),
+  );
+
+  /// A single field as a Material [ExpansionTile] wrapped in a bordered card.
+  /// [dragIndex] is the field's position within its scope group; the drag
+  /// handle shows only when it's provided (i.e. reordering is enabled).
+  Widget _buildFieldTile(
+    ThemeData theme,
+    FieldDefinition field, {
+    int? dragIndex,
+  }) {
+    final cs = theme.colorScheme;
+    final expanded = _expandedId == field.id;
+    final showBell = field.type == FieldType.date && field.notifyDefault;
+    return Padding(
+      key: ValueKey(field.id),
+      padding: const EdgeInsetsDirectional.fromSTEB(12, 4, 12, 4),
+      child: Card(
+        margin: EdgeInsets.zero,
+        clipBehavior: Clip.antiAlias,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(12),
+          side: BorderSide(color: expanded ? cs.primary : cs.outlineVariant),
+        ),
+        child: ExpansionTile(
+          controller: _controllerFor(field.id),
+          initiallyExpanded: expanded,
+          shape: const Border(),
+          collapsedShape: const Border(),
+          tilePadding: EdgeInsetsDirectional.only(
+            start: dragIndex != null ? 6 : 14,
+            end: 10,
+          ),
+          childrenPadding: const EdgeInsets.fromLTRB(12, 0, 12, 12),
+          onExpansionChanged: (e) => _onExpansionChanged(field, e),
+          leading: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              if (dragIndex != null) ...[
+                ReorderableDragStartListener(
+                  index: dragIndex,
+                  child: Icon(Icons.drag_handle, color: cs.onSurfaceVariant),
+                ),
+                const SizedBox(width: 6),
+              ],
+              Icon(fieldTypeIcon(field.type), color: cs.primary),
+            ],
+          ),
+          title: Row(
+            children: [
+              Expanded(
+                child: Text(
+                  field.name,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  textDirection: detectTextDirection(field.name),
+                  style: const TextStyle(fontWeight: FontWeight.w600),
+                ),
+              ),
+              Text(
+                fieldTypeLabel(field.type),
+                style: TextStyle(fontSize: 12.5, color: cs.onSurfaceVariant),
+              ),
+              if (showBell) ...[
+                const SizedBox(width: 8),
+                Icon(
+                  Icons.notifications_active_outlined,
+                  size: 16,
+                  color: cs.primary,
+                ),
+              ],
+            ],
+          ),
+          children: [
+            _FieldEditor(
+              key: ValueKey('cf-edit-${field.id}'),
+              houseId: widget.houseId,
+              lists: _lists,
+              initial: field,
+              onSubmit: (draft) => _submitEdit(field, draft),
+              onCancel: _closeEditor,
+              onDelete: () => _confirmDelete(field),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// A display group of fields sharing a scope: `listId == null` for the
+/// house-wide ("All lists") section, or a list id for a per-list section.
+class _FieldGroup {
+  final int? listId;
+  final String title;
+  final List<FieldDefinition> fields;
+
+  const _FieldGroup({
+    required this.listId,
+    required this.title,
+    required this.fields,
+  });
+}
+
+/// Mutable editing state for one field definition.
+class _FieldDraft {
+  String name;
+  FieldType type;
+  int? listId;
+  String? hint;
+  bool multiline;
+  String? defaultText;
+  double? defaultNumber;
+  bool defaultBool;
+  int? defaultOptionId;
+  FieldDateMode dateMode;
+  int? defaultOffsetDays;
+  bool notifyDefault;
+  int leadDays;
+  FieldOverridePolicy overridePolicy;
+  bool stopWhenDone;
+  List<_OptionDraft> options;
+
+  _FieldDraft({
+    required this.name,
+    required this.type,
+    this.listId,
+    this.hint,
+    this.multiline = false,
+    this.defaultText,
+    this.defaultNumber,
+    this.defaultBool = false,
+    this.defaultOptionId,
+    this.dateMode = FieldDateMode.absolute,
+    this.defaultOffsetDays,
+    this.notifyDefault = false,
+    this.leadDays = 0,
+    this.overridePolicy = FieldOverridePolicy.fieldOnly,
+    this.stopWhenDone = false,
+    this.options = const [],
+  });
+}
+
+class _OptionDraft {
+  final int? id;
+  String label;
+  int valueCount;
+
+  _OptionDraft({this.id, required this.label, this.valueCount = 0});
+}
+
+/// The inline field-definition editor. Owns its own draft + text controllers,
+/// and handles `select`-option removal (remap-or-clear for options in use)
+/// itself. The field save/delete are delegated to the parent so they ride the
+/// sync queue like every other write.
+class _FieldEditor extends StatefulWidget {
+  final int houseId;
+  final List<ChecklistList> lists;
+
+  /// The field being edited, or `null` when creating a new one.
+  final FieldDefinition? initial;
+  final void Function(_FieldDraft draft) onSubmit;
+  final VoidCallback onCancel;
+  final VoidCallback? onDelete;
+
+  const _FieldEditor({
+    super.key,
+    required this.houseId,
+    required this.lists,
+    required this.initial,
+    required this.onSubmit,
+    required this.onCancel,
+    this.onDelete,
+  });
+
+  @override
+  State<_FieldEditor> createState() => _FieldEditorState();
+}
+
+class _FieldEditorState extends State<_FieldEditor> {
+  static const _leadOptions = [0, 1, 2, 3, 7];
+
+  late final TextEditingController _name;
+  late final TextEditingController _hint;
+  late final TextEditingController _defaultText;
+  late final TextEditingController _defaultNumber;
+  late final TextEditingController _offset;
+  final List<TextEditingController> _optionCtrls = [];
+
+  late _FieldDraft _d;
+  TextDirection _nameDir = TextDirection.ltr;
+  bool _busy = false;
+
+  bool get _isEditing => widget.initial != null;
+
+  @override
+  void initState() {
+    super.initState();
+    final e = widget.initial;
+    _d = e == null
+        ? _FieldDraft(name: '', type: FieldType.text)
+        : _FieldDraft(
+            name: e.name,
+            type: e.type,
+            listId: e.listId,
+            hint: e.hint,
+            multiline: e.multiline,
+            defaultText: e.defaultText,
+            defaultNumber: e.defaultNumber,
+            defaultBool: e.defaultBool,
+            defaultOptionId: e.defaultOptionId,
+            dateMode: e.dateMode ?? FieldDateMode.absolute,
+            defaultOffsetDays: e.defaultOffsetDays,
+            notifyDefault: e.notifyDefault,
+            leadDays: e.leadDays,
+            overridePolicy: e.overridePolicy ?? FieldOverridePolicy.fieldOnly,
+            stopWhenDone: e.stopWhenDone,
+            options: [
+              for (final o in e.options)
+                _OptionDraft(
+                  id: o.id,
+                  label: o.label,
+                  valueCount: o.valueCount,
+                ),
+            ],
+          );
+    _name = TextEditingController(text: _d.name);
+    _hint = TextEditingController(text: _d.hint ?? '');
+    _defaultText = TextEditingController(text: _d.defaultText ?? '');
+    _defaultNumber = TextEditingController(
+      text: _d.defaultNumber?.toString() ?? '',
+    );
+    _offset = TextEditingController(
+      text: _d.defaultOffsetDays?.toString() ?? '',
+    );
+    for (final o in _d.options) {
+      _optionCtrls.add(TextEditingController(text: o.label));
+    }
+    _nameDir = detectTextDirection(_d.name);
+    _name.addListener(() {
+      final dir = detectTextDirection(_name.text);
+      if (dir != _nameDir) setState(() => _nameDir = dir);
+    });
+  }
+
+  @override
+  void dispose() {
+    _name.dispose();
+    _hint.dispose();
+    _defaultText.dispose();
+    _defaultNumber.dispose();
+    _offset.dispose();
+    for (final c in _optionCtrls) {
+      c.dispose();
+    }
+    super.dispose();
+  }
+
+  void _addOption() {
+    setState(() {
+      _d.options.add(_OptionDraft(id: null, label: ''));
+      _optionCtrls.add(TextEditingController());
+    });
+  }
+
+  Future<void> _removeOption(int index) async {
+    final opt = _d.options[index];
+    final inUse = _isEditing && (opt.id ?? 0) > 0 && opt.valueCount > 0;
+    if (!inUse) {
+      setState(() {
+        _d.options.removeAt(index);
+        _optionCtrls.removeAt(index).dispose();
+        if (opt.id != null && _d.defaultOptionId == opt.id) {
+          _d.defaultOptionId = null;
+        }
+      });
+      return;
+    }
+
+    // Reading the labels back keeps the remap dialog's option names current.
+    _syncOptionLabels();
+    final choice = await _promptRemap(opt);
+    if (choice == null || !mounted) return;
+    setState(() => _busy = true);
+    try {
+      final updated = await CustomFieldService.instance.deleteFieldOption(
+        widget.houseId,
+        widget.initial!.id,
+        opt.id!,
+        action: choice.clear
+            ? OptionDeleteAction.clear
+            : OptionDeleteAction.remap,
+        remapToId: choice.clear ? null : choice.remapToId,
+      );
+      if (!mounted) return;
+      setState(() {
+        _d.options.removeAt(index);
+        _optionCtrls.removeAt(index).dispose();
+        if (_d.defaultOptionId == opt.id) {
+          _d.defaultOptionId = choice.clear ? null : choice.remapToId;
+        }
+        // Refresh surviving counts from the server (a remap bumps the target).
+        for (final o in _d.options) {
+          for (final u in updated.options) {
+            if (u.id == o.id) o.valueCount = u.valueCount;
+          }
+        }
+      });
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(m.customFields.optionDeleteFailed)),
+        );
+      }
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  Future<_RemapChoice?> _promptRemap(_OptionDraft removing) {
+    final targets = [
+      for (final o in _d.options)
+        if ((o.id ?? 0) > 0 && o.id != removing.id && o.label.trim().isNotEmpty)
+          o,
+    ];
+    return showDialog<_RemapChoice>(
+      context: context,
+      builder: (ctx) => SimpleDialog(
+        title: Text(m.customFields.remapTitle),
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(24, 0, 24, 12),
+            child: Text(
+              m.customFields.remapPrompt(
+                removing.valueCount,
+                removing.label.trim(),
+              ),
+            ),
+          ),
+          for (final o in targets)
+            SimpleDialogOption(
+              onPressed: () =>
+                  Navigator.pop(ctx, _RemapChoice(remapToId: o.id)),
+              child: Text(m.customFields.remapMoveTo(o.label.trim())),
+            ),
+          SimpleDialogOption(
+            onPressed: () =>
+                Navigator.pop(ctx, const _RemapChoice(clear: true)),
+            child: Text(m.customFields.remapClear),
+          ),
+          SimpleDialogOption(
+            onPressed: () => Navigator.pop(ctx),
+            child: Text(m.common.cancel),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _syncOptionLabels() {
+    for (var i = 0; i < _d.options.length; i++) {
+      _d.options[i].label = _optionCtrls[i].text.trim();
+    }
+  }
+
+  void _submit() {
+    final name = _name.text.trim();
+    if (name.isEmpty) return;
+    _syncOptionLabels();
+    _d
+      ..name = name
+      ..hint = _hint.text.trim().isEmpty ? null : _hint.text.trim()
+      ..defaultText = _defaultText.text.trim().isEmpty
+          ? null
+          : _defaultText.text.trim()
+      ..defaultNumber = double.tryParse(_defaultNumber.text.trim())
+      ..defaultOffsetDays = int.tryParse(_offset.text.trim());
+    // Drop blank options so they don't reach the server as empty rows.
+    _d.options.removeWhere((o) => o.label.trim().isEmpty && o.id == null);
+    widget.onSubmit(_d);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final f = m.customFields;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        _label(f.name),
+        TextField(
+          controller: _name,
+          autofocus: !_isEditing,
+          textCapitalization: TextCapitalization.sentences,
+          textDirection: _nameDir,
+          decoration: _dec(hint: f.namePlaceholder),
+        ),
+        const SizedBox(height: 14),
+        _label(f.type),
+        const SizedBox(height: 4),
+        _buildTypeSelector(),
+        if (_isEditing)
+          Padding(
+            padding: const EdgeInsetsDirectional.only(top: 4),
+            child: Text(
+              f.typeLocked,
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ),
+        const SizedBox(height: 14),
+        _label(f.scope),
+        const SizedBox(height: 4),
+        _buildScopeSelector(),
+        if (_hasHint) ...[
+          const SizedBox(height: 14),
+          _label(f.hint),
+          TextField(
+            controller: _hint,
+            decoration: _dec(hint: f.hintPlaceholder),
+          ),
+        ],
+        ..._buildTypeConfig(),
+        ..._buildDefaultValue(),
+        const SizedBox(height: 16),
+        _buildActions(),
+      ],
+    );
+  }
+
+  bool get _hasHint =>
+      _d.type == FieldType.text ||
+      _d.type == FieldType.number ||
+      _d.type == FieldType.select;
+
+  Widget _buildTypeSelector() {
+    return Wrap(
+      spacing: 6,
+      runSpacing: 6,
+      children: [
+        for (final type in kFieldTypesInOrder)
+          ChoiceChip(
+            avatar: Icon(fieldTypeIcon(type), size: 18),
+            label: Text(fieldTypeLabel(type)),
+            selected: _d.type == type,
+            // The type is immutable after creation.
+            onSelected: _isEditing
+                ? null
+                : (_) => setState(() => _d.type = type),
+          ),
+      ],
+    );
+  }
+
+  Widget _buildScopeSelector() {
+    final knownIds = widget.lists.map((l) => l.id).toSet();
+    final value = _d.listId == null || knownIds.contains(_d.listId)
+        ? _d.listId
+        : null;
+    return DropdownButtonFormField<int?>(
+      initialValue: value,
+      isExpanded: true,
+      decoration: _dec(),
+      items: [
+        DropdownMenuItem<int?>(
+          value: null,
+          child: Text(m.customFields.allLists),
+        ),
+        for (final list in widget.lists)
+          DropdownMenuItem<int?>(
+            value: list.id,
+            child: Text(
+              list.name,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+      ],
+      onChanged: (v) => setState(() => _d.listId = v),
+    );
+  }
+
+  List<Widget> _buildTypeConfig() {
+    final f = m.customFields;
+    switch (_d.type) {
+      case FieldType.text:
+        return [
+          SwitchListTile(
+            contentPadding: EdgeInsets.zero,
+            title: Text(f.multiline),
+            value: _d.multiline,
+            onChanged: (v) => setState(() => _d.multiline = v),
+          ),
+        ];
+      case FieldType.number:
+      case FieldType.checkbox:
+        return const [];
+      case FieldType.select:
+        return _buildOptionsEditor();
+      case FieldType.date:
+        return _buildDateConfig();
+    }
+  }
+
+  List<Widget> _buildOptionsEditor() {
+    final f = m.customFields;
+    return [
+      const SizedBox(height: 14),
+      _label(f.options),
+      for (var i = 0; i < _d.options.length; i++)
+        Padding(
+          padding: const EdgeInsets.only(bottom: 6),
+          child: Row(
+            children: [
+              Expanded(
+                child: TextField(
+                  controller: _optionCtrls[i],
+                  decoration: _dec(hint: f.optionPlaceholder),
+                ),
+              ),
+              IconButton(
+                icon: const Icon(Icons.close, size: 20),
+                tooltip: f.removeOption,
+                onPressed: _busy ? null : () => _removeOption(i),
+              ),
+            ],
+          ),
+        ),
+      Align(
+        alignment: AlignmentDirectional.centerStart,
+        child: TextButton.icon(
+          onPressed: _busy ? null : _addOption,
+          icon: const Icon(Icons.add, size: 18),
+          label: Text(f.addOption),
+        ),
+      ),
+    ];
+  }
+
+  List<Widget> _buildDateConfig() {
+    final f = m.customFields;
+    return [
+      const SizedBox(height: 14),
+      _label(f.entryMode),
+      const SizedBox(height: 4),
+      SegmentedButton<FieldDateMode>(
+        segments: [
+          ButtonSegment(
+            value: FieldDateMode.absolute,
+            label: Text(f.dateAbsolute),
+          ),
+          ButtonSegment(
+            value: FieldDateMode.relative,
+            label: Text(f.dateRelative),
+          ),
+        ],
+        selected: {_d.dateMode},
+        onSelectionChanged: (s) => setState(() => _d.dateMode = s.first),
+      ),
+      if (_d.dateMode == FieldDateMode.relative) ...[
+        const SizedBox(height: 14),
+        _label(f.defaultOffset),
+        TextField(
+          controller: _offset,
+          keyboardType: TextInputType.number,
+          decoration: _dec(hint: f.defaultOffsetPlaceholder),
+        ),
+      ],
+      SwitchListTile(
+        contentPadding: EdgeInsets.zero,
+        title: Text(f.notifyDefault),
+        value: _d.notifyDefault,
+        onChanged: (v) => setState(() => _d.notifyDefault = v),
+      ),
+      if (_d.notifyDefault) ...[
+        _label(f.leadTime),
+        const SizedBox(height: 4),
+        DropdownButtonFormField<int>(
+          initialValue: _leadOptions.contains(_d.leadDays) ? _d.leadDays : 0,
+          isExpanded: true,
+          decoration: _dec(),
+          items: [
+            for (final days in _leadOptions)
+              DropdownMenuItem(value: days, child: Text(_leadLabel(days))),
+          ],
+          onChanged: (v) => setState(() => _d.leadDays = v ?? 0),
+        ),
+        const SizedBox(height: 14),
+      ],
+      _label(f.overridePolicy),
+      const SizedBox(height: 4),
+      DropdownButtonFormField<FieldOverridePolicy>(
+        initialValue: _d.overridePolicy,
+        isExpanded: true,
+        decoration: _dec(),
+        items: [
+          DropdownMenuItem(
+            value: FieldOverridePolicy.fieldOnly,
+            child: Text(f.overrideFieldOnly),
+          ),
+          DropdownMenuItem(
+            value: FieldOverridePolicy.itemOverride,
+            child: Text(f.overrideItem),
+          ),
+        ],
+        onChanged: (v) => setState(
+          () => _d.overridePolicy = v ?? FieldOverridePolicy.fieldOnly,
+        ),
+      ),
+      SwitchListTile(
+        contentPadding: EdgeInsets.zero,
+        title: Text(f.stopWhenDone),
+        value: _d.stopWhenDone,
+        onChanged: (v) => setState(() => _d.stopWhenDone = v),
+      ),
+    ];
+  }
+
+  List<Widget> _buildDefaultValue() {
+    final f = m.customFields;
+    switch (_d.type) {
+      case FieldType.text:
+        return [
+          const SizedBox(height: 14),
+          _label(f.defaultValue),
+          TextField(
+            controller: _defaultText,
+            decoration: _dec(hint: f.noDefault),
+          ),
+        ];
+      case FieldType.number:
+        return [
+          const SizedBox(height: 14),
+          _label(f.defaultValue),
+          TextField(
+            controller: _defaultNumber,
+            keyboardType: const TextInputType.numberWithOptions(decimal: true),
+            decoration: _dec(hint: f.noDefault),
+          ),
+        ];
+      case FieldType.checkbox:
+        return [
+          SwitchListTile(
+            contentPadding: EdgeInsets.zero,
+            title: Text(f.defaultChecked),
+            value: _d.defaultBool,
+            onChanged: (v) => setState(() => _d.defaultBool = v),
+          ),
+        ];
+      case FieldType.select:
+        final saved = [
+          for (final o in _d.options)
+            if ((o.id ?? 0) > 0 && o.label.trim().isNotEmpty) o,
+        ];
+        if (saved.isEmpty) return const [];
+        final value = saved.any((o) => o.id == _d.defaultOptionId)
+            ? _d.defaultOptionId
+            : null;
+        return [
+          const SizedBox(height: 14),
+          _label(f.defaultValue),
+          const SizedBox(height: 4),
+          DropdownButtonFormField<int?>(
+            initialValue: value,
+            isExpanded: true,
+            decoration: _dec(),
+            items: [
+              DropdownMenuItem<int?>(value: null, child: Text(f.noDefault)),
+              for (final o in saved)
+                DropdownMenuItem<int?>(
+                  value: o.id,
+                  child: Text(
+                    o.label.trim(),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+            ],
+            onChanged: (v) => setState(() => _d.defaultOptionId = v),
+          ),
+        ];
+      case FieldType.date:
+        return const [];
+    }
+  }
+
+  Widget _buildActions() {
+    return Row(
+      children: [
+        if (_isEditing && widget.onDelete != null)
+          TextButton.icon(
+            onPressed: _busy ? null : widget.onDelete,
+            icon: const Icon(Icons.delete_outline, size: 18),
+            label: Text(m.common.delete),
+            style: TextButton.styleFrom(
+              foregroundColor: Theme.of(context).colorScheme.error,
+            ),
+          )
+        else
+          TextButton(
+            onPressed: _busy ? null : widget.onCancel,
+            child: Text(m.common.cancel),
+          ),
+        const Spacer(),
+        FilledButton(
+          onPressed: _busy ? null : _submit,
+          child: Text(m.customFields.done),
+        ),
+      ],
+    );
+  }
+
+  String _leadLabel(int days) => switch (days) {
+    0 => m.customFields.leadOnDay,
+    1 => m.customFields.leadDay1,
+    2 => m.customFields.leadDay2,
+    3 => m.customFields.leadDay3,
+    _ => m.customFields.leadWeek1,
+  };
+
+  Widget _label(String text) => Padding(
+    padding: const EdgeInsetsDirectional.only(bottom: 4, top: 2),
+    child: Text(
+      text,
+      style: TextStyle(
+        fontSize: 12.5,
+        fontWeight: FontWeight.w600,
+        color: Theme.of(context).colorScheme.onSurfaceVariant,
+      ),
+    ),
+  );
+
+  InputDecoration _dec({String? hint}) => InputDecoration(
+    isDense: true,
+    hintText: hint,
+    border: const OutlineInputBorder(),
+  );
+}
+
+/// The user's answer to the remap-or-clear prompt: [clear] empties the values,
+/// otherwise they move to [remapToId].
+class _RemapChoice {
+  final bool clear;
+  final int? remapToId;
+
+  const _RemapChoice({this.clear = false, this.remapToId});
+}

--- a/lib/views/custom_fields/item_custom_fields_display.dart
+++ b/lib/views/custom_fields/item_custom_fields_display.dart
@@ -1,0 +1,162 @@
+import 'package:flutter/material.dart';
+import 'package:pantry/i18n.dart';
+import 'package:pantry/models/custom_field.dart';
+import 'package:pantry/services/custom_field_service.dart';
+import 'package:pantry/utils/field_type_icons.dart';
+import 'package:pantry/utils/text_direction.dart';
+
+/// Read-only display of an item's custom-field values, one row per filled
+/// field, resolved against the field definitions (for names, option labels and
+/// per-type formatting). Styled to match the item detail's fact tiles; renders
+/// nothing when the item has no resolvable values.
+class ItemCustomFieldsDisplay extends StatefulWidget {
+  final int houseId;
+  final List<FieldValue> values;
+
+  const ItemCustomFieldsDisplay({
+    super.key,
+    required this.houseId,
+    required this.values,
+  });
+
+  @override
+  State<ItemCustomFieldsDisplay> createState() =>
+      _ItemCustomFieldsDisplayState();
+}
+
+class _ItemCustomFieldsDisplayState extends State<ItemCustomFieldsDisplay> {
+  Map<int, FieldDefinition> _defs = {};
+
+  @override
+  void initState() {
+    super.initState();
+    final cached = CustomFieldService.instance.getCached(widget.houseId);
+    if (cached != null) _defs = {for (final f in cached) f.id: f};
+    _load();
+  }
+
+  Future<void> _load() async {
+    try {
+      final defs = await CustomFieldService.instance.getFields(widget.houseId);
+      if (mounted) setState(() => _defs = {for (final f in defs) f.id: f});
+    } catch (_) {
+      // Offline or transient — keep whatever the cache seeded.
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (widget.values.isEmpty) return const SizedBox.shrink();
+    final cs = Theme.of(context).colorScheme;
+
+    // Only rows we can resolve a definition (and a value) for, in the
+    // definitions' display order.
+    final rows = <FieldValue>[];
+    for (final v in widget.values) {
+      final def = _defs[v.fieldId];
+      if (def != null && _hasValue(def, v)) rows.add(v);
+    }
+    if (rows.isEmpty) return const SizedBox.shrink();
+    rows.sort((a, b) {
+      final da = _defs[a.fieldId]!;
+      final db = _defs[b.fieldId]!;
+      final c = da.sortOrder.compareTo(db.sortOrder);
+      return c != 0 ? c : da.id.compareTo(db.id);
+    });
+
+    return Container(
+      padding: const EdgeInsets.fromLTRB(15, 14, 15, 14),
+      decoration: BoxDecoration(
+        color: cs.surfaceContainer,
+        border: Border.all(color: cs.outlineVariant),
+        borderRadius: BorderRadius.circular(15),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            m.customFields.manageTitle.toUpperCase(),
+            style: TextStyle(
+              fontSize: 11,
+              fontWeight: FontWeight.w700,
+              letterSpacing: 0.6,
+              color: cs.onSurfaceVariant,
+            ),
+          ),
+          const SizedBox(height: 10),
+          for (var i = 0; i < rows.length; i++) ...[
+            if (i > 0) const SizedBox(height: 12),
+            _buildRow(cs, _defs[rows[i].fieldId]!, rows[i]),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Widget _buildRow(ColorScheme cs, FieldDefinition def, FieldValue v) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Icon(fieldTypeIcon(def.type), size: 18, color: cs.onSurfaceVariant),
+        const SizedBox(width: 10),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                def.name,
+                style: TextStyle(fontSize: 12, color: cs.onSurfaceVariant),
+              ),
+              const SizedBox(height: 2),
+              _buildValue(cs, def, v),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildValue(ColorScheme cs, FieldDefinition def, FieldValue v) {
+    if (def.type == FieldType.checkbox) {
+      return Icon(Icons.check, size: 20, color: cs.primary);
+    }
+    final text = _format(def, v) ?? '';
+    return Text(
+      text,
+      textDirection: detectTextDirection(text),
+      style: const TextStyle(fontSize: 15, fontWeight: FontWeight.w600),
+    );
+  }
+
+  bool _hasValue(FieldDefinition def, FieldValue v) => switch (def.type) {
+    FieldType.checkbox => v.valueBool,
+    _ => _format(def, v) != null,
+  };
+
+  /// Format a non-checkbox value for display, or `null` when it holds nothing.
+  String? _format(FieldDefinition def, FieldValue v) {
+    switch (def.type) {
+      case FieldType.text:
+        final t = v.valueText?.trim();
+        return (t == null || t.isEmpty) ? null : t;
+      case FieldType.number:
+        final n = v.valueNumber;
+        if (n == null) return null;
+        return n == n.roundToDouble() ? n.toInt().toString() : n.toString();
+      case FieldType.checkbox:
+        return null;
+      case FieldType.select:
+        final id = v.valueOptionId;
+        if (id == null) return null;
+        for (final o in def.options) {
+          if (o.id == id) return o.label;
+        }
+        return null;
+      case FieldType.date:
+        final secs = v.valueDate;
+        if (secs == null) return null;
+        final date = DateTime.fromMillisecondsSinceEpoch(secs * 1000);
+        return MaterialLocalizations.of(context).formatMediumDate(date);
+    }
+  }
+}

--- a/lib/views/custom_fields/item_custom_fields_editor.dart
+++ b/lib/views/custom_fields/item_custom_fields_editor.dart
@@ -1,0 +1,587 @@
+import 'package:flutter/material.dart';
+import 'package:pantry/i18n.dart';
+import 'package:pantry/models/custom_field.dart';
+import 'package:pantry/services/custom_field_service.dart';
+import 'package:pantry/utils/text_direction.dart';
+
+/// The per-item "Custom fields" value-filling section. Renders one control per
+/// applicable field (house-wide ∪ the item's list), mirroring the web
+/// `ItemCustomFieldsEditor`. Owns its own draft state and reports the composed
+/// [FieldValue] list through [onChanged]; the parent only stores the result and
+/// sends it when the item is saved.
+class ItemCustomFieldsEditor extends StatefulWidget {
+  final int houseId;
+
+  /// The item's list, so list-scoped fields apply. `null` = no list in context
+  /// (only house-wide fields apply).
+  final int? listId;
+  final List<FieldValue> initial;
+  final void Function(List<FieldValue> values) onChanged;
+
+  const ItemCustomFieldsEditor({
+    super.key,
+    required this.houseId,
+    required this.listId,
+    required this.initial,
+    required this.onChanged,
+  });
+
+  @override
+  State<ItemCustomFieldsEditor> createState() => _ItemCustomFieldsEditorState();
+}
+
+class _ItemCustomFieldsEditorState extends State<ItemCustomFieldsEditor> {
+  static const _leadOptions = [0, 1, 2, 3, 7];
+
+  List<FieldDefinition> _fields = [];
+  final Map<int, _ValueDraft> _drafts = {};
+  final Map<int, TextEditingController> _textCtrls = {};
+  final Map<int, TextEditingController> _numberCtrls = {};
+  final Map<int, TextEditingController> _offsetCtrls = {};
+
+  @override
+  void initState() {
+    super.initState();
+    final cached = CustomFieldService.instance.getCached(widget.houseId);
+    if (cached != null) _applyDefs(cached);
+    _load();
+  }
+
+  @override
+  void dispose() {
+    for (final c in _textCtrls.values) {
+      c.dispose();
+    }
+    for (final c in _numberCtrls.values) {
+      c.dispose();
+    }
+    for (final c in _offsetCtrls.values) {
+      c.dispose();
+    }
+    super.dispose();
+  }
+
+  Future<void> _load() async {
+    try {
+      final defs = await CustomFieldService.instance.getFields(widget.houseId);
+      if (mounted) setState(() => _applyDefs(defs));
+    } catch (_) {
+      // Offline or transient — keep whatever the cache seeded.
+    }
+  }
+
+  /// Filter to the applicable fields and ensure a draft + controllers exist for
+  /// each. Safe to call again when definitions arrive from the network: drafts
+  /// already in hand are preserved (so edits made before the load finishes
+  /// aren't clobbered), only newly-applicable fields are seeded from the
+  /// initial values, and controllers for fields that dropped out are released.
+  void _applyDefs(List<FieldDefinition> defs) {
+    _fields = CustomFieldService.sortFields(
+      defs.where((f) => f.listId == null || f.listId == widget.listId),
+    );
+    final byField = {for (final v in widget.initial) v.fieldId: v};
+    final applicableIds = {for (final f in _fields) f.id};
+
+    for (final field in _fields) {
+      if (_drafts.containsKey(field.id)) continue;
+      final existing = byField[field.id];
+      final d = existing != null
+          ? _ValueDraft.fromValue(existing)
+          : _ValueDraft.empty();
+      _drafts[field.id] = d;
+      _textCtrls[field.id] = TextEditingController(text: d.text);
+      _numberCtrls[field.id] = TextEditingController(text: d.number);
+      _offsetCtrls[field.id] = TextEditingController(
+        text: d.offsetDays?.toString() ?? '',
+      );
+    }
+
+    // Release state for fields that are no longer applicable.
+    for (final id in _drafts.keys.toList()) {
+      if (applicableIds.contains(id)) continue;
+      _drafts.remove(id);
+      _textCtrls.remove(id)?.dispose();
+      _numberCtrls.remove(id)?.dispose();
+      _offsetCtrls.remove(id)?.dispose();
+    }
+  }
+
+  _ValueDraft _draftFor(int fieldId) =>
+      _drafts.putIfAbsent(fieldId, _ValueDraft.empty);
+
+  /// Compose the filled values and hand them to the parent. A field with no
+  /// value produces no row (mirrors the server's upsert semantics).
+  void _emit() {
+    final out = <FieldValue>[];
+    for (final field in _fields) {
+      final d = _drafts[field.id];
+      if (d == null) continue;
+      int? valueDate;
+      String? valueText;
+      double? valueNumber;
+      var valueBool = false;
+      int? valueOptionId;
+      switch (field.type) {
+        case FieldType.text:
+          if (d.text.trim().isEmpty) continue;
+          valueText = d.text;
+        case FieldType.number:
+          final n = double.tryParse(d.number.trim());
+          if (n == null) continue;
+          valueNumber = n;
+        case FieldType.checkbox:
+          if (!d.boolValue) continue;
+          valueBool = true;
+        case FieldType.select:
+          if (d.optionId == null) continue;
+          valueOptionId = d.optionId;
+        case FieldType.date:
+          if (d.date == null) continue;
+          final dt = d.date!;
+          valueDate =
+              DateTime(dt.year, dt.month, dt.day).millisecondsSinceEpoch ~/
+              1000;
+      }
+      out.add(
+        FieldValue(
+          fieldId: field.id,
+          valueText: valueText,
+          valueNumber: valueNumber,
+          valueBool: valueBool,
+          valueDate: valueDate,
+          valueOptionId: valueOptionId,
+          offsetDays: d.offsetDays,
+          notifyOverride: d.notifyOverride,
+          notifyEnabled: d.notifyEnabled,
+          notifyLeadDays: d.notifyLeadDays,
+        ),
+      );
+    }
+    widget.onChanged(out);
+  }
+
+  /// Local midnight, [offset] days from today.
+  DateTime _anchor(int offset) {
+    final now = DateTime.now();
+    return DateTime(now.year, now.month, now.day).add(Duration(days: offset));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_fields.isEmpty) return const SizedBox.shrink();
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        for (final field in _fields) ...[
+          _buildField(field),
+          const SizedBox(height: 14),
+        ],
+      ],
+    );
+  }
+
+  Widget _buildField(FieldDefinition field) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        switch (field.type) {
+          FieldType.text => _buildText(field),
+          FieldType.number => _buildNumber(field),
+          FieldType.checkbox => _buildCheckbox(field),
+          FieldType.select => _buildSelect(field),
+          FieldType.date => _buildDate(field),
+        },
+        if (_showReminderOverride(field)) _buildReminderOverride(field),
+      ],
+    );
+  }
+
+  Widget _buildText(FieldDefinition field) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        _label(field.name),
+        TextField(
+          controller: _textCtrls[field.id],
+          minLines: field.multiline ? 2 : 1,
+          maxLines: field.multiline ? 5 : 1,
+          textDirection: detectTextDirection(_textCtrls[field.id]?.text),
+          decoration: _dec(hint: field.hint),
+          onChanged: (v) {
+            _draftFor(field.id).text = v;
+            _emit();
+          },
+        ),
+      ],
+    );
+  }
+
+  Widget _buildNumber(FieldDefinition field) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        _label(field.name),
+        TextField(
+          controller: _numberCtrls[field.id],
+          keyboardType: const TextInputType.numberWithOptions(decimal: true),
+          decoration: _dec(hint: field.hint),
+          onChanged: (v) {
+            _draftFor(field.id).number = v;
+            _emit();
+          },
+        ),
+      ],
+    );
+  }
+
+  Widget _buildCheckbox(FieldDefinition field) {
+    return SwitchListTile(
+      contentPadding: EdgeInsets.zero,
+      title: Text(field.name),
+      value: _draftFor(field.id).boolValue,
+      onChanged: (v) {
+        setState(() => _draftFor(field.id).boolValue = v);
+        _emit();
+      },
+    );
+  }
+
+  Widget _buildSelect(FieldDefinition field) {
+    final d = _draftFor(field.id);
+    final value = field.options.any((o) => o.id == d.optionId)
+        ? d.optionId
+        : null;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        _label(field.name),
+        DropdownButtonFormField<int?>(
+          initialValue: value,
+          isExpanded: true,
+          decoration: _dec(hint: field.hint),
+          items: [
+            DropdownMenuItem<int?>(
+              value: null,
+              child: Text(
+                m.customFields.noValue,
+                style: TextStyle(
+                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ),
+            for (final o in field.options)
+              DropdownMenuItem<int?>(
+                value: o.id,
+                child: Text(
+                  o.label,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+          ],
+          onChanged: (v) {
+            setState(() => d.optionId = v);
+            _emit();
+          },
+        ),
+      ],
+    );
+  }
+
+  Widget _buildDate(FieldDefinition field) {
+    final d = _draftFor(field.id);
+    if (field.dateMode == FieldDateMode.relative) {
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          _label(field.name),
+          TextField(
+            controller: _offsetCtrls[field.id],
+            keyboardType: TextInputType.number,
+            decoration: _dec(hint: m.customFields.daysFromToday),
+            onChanged: (v) {
+              final s = v.trim();
+              setState(() {
+                if (s.isEmpty) {
+                  d.offsetDays = null;
+                  d.date = null;
+                } else {
+                  final n = int.tryParse(s);
+                  if (n != null) {
+                    d.offsetDays = n;
+                    d.date = _anchor(n);
+                  }
+                }
+              });
+              _emit();
+            },
+          ),
+          if (d.date != null)
+            Padding(
+              padding: const EdgeInsetsDirectional.only(top: 4),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      m.customFields.due(
+                        MaterialLocalizations.of(
+                          context,
+                        ).formatMediumDate(d.date!),
+                      ),
+                      style: TextStyle(
+                        color: Theme.of(context).colorScheme.onSurfaceVariant,
+                        fontSize: 13,
+                      ),
+                    ),
+                  ),
+                  TextButton.icon(
+                    onPressed: () {
+                      if (d.offsetDays == null) return;
+                      setState(() => d.date = _anchor(d.offsetDays!));
+                      _emit();
+                    },
+                    icon: const Icon(Icons.refresh, size: 18),
+                    label: Text(m.customFields.reanchor),
+                  ),
+                ],
+              ),
+            ),
+        ],
+      );
+    }
+    // Absolute date: a tappable field opening the platform date picker.
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        _label(field.name),
+        InkWell(
+          onTap: () => _pickDate(field),
+          borderRadius: BorderRadius.circular(4),
+          child: InputDecorator(
+            decoration: _dec(),
+            child: Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    d.date != null
+                        ? MaterialLocalizations.of(
+                            context,
+                          ).formatMediumDate(d.date!)
+                        : m.customFields.noValue,
+                    style: d.date == null
+                        ? TextStyle(
+                            color: Theme.of(
+                              context,
+                            ).colorScheme.onSurfaceVariant,
+                          )
+                        : null,
+                  ),
+                ),
+                if (d.date != null)
+                  InkWell(
+                    onTap: () {
+                      setState(() => d.date = null);
+                      _emit();
+                    },
+                    child: Icon(
+                      Icons.close,
+                      size: 18,
+                      color: Theme.of(context).colorScheme.onSurfaceVariant,
+                    ),
+                  )
+                else
+                  Icon(
+                    Icons.event,
+                    size: 18,
+                    color: Theme.of(context).colorScheme.onSurfaceVariant,
+                  ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Future<void> _pickDate(FieldDefinition field) async {
+    final d = _draftFor(field.id);
+    final now = DateTime.now();
+    final picked = await showDatePicker(
+      context: context,
+      initialDate: d.date ?? now,
+      firstDate: DateTime(now.year - 5),
+      lastDate: DateTime(now.year + 10),
+    );
+    if (picked == null) return;
+    setState(() => d.date = DateTime(picked.year, picked.month, picked.day));
+    _emit();
+  }
+
+  bool _showReminderOverride(FieldDefinition field) =>
+      field.type == FieldType.date &&
+      field.overridePolicy == FieldOverridePolicy.itemOverride &&
+      _draftFor(field.id).date != null;
+
+  Widget _buildReminderOverride(FieldDefinition field) {
+    final d = _draftFor(field.id);
+    final on = d.notifyOverride ? d.notifyEnabled : field.notifyDefault;
+    final lead = d.notifyOverride
+        ? (d.notifyLeadDays ?? field.leadDays)
+        : field.leadDays;
+    final differs =
+        d.notifyOverride &&
+        (d.notifyEnabled != field.notifyDefault ||
+            (d.notifyEnabled &&
+                (d.notifyLeadDays ?? field.leadDays) != field.leadDays));
+    final theme = Theme.of(context);
+    return Container(
+      margin: const EdgeInsetsDirectional.only(start: 8, top: 4),
+      padding: const EdgeInsetsDirectional.only(start: 8),
+      decoration: BoxDecoration(
+        border: BorderDirectional(
+          start: BorderSide(color: theme.colorScheme.outlineVariant, width: 2),
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          SwitchListTile(
+            contentPadding: EdgeInsets.zero,
+            title: Text(m.customFields.remindMe),
+            value: on,
+            onChanged: (v) {
+              setState(() {
+                d.notifyOverride = true;
+                d.notifyEnabled = v;
+                if (v && d.notifyLeadDays == null) {
+                  d.notifyLeadDays = field.leadDays;
+                }
+              });
+              _emit();
+            },
+          ),
+          if (on) ...[
+            _label(m.customFields.leadTime),
+            const SizedBox(height: 4),
+            DropdownButtonFormField<int>(
+              initialValue: _leadOptions.contains(lead) ? lead : 0,
+              isExpanded: true,
+              decoration: _dec(),
+              items: [
+                for (final days in _leadOptions)
+                  DropdownMenuItem(value: days, child: Text(_leadLabel(days))),
+              ],
+              onChanged: (v) {
+                setState(() {
+                  d.notifyOverride = true;
+                  d.notifyEnabled = true;
+                  d.notifyLeadDays = v ?? 0;
+                });
+                _emit();
+              },
+            ),
+          ],
+          if (differs)
+            Padding(
+              padding: const EdgeInsetsDirectional.only(top: 4),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      m.customFields.customReminder,
+                      style: TextStyle(
+                        fontSize: 12.5,
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                  ),
+                  TextButton(
+                    onPressed: () {
+                      setState(() {
+                        d.notifyOverride = false;
+                        d.notifyEnabled = false;
+                        d.notifyLeadDays = null;
+                      });
+                      _emit();
+                    },
+                    child: Text(m.customFields.useFieldDefault),
+                  ),
+                ],
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  String _leadLabel(int days) => switch (days) {
+    0 => m.customFields.leadOnDay,
+    1 => m.customFields.leadDay1,
+    2 => m.customFields.leadDay2,
+    3 => m.customFields.leadDay3,
+    _ => m.customFields.leadWeek1,
+  };
+
+  Widget _label(String text) => Padding(
+    padding: const EdgeInsetsDirectional.only(bottom: 4, top: 2),
+    child: Text(
+      text,
+      style: TextStyle(
+        fontSize: 12.5,
+        fontWeight: FontWeight.w600,
+        color: Theme.of(context).colorScheme.onSurfaceVariant,
+      ),
+    ),
+  );
+
+  InputDecoration _dec({String? hint}) => InputDecoration(
+    isDense: true,
+    hintText: hint,
+    border: const OutlineInputBorder(),
+  );
+}
+
+/// Mutable per-field editing state, keyed by field id.
+class _ValueDraft {
+  String text;
+  String number;
+  bool boolValue;
+  int? optionId;
+  DateTime? date;
+  int? offsetDays;
+  bool notifyOverride;
+  bool notifyEnabled;
+  int? notifyLeadDays;
+
+  _ValueDraft({
+    this.text = '',
+    this.number = '',
+    this.boolValue = false,
+    this.optionId,
+    this.date,
+    this.offsetDays,
+    this.notifyOverride = false,
+    this.notifyEnabled = false,
+    this.notifyLeadDays,
+  });
+
+  factory _ValueDraft.empty() => _ValueDraft();
+
+  factory _ValueDraft.fromValue(FieldValue v) => _ValueDraft(
+    text: v.valueText ?? '',
+    number: v.valueNumber != null ? _trimNumber(v.valueNumber!) : '',
+    boolValue: v.valueBool,
+    optionId: v.valueOptionId,
+    date: v.valueDate != null
+        ? DateTime.fromMillisecondsSinceEpoch(v.valueDate! * 1000)
+        : null,
+    offsetDays: v.offsetDays,
+    notifyOverride: v.notifyOverride,
+    notifyEnabled: v.notifyEnabled,
+    notifyLeadDays: v.notifyLeadDays,
+  );
+
+  /// Render a stored number without a trailing `.0` for whole values.
+  static String _trimNumber(double n) =>
+      n == n.roundToDouble() ? n.toInt().toString() : n.toString();
+}

--- a/lib/views/custom_fields/item_custom_fields_editor.dart
+++ b/lib/views/custom_fields/item_custom_fields_editor.dart
@@ -3,6 +3,7 @@ import 'package:pantry/i18n.dart';
 import 'package:pantry/models/custom_field.dart';
 import 'package:pantry/services/custom_field_service.dart';
 import 'package:pantry/utils/text_direction.dart';
+import 'package:pantry/views/checklists/form_components.dart';
 
 /// The per-item "Custom fields" value-filling section. Renders one control per
 /// applicable field (house-wide ∪ the item's list), mirroring the web
@@ -181,92 +182,89 @@ class _ItemCustomFieldsEditorState extends State<ItemCustomFieldsEditor> {
   }
 
   Widget _buildField(FieldDefinition field) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        switch (field.type) {
-          FieldType.text => _buildText(field),
-          FieldType.number => _buildNumber(field),
-          FieldType.checkbox => _buildCheckbox(field),
-          FieldType.select => _buildSelect(field),
-          FieldType.date => _buildDate(field),
-        },
-        if (_showReminderOverride(field)) _buildReminderOverride(field),
-      ],
-    );
+    return switch (field.type) {
+      FieldType.text => _buildText(field),
+      FieldType.number => _buildNumber(field),
+      FieldType.checkbox => _buildCheckbox(field),
+      FieldType.select => _buildSelect(field),
+      FieldType.date => _buildDate(field),
+    };
   }
 
   Widget _buildText(FieldDefinition field) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        _label(field.name),
-        TextField(
-          controller: _textCtrls[field.id],
-          minLines: field.multiline ? 2 : 1,
-          maxLines: field.multiline ? 5 : 1,
-          textDirection: detectTextDirection(_textCtrls[field.id]?.text),
-          decoration: _dec(hint: field.hint),
-          onChanged: (v) {
-            _draftFor(field.id).text = v;
-            _emit();
-          },
-        ),
-      ],
+    return LabeledFieldCard(
+      label: field.name,
+      child: TextField(
+        controller: _textCtrls[field.id],
+        minLines: field.multiline ? 2 : 1,
+        maxLines: field.multiline ? 5 : 1,
+        textDirection: detectTextDirection(_textCtrls[field.id]?.text),
+        style: _valueStyle,
+        decoration: _bare(hint: field.hint),
+        onChanged: (v) {
+          _draftFor(field.id).text = v;
+          _emit();
+        },
+      ),
     );
   }
 
   Widget _buildNumber(FieldDefinition field) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        _label(field.name),
-        TextField(
-          controller: _numberCtrls[field.id],
-          keyboardType: const TextInputType.numberWithOptions(decimal: true),
-          decoration: _dec(hint: field.hint),
-          onChanged: (v) {
-            _draftFor(field.id).number = v;
-            _emit();
-          },
-        ),
-      ],
+    return LabeledFieldCard(
+      label: field.name,
+      child: TextField(
+        controller: _numberCtrls[field.id],
+        keyboardType: const TextInputType.numberWithOptions(decimal: true),
+        style: _valueStyle,
+        decoration: _bare(hint: field.hint),
+        onChanged: (v) {
+          _draftFor(field.id).number = v;
+          _emit();
+        },
+      ),
     );
   }
 
   Widget _buildCheckbox(FieldDefinition field) {
-    return SwitchListTile(
-      contentPadding: EdgeInsets.zero,
-      title: Text(field.name),
-      value: _draftFor(field.id).boolValue,
-      onChanged: (v) {
-        setState(() => _draftFor(field.id).boolValue = v);
-        _emit();
-      },
+    final d = _draftFor(field.id);
+    return LabeledFieldCard(
+      label: field.name,
+      trailing: Switch(
+        value: d.boolValue,
+        onChanged: (v) {
+          setState(() => d.boolValue = v);
+          _emit();
+        },
+      ),
     );
   }
 
   Widget _buildSelect(FieldDefinition field) {
     final d = _draftFor(field.id);
+    final cs = Theme.of(context).colorScheme;
     final value = field.options.any((o) => o.id == d.optionId)
         ? d.optionId
         : null;
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        _label(field.name),
-        DropdownButtonFormField<int?>(
-          initialValue: value,
+    return LabeledFieldCard(
+      label: field.name,
+      child: DropdownButtonHideUnderline(
+        child: DropdownButton<int?>(
+          value: value,
           isExpanded: true,
-          decoration: _dec(hint: field.hint),
+          isDense: true,
+          padding: EdgeInsets.zero,
+          borderRadius: BorderRadius.circular(12),
+          style: _valueStyle,
+          hint: Text(
+            field.hint ?? m.customFields.noValue,
+            style: _valueStyle?.copyWith(color: cs.onSurfaceVariant),
+          ),
           items: [
             DropdownMenuItem<int?>(
               value: null,
               child: Text(
                 m.customFields.noValue,
-                style: TextStyle(
-                  color: Theme.of(context).colorScheme.onSurfaceVariant,
-                ),
+                style: TextStyle(color: cs.onSurfaceVariant),
               ),
             ),
             for (final o in field.options)
@@ -284,81 +282,89 @@ class _ItemCustomFieldsEditorState extends State<ItemCustomFieldsEditor> {
             _emit();
           },
         ),
-      ],
+      ),
     );
   }
 
   Widget _buildDate(FieldDefinition field) {
     final d = _draftFor(field.id);
+    final cs = Theme.of(context).colorScheme;
     if (field.dateMode == FieldDateMode.relative) {
-      return Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          _label(field.name),
-          TextField(
-            controller: _offsetCtrls[field.id],
-            keyboardType: TextInputType.number,
-            decoration: _dec(hint: m.customFields.daysFromToday),
-            onChanged: (v) {
-              final s = v.trim();
-              setState(() {
-                if (s.isEmpty) {
-                  d.offsetDays = null;
-                  d.date = null;
-                } else {
-                  final n = int.tryParse(s);
-                  if (n != null) {
-                    d.offsetDays = n;
-                    d.date = _anchor(n);
+      return LabeledFieldCard(
+        label: field.name,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            TextField(
+              controller: _offsetCtrls[field.id],
+              keyboardType: TextInputType.number,
+              style: _valueStyle,
+              decoration: _bare(hint: m.customFields.daysFromToday),
+              onChanged: (v) {
+                final s = v.trim();
+                setState(() {
+                  if (s.isEmpty) {
+                    d.offsetDays = null;
+                    d.date = null;
+                  } else {
+                    final n = int.tryParse(s);
+                    if (n != null) {
+                      d.offsetDays = n;
+                      d.date = _anchor(n);
+                    }
                   }
-                }
-              });
-              _emit();
-            },
-          ),
-          if (d.date != null)
-            Padding(
-              padding: const EdgeInsetsDirectional.only(top: 4),
-              child: Row(
-                children: [
-                  Expanded(
-                    child: Text(
-                      m.customFields.due(
-                        MaterialLocalizations.of(
-                          context,
-                        ).formatMediumDate(d.date!),
-                      ),
-                      style: TextStyle(
-                        color: Theme.of(context).colorScheme.onSurfaceVariant,
-                        fontSize: 13,
+                });
+                _emit();
+              },
+            ),
+            if (d.date != null)
+              Padding(
+                padding: const EdgeInsetsDirectional.only(top: 6),
+                child: Row(
+                  children: [
+                    Expanded(
+                      child: Text(
+                        m.customFields.due(
+                          MaterialLocalizations.of(
+                            context,
+                          ).formatMediumDate(d.date!),
+                        ),
+                        style: TextStyle(
+                          color: cs.onSurfaceVariant,
+                          fontSize: 13,
+                        ),
                       ),
                     ),
-                  ),
-                  TextButton.icon(
-                    onPressed: () {
-                      if (d.offsetDays == null) return;
-                      setState(() => d.date = _anchor(d.offsetDays!));
-                      _emit();
-                    },
-                    icon: const Icon(Icons.refresh, size: 18),
-                    label: Text(m.customFields.reanchor),
-                  ),
-                ],
+                    TextButton.icon(
+                      onPressed: () {
+                        if (d.offsetDays == null) return;
+                        setState(() => d.date = _anchor(d.offsetDays!));
+                        _emit();
+                      },
+                      icon: const Icon(Icons.refresh, size: 18),
+                      label: Text(m.customFields.reanchor),
+                      style: TextButton.styleFrom(
+                        padding: const EdgeInsets.symmetric(horizontal: 8),
+                        visualDensity: VisualDensity.compact,
+                      ),
+                    ),
+                  ],
+                ),
               ),
-            ),
-        ],
+            ..._reminderSection(field),
+          ],
+        ),
       );
     }
-    // Absolute date: a tappable field opening the platform date picker.
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        _label(field.name),
-        InkWell(
-          onTap: () => _pickDate(field),
-          borderRadius: BorderRadius.circular(4),
-          child: InputDecorator(
-            decoration: _dec(),
+    // Absolute date: a tappable row opening the platform date picker, with the
+    // reminder controls tucked into the same card below.
+    return LabeledFieldCard(
+      label: field.name,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          InkWell(
+            onTap: () => _pickDate(field),
             child: Row(
               children: [
                 Expanded(
@@ -369,16 +375,12 @@ class _ItemCustomFieldsEditorState extends State<ItemCustomFieldsEditor> {
                           ).formatMediumDate(d.date!)
                         : m.customFields.noValue,
                     style: d.date == null
-                        ? TextStyle(
-                            color: Theme.of(
-                              context,
-                            ).colorScheme.onSurfaceVariant,
-                          )
-                        : null,
+                        ? _valueStyle?.copyWith(color: cs.onSurfaceVariant)
+                        : _valueStyle,
                   ),
                 ),
                 if (d.date != null)
-                  InkWell(
+                  InkResponse(
                     onTap: () {
                       setState(() => d.date = null);
                       _emit();
@@ -386,20 +388,17 @@ class _ItemCustomFieldsEditorState extends State<ItemCustomFieldsEditor> {
                     child: Icon(
                       Icons.close,
                       size: 18,
-                      color: Theme.of(context).colorScheme.onSurfaceVariant,
+                      color: cs.onSurfaceVariant,
                     ),
                   )
                 else
-                  Icon(
-                    Icons.event,
-                    size: 18,
-                    color: Theme.of(context).colorScheme.onSurfaceVariant,
-                  ),
+                  Icon(Icons.event, size: 18, color: cs.onSurfaceVariant),
               ],
             ),
           ),
-        ),
-      ],
+          ..._reminderSection(field),
+        ],
+      ),
     );
   }
 
@@ -422,7 +421,11 @@ class _ItemCustomFieldsEditorState extends State<ItemCustomFieldsEditor> {
       field.overridePolicy == FieldOverridePolicy.itemOverride &&
       _draftFor(field.id).date != null;
 
-  Widget _buildReminderOverride(FieldDefinition field) {
+  /// The per-item reminder controls, embedded *inside* the date field's card
+  /// (below the date) so they read as part of that field rather than a separate
+  /// one. Empty when the field doesn't allow an item override or no date is set.
+  List<Widget> _reminderSection(FieldDefinition field) {
+    if (!_showReminderOverride(field)) return const [];
     final d = _draftFor(field.id);
     final on = d.notifyOverride ? d.notifyEnabled : field.notifyDefault;
     final lead = d.notifyOverride
@@ -433,21 +436,23 @@ class _ItemCustomFieldsEditorState extends State<ItemCustomFieldsEditor> {
         (d.notifyEnabled != field.notifyDefault ||
             (d.notifyEnabled &&
                 (d.notifyLeadDays ?? field.leadDays) != field.leadDays));
-    final theme = Theme.of(context);
-    return Container(
-      margin: const EdgeInsetsDirectional.only(start: 8, top: 4),
-      padding: const EdgeInsetsDirectional.only(start: 8),
-      decoration: BoxDecoration(
-        border: BorderDirectional(
-          start: BorderSide(color: theme.colorScheme.outlineVariant, width: 2),
-        ),
+    final cs = Theme.of(context).colorScheme;
+    return [
+      Padding(
+        padding: const EdgeInsetsDirectional.only(top: 10, bottom: 2),
+        child: Divider(height: 1, color: cs.outlineVariant),
       ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
+      Row(
         children: [
-          SwitchListTile(
-            contentPadding: EdgeInsets.zero,
-            title: Text(m.customFields.remindMe),
+          Icon(Icons.notifications_none, size: 18, color: cs.onSurfaceVariant),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              m.customFields.remindMe,
+              style: _valueStyle?.copyWith(color: cs.onSurface),
+            ),
+          ),
+          Switch(
             value: on,
             onChanged: (v) {
               setState(() {
@@ -460,58 +465,58 @@ class _ItemCustomFieldsEditorState extends State<ItemCustomFieldsEditor> {
               _emit();
             },
           ),
-          if (on) ...[
-            _label(m.customFields.leadTime),
-            const SizedBox(height: 4),
-            DropdownButtonFormField<int>(
-              initialValue: _leadOptions.contains(lead) ? lead : 0,
-              isExpanded: true,
-              decoration: _dec(),
-              items: [
-                for (final days in _leadOptions)
-                  DropdownMenuItem(value: days, child: Text(_leadLabel(days))),
-              ],
-              onChanged: (v) {
+        ],
+      ),
+      if (on)
+        DropdownButtonHideUnderline(
+          child: DropdownButton<int>(
+            value: _leadOptions.contains(lead) ? lead : 0,
+            isExpanded: true,
+            isDense: true,
+            padding: EdgeInsets.zero,
+            borderRadius: BorderRadius.circular(12),
+            style: _valueStyle,
+            items: [
+              for (final days in _leadOptions)
+                DropdownMenuItem(value: days, child: Text(_leadLabel(days))),
+            ],
+            onChanged: (v) {
+              setState(() {
+                d.notifyOverride = true;
+                d.notifyEnabled = true;
+                d.notifyLeadDays = v ?? 0;
+              });
+              _emit();
+            },
+          ),
+        ),
+      if (on && differs)
+        Row(
+          children: [
+            Expanded(
+              child: Text(
+                m.customFields.customReminder,
+                style: TextStyle(fontSize: 12.5, color: cs.onSurfaceVariant),
+              ),
+            ),
+            TextButton(
+              onPressed: () {
                 setState(() {
-                  d.notifyOverride = true;
-                  d.notifyEnabled = true;
-                  d.notifyLeadDays = v ?? 0;
+                  d.notifyOverride = false;
+                  d.notifyEnabled = false;
+                  d.notifyLeadDays = null;
                 });
                 _emit();
               },
+              style: TextButton.styleFrom(
+                padding: const EdgeInsets.symmetric(horizontal: 8),
+                visualDensity: VisualDensity.compact,
+              ),
+              child: Text(m.customFields.useFieldDefault),
             ),
           ],
-          if (differs)
-            Padding(
-              padding: const EdgeInsetsDirectional.only(top: 4),
-              child: Row(
-                children: [
-                  Expanded(
-                    child: Text(
-                      m.customFields.customReminder,
-                      style: TextStyle(
-                        fontSize: 12.5,
-                        color: theme.colorScheme.onSurfaceVariant,
-                      ),
-                    ),
-                  ),
-                  TextButton(
-                    onPressed: () {
-                      setState(() {
-                        d.notifyOverride = false;
-                        d.notifyEnabled = false;
-                        d.notifyLeadDays = null;
-                      });
-                      _emit();
-                    },
-                    child: Text(m.customFields.useFieldDefault),
-                  ),
-                ],
-              ),
-            ),
-        ],
-      ),
-    );
+        ),
+    ];
   }
 
   String _leadLabel(int days) => switch (days) {
@@ -522,23 +527,15 @@ class _ItemCustomFieldsEditorState extends State<ItemCustomFieldsEditor> {
     _ => m.customFields.leadWeek1,
   };
 
-  Widget _label(String text) => Padding(
-    padding: const EdgeInsetsDirectional.only(bottom: 4, top: 2),
-    child: Text(
-      text,
-      style: TextStyle(
-        fontSize: 12.5,
-        fontWeight: FontWeight.w600,
-        color: Theme.of(context).colorScheme.onSurfaceVariant,
-      ),
-    ),
-  );
+  TextStyle? get _valueStyle =>
+      const TextStyle(fontSize: 15.5, fontWeight: FontWeight.w500);
 
-  InputDecoration _dec({String? hint}) => InputDecoration(
-    isDense: true,
-    hintText: hint,
-    border: const OutlineInputBorder(),
-  );
+  /// Borderless input styling — the [LabeledFieldCard] provides the frame.
+  InputDecoration _bare({String? hint}) => const InputDecoration(
+    isCollapsed: true,
+    border: InputBorder.none,
+    contentPadding: EdgeInsets.zero,
+  ).copyWith(hintText: hint);
 }
 
 /// Mutable per-field editing state, keyed by field id.

--- a/lib/views/home/home_view.dart
+++ b/lib/views/home/home_view.dart
@@ -239,6 +239,17 @@ class _HomeViewBodyState extends State<_HomeViewBody>
     if (link == null) return;
     final homeController = context.read<HomeController>();
 
+    // A reminder that names a list + item opens that item detail directly,
+    // reusing the shared list/item sink (house switch, preselect, tab jump).
+    if (link.listId != null) {
+      _openList(
+        listId: link.listId!,
+        houseId: link.houseId,
+        itemId: link.itemId,
+      );
+      return;
+    }
+
     if (link.houseId != null &&
         link.houseId != homeController.currentHouse?.id) {
       final house = homeController.houses.cast<House?>().firstWhere(

--- a/test/models/custom_field_reminder_link_test.dart
+++ b/test/models/custom_field_reminder_link_test.dart
@@ -1,0 +1,63 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pantry/models/notification.dart';
+import 'package:pantry/services/deep_link_service.dart';
+
+void main() {
+  group('cf_reminder notification deep link', () {
+    NcNotification reminder({String? link}) => NcNotification(
+      notificationId: 1,
+      app: 'pantry',
+      user: 'casraf',
+      subject: 'Milk — Expiry: Sep 7',
+      message: '',
+      datetime: '',
+      objectType: 'cf_reminder',
+      objectId: '56:6',
+      link: link,
+    );
+
+    test('targets the checklists tab', () {
+      expect(reminder().target, NotificationTarget.checklists);
+    });
+
+    test('parses house/list/item ids from the link', () {
+      final target = reminder(
+        link:
+            'https://nc.example/index.php/apps/pantry/houses/12/lists/34'
+            '?item=56',
+      ).itemLinkTarget;
+
+      expect(target, isNotNull);
+      expect(target!.houseId, 12);
+      expect(target.listId, 34);
+      expect(target.itemId, 56);
+    });
+
+    test('yields no target when the link is missing the item query', () {
+      final target = reminder(
+        link: 'https://nc.example/apps/pantry/houses/12/lists/34',
+      ).itemLinkTarget;
+      expect(target, isNull);
+    });
+  });
+
+  group('DeepLink item payload', () {
+    test('round-trips list + item ids', () {
+      const link = DeepLink(tabIndex: 0, houseId: 12, listId: 34, itemId: 56);
+      final decoded = DeepLink.decode(link.encode());
+
+      expect(decoded, isNotNull);
+      expect(decoded!.houseId, 12);
+      expect(decoded.listId, 34);
+      expect(decoded.itemId, 56);
+    });
+
+    test('decodes the older two-field (tab:house) payload', () {
+      final decoded = DeepLink.decode('0:12');
+      expect(decoded, isNotNull);
+      expect(decoded!.houseId, 12);
+      expect(decoded.listId, isNull);
+      expect(decoded.itemId, isNull);
+    });
+  });
+}

--- a/test/models/custom_field_test.dart
+++ b/test/models/custom_field_test.dart
@@ -1,0 +1,183 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pantry/models/checklist.dart';
+import 'package:pantry/models/custom_field.dart';
+
+void main() {
+  group('FieldDefinition serialization', () {
+    test('round-trips a select field with options through JSON', () {
+      const def = FieldDefinition(
+        id: 5,
+        houseId: 2,
+        listId: 9,
+        name: 'Aisle',
+        type: FieldType.select,
+        sortOrder: 3,
+        hint: 'Pick one',
+        options: [
+          FieldOption(id: 1, label: 'Dairy', sortOrder: 0, valueCount: 2),
+          FieldOption(id: 2, label: 'Produce', sortOrder: 1),
+        ],
+        createdAt: 100,
+        updatedAt: 200,
+      );
+
+      final decoded = FieldDefinition.fromJson(def.toJson());
+
+      expect(decoded.type, FieldType.select);
+      expect(decoded.listId, 9);
+      expect(decoded.options.map((o) => o.label), ['Dairy', 'Produce']);
+      expect(decoded.options.first.valueCount, 2);
+    });
+
+    test('round-trips date reminder config, mapping wire enums', () {
+      const def = FieldDefinition(
+        id: 6,
+        houseId: 2,
+        name: 'Expiry',
+        type: FieldType.date,
+        sortOrder: 0,
+        dateMode: FieldDateMode.relative,
+        defaultOffsetDays: 7,
+        notifyDefault: true,
+        leadDays: 2,
+        overridePolicy: FieldOverridePolicy.itemOverride,
+        stopWhenDone: true,
+        createdAt: 1,
+        updatedAt: 1,
+      );
+
+      final json = def.toJson();
+      expect(json['dateMode'], 'relative');
+      expect(json['overridePolicy'], 'item-override');
+
+      final decoded = FieldDefinition.fromJson(json);
+      expect(decoded.dateMode, FieldDateMode.relative);
+      expect(decoded.overridePolicy, FieldOverridePolicy.itemOverride);
+      expect(decoded.stopWhenDone, isTrue);
+      expect(decoded.listId, isNull);
+    });
+
+    test('copyWith listId sentinel distinguishes "clear" from "unchanged"', () {
+      const def = FieldDefinition(
+        id: 1,
+        houseId: 2,
+        listId: 4,
+        name: 'X',
+        type: FieldType.text,
+        sortOrder: 0,
+        createdAt: 1,
+        updatedAt: 1,
+      );
+
+      expect(def.copyWith(name: 'Y').listId, 4);
+      expect(def.copyWith(listId: null).listId, isNull);
+      expect(def.copyWith(listId: 8).listId, 8);
+    });
+  });
+
+  group('seedFieldValues', () {
+    FieldDefinition def(
+      int id,
+      FieldType type, {
+      int? listId,
+      String? defaultText,
+      double? defaultNumber,
+      bool defaultBool = false,
+      int? defaultOptionId,
+    }) => FieldDefinition(
+      id: id,
+      houseId: 1,
+      listId: listId,
+      name: 'F$id',
+      type: type,
+      sortOrder: id,
+      defaultText: defaultText,
+      defaultNumber: defaultNumber,
+      defaultBool: defaultBool,
+      defaultOptionId: defaultOptionId,
+      createdAt: 0,
+      updatedAt: 0,
+    );
+
+    test('emits a value only for fields that define a default', () {
+      final defs = [
+        def(1, FieldType.text, defaultText: 'hi'),
+        def(2, FieldType.text), // no default → skipped
+        def(3, FieldType.number, defaultNumber: 4),
+        def(4, FieldType.checkbox, defaultBool: true),
+        def(5, FieldType.checkbox), // false default → skipped
+        def(6, FieldType.select, defaultOptionId: 9),
+        def(7, FieldType.date), // date has no default → skipped
+      ];
+
+      final seeds = seedFieldValues(defs, null);
+
+      expect(seeds.map((v) => v.fieldId), [1, 3, 4, 6]);
+      expect(seeds[0].valueText, 'hi');
+      expect(seeds[1].valueNumber, 4);
+      expect(seeds[2].valueBool, isTrue);
+      expect(seeds[3].valueOptionId, 9);
+    });
+
+    test('applies the effective-list scope', () {
+      final defs = [
+        def(1, FieldType.text, defaultText: 'global'),
+        def(2, FieldType.text, listId: 10, defaultText: 'list-10'),
+        def(3, FieldType.text, listId: 99, defaultText: 'other-list'),
+      ];
+
+      expect(seedFieldValues(defs, 10).map((v) => v.fieldId), [1, 2]);
+      expect(seedFieldValues(defs, null).map((v) => v.fieldId), [1]);
+    });
+  });
+
+  group('ListItem.customFields serialization', () {
+    test('round-trips values through toJson/fromJson', () {
+      final item = ListItem(
+        id: 1,
+        listId: 2,
+        name: 'Milk',
+        done: false,
+        repeatFromCompletion: false,
+        deleteOnDone: false,
+        sortOrder: 0,
+        createdAt: 100,
+        updatedAt: 200,
+        customFields: const [
+          FieldValue(fieldId: 5, valueText: 'B12'),
+          FieldValue(
+            fieldId: 6,
+            valueDate: 1788000000,
+            notifyOverride: true,
+            notifyEnabled: true,
+            notifyLeadDays: 1,
+          ),
+        ],
+      );
+
+      final decoded = ListItem.fromJson(item.toJson());
+
+      expect(decoded.customFields, hasLength(2));
+      expect(decoded.customFields.first.valueText, 'B12');
+      final date = decoded.customFields[1];
+      expect(date.valueDate, 1788000000);
+      expect(date.notifyOverride, isTrue);
+      expect(date.notifyLeadDays, 1);
+    });
+
+    test('treats a missing customFields key as empty', () {
+      final decoded = ListItem.fromJson({
+        'id': 1,
+        'listId': 2,
+        'name': 'Milk',
+        'done': false,
+        'repeatFromCompletion': false,
+        'sortOrder': 0,
+        'createdAt': 100,
+        'updatedAt': 200,
+      });
+
+      expect(decoded.customFields, isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
Companion-app side of custom fields for checklist items (server + web landed in chenasraf/nextcloud-pantry#247).

## Manage fields
- New `FieldDefinition` / `FieldOption` / `FieldValue` / `FieldType` models and a `CustomFieldService`, mirroring the `Category` / `ItemPrice` conventions, with `SyncEntity.customField` wiring through the offline sync queue.
- A "Custom fields" manager reachable from a list's manage menu (gated on `hasFeature('custom-fields')` + the new `canEditFields` capability): scope-grouped, inline-expand `ExpansionTile` accordion with per-scope drag-reorder, all five field types, select options with remap-or-clear on delete, and date reminder config.

## Fill values
- Per-item value editing for all five types, incl. relative dates with Re-anchor and the per-item reminder override — available both in the item edit form and as a compose-bar tray (which also seeds each field's default value on quick-add).
- Values ride the item create/update payload (`customFieldsBody`, mirroring `itemPriceBody`) and reconcile through the existing optimistic sync paths; read-only display on the item detail.

## Reminders
- Date-field reminders surface through the existing OCS-notifications poll → local-notification pipeline (no native push) and deep-link straight to the item detail.

## Notes
- All UI uses Material controls aligned to the app's existing field styling (shared `LabeledFieldCard`).
- i18n added across all locales; unit tests cover model/enum serialization, default seeding, and notification deep-link parsing.
